### PR TITLE
[CTSKF-1029] Add new LGFS refuse/reject reasons

### DIFF
--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -32,7 +32,16 @@ class ClaimStateTransitionReason
     end
 
     def refuse_reasons_for(claim)
-      reasons_for("refused_#{claim.class.to_s.demodulize.tableize}")
+      reasons = reasons_for("refused_#{claim.class.to_s.demodulize.tableize}")
+      if claim.lgfs?
+        reason_key = if claim.redetermination? || claim.awaiting_written_reasons?
+                       :refused_litigator_redetermination_claims
+                     else
+                       :refused_litigator_new_claims
+                     end
+        reasons.insert(1, reasons_for(reason_key))
+      end
+      reasons.flatten
     end
 
     def transition_reasons

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -40,16 +40,16 @@ en:
           long: &agfs_incorrect_supplemental_case_long We refused your claim because the supplemental fee was claimed under the incorrect case. More information provided on previous note.
         lgfs_second_fee:
           short: &lgfs_second_fee_short Second fee not payable (Stayed Indictment)
-          long: &lgfs_second_fee_long We have refused your claim because, although an indictment was stayed, that nature of the criminality alleged against the defendant did not significantly change. To amend and indictment it is often necessary to upload a new version to the Digital Case System. This creates multiple versions of the indictment which may need to be stayed whereas, in reality, there was only ever one case against the defendant. A second fee for a 'new' indictment will only be payable if there has been a significant change in the alleged criminality.
+          long: &lgfs_second_fee_long We have refused your claim because, although an indictment was stayed, the nature of the criminality alleged against the defendant did not significantly change. To amend an indictment it is often necessary to upload a new version to the Digital Case System. This creates multiple versions of the indictment which may need to be stayed whereas, in reality, there was only ever one case against the defendant. A second fee for a 'new' indictment will only be payable if there has been a significant change in the alleged criminality.
         lgfs_unjustified_disbursement:
           short: &lgfs_unjustified_disbursement_short Disbursement has not been justified
           long: &lgfs_unjustified_disbursement_long Your claim has been refused because you have not provided a Prior authority for the disbursement or explained why it was necessary to the case to incur the expense of the disbursement/s claimed.
         lgfs_wrong_maat_ref:
           short: &lgfs_wrong_maat_ref_short MAAT number provided does not match the defendant name and date of birth given
-          long: &lgfs_wrong_maat_ref_long We have refused your claim because the MAAT reference provided does not relate to the defendant named and we have been unable to validate that in your claim was granted Legal Aid.
+          long: &lgfs_wrong_maat_ref_long We have refused your claim because the MAAT reference provided does not relate to the defendant named and we have been unable to validate that your client was granted Legal Aid.
         lgfs_proceed_of_crime_act:
           short: &lgfs_proceed_of_crime_act_short Out of Scope of LGFS - Proceeds of Crime Act
-          long: &lgfs_proceed_of_crime_act_long We have refused your claim because it relates to proceeding under the Proceeds of Crime Act 2002 (POCA). Work relating to POCA proceedings is not remunerated under the Litigator Graduated Fee Scheme and should be claimed from the Criminal Cases Unit (CCU). Please see Appendix Q of the Crown Court Fee Guidance.
+          long: &lgfs_proceed_of_crime_act_long We have refused your claim because it relates to proceedings under the Proceeds of Crime Act 2002 (POCA). Work relating to POCA proceedings is not remunerated under the Litigator Graduated Fee Scheme and should be claimed from the Criminal Cases Unit (CCU). Please see Appendix Q of the Crown Court Fee Guidance.
         lgfs_prescribed_proceedings:
           short: &lgfs_prescribed_proceedings_short Out of Scope of LGFS - Prescribed Proceedings
           long: &lgfs_prescribed_proceedings_long We have refused your claim because it relates to prescribed proceedings. Prescribed proceedings are proceedings which have been prescribed as criminal for the purposes of Legal Aid listed under Regulation 9 of the Criminal Legal Aid (General) Regulations 2013. Work under prescribed proceedings are not remunerated under the Litigator Graduated Fee Scheme and should be claimed in your monthly submission on CWA. Please see Appendix N of the Crown Court Fee Guidance.
@@ -64,10 +64,10 @@ en:
           long: &lgfs_redet_unjustified_disbursement_long Your appeal has been refused because you have not provided a Prior authority for the disbursement or explained why it was necessary to the case to incur the expense of the disbursement/s claimed.
         lgfs_redet_wrong_maat_ref:
           short: &lgfs_redet_wrong_maat_ref_short MAAT number provided does not match the defendant name and date of birth given
-          long: &lgfs_redet_wrong_maat_ref_long We have refused your appeal because the MAAT reference provided does not relate to the defendant named and we have been unable to validate that in your claim was granted Legal Aid.
+          long: &lgfs_redet_wrong_maat_ref_long We have refused your appeal because the MAAT reference provided does not relate to the defendant named and we have been unable to validate that your client was granted Legal Aid.
         lgfs_redet_proceed_of_crime_act:
           short: &lgfs_redet_proceed_of_crime_act_short Out of Scope of LGFS - Proceeds of Crime Act
-          long: &lgfs_redet_proceed_of_crime_act_long We have refused your appeal because it relates to proceeding under the Proceeds of Crime Act 2002 (POCA). Work relating to POCA proceedings is not remunerated under the Litigator Graduated Fee Scheme and should be claimed from the Criminal Cases Unit (CCU). Please see Appendix Q of the Crown Court Fee Guidance.
+          long: &lgfs_redet_proceed_of_crime_act_long We have refused your appeal because it relates to proceedings under the Proceeds of Crime Act 2002 (POCA). Work relating to POCA proceedings is not remunerated under the Litigator Graduated Fee Scheme and should be claimed from the Criminal Cases Unit (CCU). Please see Appendix Q of the Crown Court Fee Guidance.
         lgfs_redet_prescribed_proceedings:
           short: &lgfs_redet_prescribed_proceedings_short Out of Scope of LGFS - Prescribed Proceedings
           long: &lgfs_redet_prescribed_proceedings_long We have refused your appeal because it relates to prescribed proceedings. Prescribed proceedings are proceedings which have been prescribed as criminal for the purposes of Legal Aid listed under Regulation 9 of the Criminal Legal Aid (General) Regulations 2013. Work under prescribed proceedings are not remunerated under the Litigator Graduated Fee Scheme and should be claimed in your monthly submission on CWA. Please see Appendix N of the Crown Court Fee Guidance.
@@ -79,13 +79,13 @@ en:
           long: &lgfs_redet_request_info_long We have refused your appeal because you have not asked that we redetermine any element of this claim. Your request was for further information only.
         lgfs_redet_relevance_electronic_material:
           short: &lgfs_redet_relevance_electronic_material_short No Submissions on relevance of electronic material
-          long: &lgfs_redet_relevance_electronic_material_long We have refused your appeal because you have not provided submission explaining the relevance of the electronic material to the case. Electronic material is subject to a qualitative assessment in which the determining officer must take into account the nature of the document and any other relevant circumstances. To do this we need an explanation of how the material was of central importance to the prosecution’s case.
+          long: &lgfs_redet_relevance_electronic_material_long We have refused your appeal because you have not provided submissions explaining the relevance of the electronic material to the case. Electronic material is subject to a qualitative assessment in which the determining officer must take into account the nature of the document and any other relevant circumstances. To do this we need an explanation of how the material was of central importance to the prosecution’s case.
         lgfs_redet_no_exlectronic_material:
           short: &lgfs_redet_no_exlectronic_material_short Electronic material has not been provided for assessment
-          long: &lgfs_redet_no_exlectronic_material_long We have refused your appeal because the electronic material being claimed has not been provide for assessment. Electronic material is subject to a qualitative assessment in which the determining officer must take into account the nature of the document and any other relevant circumstances. To do this we need to see the electronic material to consider if it is appropriate to include as PPE.
+          long: &lgfs_redet_no_exlectronic_material_long  We have refused your appeal because the electronic material being claimed has not been provided for assessment. Electronic material is subject to a qualitative assessment in which the determining officer must take into account the nature of the document and any other relevant circumstances. To do this we need to see the electronic material to consider if it is appropriate to include as PPE.
         lgfs_redet_offence_class:
           short: &lgfs_redet_offence_class_short Incorrect Offence Class claimed
-          long: &lgfs_redet_offence_class_long We have refused your appeal because the offences on the indictment does not fall under the classification of offence claimed. Offence classifications are dictated by the Table of Offences in The Criminal Legal Aid (Remuneration) Regulations 2013. If the offence does not appear in the Table of Offences then is defaults to class H.
+          long: &lgfs_redet_offence_class_long We have refused your appeal because the offences on the indictment does not fall under the classification of the offence claimed. Offence classifications are dictated by the Table of Offences in The Criminal Legal Aid (Remuneration) Regulations 2013. If the offence does not appear in the Table of Offences then is defaults to class H, but reclassifcation may be considered based on the specific facts of the case.
         lgfs_redet_written_reasons:
           short: &lgfs_redet_written_reasons_short Formal Written Reasons already provided
           long: &lgfs_redet_written_reasons_long We have refused your appeal because we have already provided you with our formal written reasons on the point/s in dispute. You can appeal the determining officer's decision to the Senior Courts Cost Office (SCCO). Guidance on how to do so is included at the bottom of our written reasons letter.
@@ -146,13 +146,13 @@ en:
           long: &lgfs_litigator_request_long Your claim has been rejected as per your request.
         lgfs_no_breakdown:
           short: &lgfs_no_breakdown_short Invoice does not include a breakdown of work completed
-          long: &lgfs_no_breakdown_long We have rejected your claim for disbursement because the invoice provided does not include an hourly breakdown and the rate per hour claimed for the work completed. We require such a breakdown to be able to assess if the disbursement claimed is reasonable.
+          long: &lgfs_no_breakdown_long We have rejected your claim for disbursement because the invoice provided does not include an hourly breakdown and the rate per hour claimed for the work completed. We require such a breakdown to be able to assess whether the disbursement claimed is reasonable.
         lgfs_no_reference:
           short: &lgfs_no_reference_short Invoice does not include any recognisable reference to this case
-          long: &lgfs_no_reference_long We have rejected your claim for disbursement because the invoice provided does not include any reference to associate it with the case against the defendant. We need to see a reference to the case such as a case number or defendants name so that we can validate the work completed was for this case.
+          long: &lgfs_no_reference_long We have rejected your claim for disbursement/s because the invoice provided does not include any reference to associate it with the case against the defendant. We need to see a reference to the case such as a case number or defendant's name so that we can validate the work completed was for this case.
         lgfs_breach_or_appeal:
           short: &lgfs_breach_or_appeal_short Rep Order does not cover Breach or Appeal Proceedings
-          long: &lgfs_breach_or_appeal_long We have rejected your claim because the representation order provided does not cover the breach or appeal proceedings. For this type of proceedings and separate application for legal aid must be made. Appeal rep orders will be denoted with the word (Appeal) in the heading. Breach rep orders may be granted by the Court or the LAA and will not have a MAAT reference attached.
+          long: &lgfs_breach_or_appeal_long We have rejected your claim because the representation order provided does not cover the breach or appeal proceedings. For this type of proceedings a separate application for legal aid must be made. Appeal rep orders will be denoted with the word (Appeal) in the heading. Breach rep orders may be granted by the Court or the LAA and will not have a MAAT reference attached.
   claim_state_transition_reason:
     disbursement:
       no_prior_authority:

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -84,6 +84,18 @@ en:
         agfs_soft_reject_attendance_notes:
           short: &agfs_soft_reject_attendance_notes_short Main hearing attendance note(s) required
           long: &agfs_soft_reject_attendance_notes_long Soft Reject – we rejected your claim because you have not responded to our request for an attendance note to confirm counsel had attended the main hearing/first day of trial.
+        lgfs_litigator_request:
+          short: &lgfs_litigator_request_short Rejected at the request of the Litigator
+          long: &lgfs_litigator_request_long Your claim has been rejected as per your request.
+        lgfs_no_breakdown:
+          short: &lgfs_no_breakdown_short Invoice does not include a breakdown of work completed
+          long: &lgfs_no_breakdown_long We have rejected your claim for disbursement because the invoice provided does not include an hourly breakdown and the rate per hour claimed for the work completed. We require such a breakdown to be able to assess if the disbursement claimed is reasonable.
+        lgfs_no_reference:
+          short: &lgfs_no_reference_short Invoice does not include any recognisable reference to this case
+          long: &lgfs_no_reference_long We have rejected your claim for disbursement because the invoice provided does not include any reference to associate it with the case against the defendant. We need to see a reference to the case such as a case number or defendants name so that we can validate the work completed was for this case.
+        lgfs_breach_or_appeal:
+          short: &lgfs_breach_or_appeal_short Rep Order does not cover Breach or Appeal Proceedings
+          long: &lgfs_breach_or_appeal_long We have rejected your claim because the representation order provided does not cover the breach or appeal proceedings. For this type of proceedings and separate application for legal aid must be made. Appeal rep orders will be denoted with the word (Appeal) in the heading. Breach rep orders may be granted by the Court or the LAA and will not have a MAAT reference attached.
   claim_state_transition_reason:
     disbursement:
       no_prior_authority:
@@ -312,6 +324,18 @@ en:
       wrong_maat_ref:
         short: *wrong_maat_ref_short
         long: *wrong_maat_ref_long
+      lgfs_litigator_request:
+        short: *lgfs_litigator_request_short
+        long: *lgfs_litigator_request_long
+      lgfs_no_breakdown:
+        short: *lgfs_no_breakdown_short
+        long: *lgfs_no_breakdown_long
+      lgfs_no_reference:
+        short: *lgfs_no_reference_short
+        long: *lgfs_no_reference_long
+      lgfs_breach_or_appeal:
+        short: *lgfs_breach_or_appeal_short
+        long: *lgfs_breach_or_appeal_long
       other:
         short: *other
         long: *blank

--- a/config/locales/claim_state_transition_reason.en.yml
+++ b/config/locales/claim_state_transition_reason.en.yml
@@ -38,6 +38,63 @@ en:
         agfs_incorrect_supplemental_case:
           short: &agfs_incorrect_supplemental_case_short Supplemental fee claimed under the incorrect case
           long: &agfs_incorrect_supplemental_case_long We refused your claim because the supplemental fee was claimed under the incorrect case. More information provided on previous note.
+        lgfs_second_fee:
+          short: &lgfs_second_fee_short Second fee not payable (Stayed Indictment)
+          long: &lgfs_second_fee_long We have refused your claim because, although an indictment was stayed, that nature of the criminality alleged against the defendant did not significantly change. To amend and indictment it is often necessary to upload a new version to the Digital Case System. This creates multiple versions of the indictment which may need to be stayed whereas, in reality, there was only ever one case against the defendant. A second fee for a 'new' indictment will only be payable if there has been a significant change in the alleged criminality.
+        lgfs_unjustified_disbursement:
+          short: &lgfs_unjustified_disbursement_short Disbursement has not been justified
+          long: &lgfs_unjustified_disbursement_long Your claim has been refused because you have not provided a Prior authority for the disbursement or explained why it was necessary to the case to incur the expense of the disbursement/s claimed.
+        lgfs_wrong_maat_ref:
+          short: &lgfs_wrong_maat_ref_short MAAT number provided does not match the defendant name and date of birth given
+          long: &lgfs_wrong_maat_ref_long We have refused your claim because the MAAT reference provided does not relate to the defendant named and we have been unable to validate that in your claim was granted Legal Aid.
+        lgfs_proceed_of_crime_act:
+          short: &lgfs_proceed_of_crime_act_short Out of Scope of LGFS - Proceeds of Crime Act
+          long: &lgfs_proceed_of_crime_act_long We have refused your claim because it relates to proceeding under the Proceeds of Crime Act 2002 (POCA). Work relating to POCA proceedings is not remunerated under the Litigator Graduated Fee Scheme and should be claimed from the Criminal Cases Unit (CCU). Please see Appendix Q of the Crown Court Fee Guidance.
+        lgfs_prescribed_proceedings:
+          short: &lgfs_prescribed_proceedings_short Out of Scope of LGFS - Prescribed Proceedings
+          long: &lgfs_prescribed_proceedings_long We have refused your claim because it relates to prescribed proceedings. Prescribed proceedings are proceedings which have been prescribed as criminal for the purposes of Legal Aid listed under Regulation 9 of the Criminal Legal Aid (General) Regulations 2013. Work under prescribed proceedings are not remunerated under the Litigator Graduated Fee Scheme and should be claimed in your monthly submission on CWA. Please see Appendix N of the Crown Court Fee Guidance.
+        lgfs_rep_order_not_in_place:
+          short: &lgfs_rep_order_not_in_place_short A valid Representation Order is not in place
+          long: &lgfs_rep_order_not_in_place_long We have refused your claim because our records show that there isn’t a valid representation order in place for your firm.
+        lgfs_redet_second_fee:
+          short: &lgfs_redet_second_fee_short Second fee not payable (Stayed Indictment)
+          long: &lgfs_redet_second_fee_long We have refused your appeal because, although an indictment was stayed, that nature of the criminality alleged against the defendant did not significantly change. To amend and indictment it is often necessary to upload a new version to the Digital Case System. This creates multiple versions of the indictment which may need to be stayed whereas, in reality, there was only ever one case against the defendant. A second fee for a 'new' indictment will only be payable if there has been a significant change in the alleged criminality.
+        lgfs_redet_unjustified_disbursement:
+          short: &lgfs_redet_unjustified_disbursement_short Disbursement has not been justified
+          long: &lgfs_redet_unjustified_disbursement_long Your appeal has been refused because you have not provided a Prior authority for the disbursement or explained why it was necessary to the case to incur the expense of the disbursement/s claimed.
+        lgfs_redet_wrong_maat_ref:
+          short: &lgfs_redet_wrong_maat_ref_short MAAT number provided does not match the defendant name and date of birth given
+          long: &lgfs_redet_wrong_maat_ref_long We have refused your appeal because the MAAT reference provided does not relate to the defendant named and we have been unable to validate that in your claim was granted Legal Aid.
+        lgfs_redet_proceed_of_crime_act:
+          short: &lgfs_redet_proceed_of_crime_act_short Out of Scope of LGFS - Proceeds of Crime Act
+          long: &lgfs_redet_proceed_of_crime_act_long We have refused your appeal because it relates to proceeding under the Proceeds of Crime Act 2002 (POCA). Work relating to POCA proceedings is not remunerated under the Litigator Graduated Fee Scheme and should be claimed from the Criminal Cases Unit (CCU). Please see Appendix Q of the Crown Court Fee Guidance.
+        lgfs_redet_prescribed_proceedings:
+          short: &lgfs_redet_prescribed_proceedings_short Out of Scope of LGFS - Prescribed Proceedings
+          long: &lgfs_redet_prescribed_proceedings_long We have refused your appeal because it relates to prescribed proceedings. Prescribed proceedings are proceedings which have been prescribed as criminal for the purposes of Legal Aid listed under Regulation 9 of the Criminal Legal Aid (General) Regulations 2013. Work under prescribed proceedings are not remunerated under the Litigator Graduated Fee Scheme and should be claimed in your monthly submission on CWA. Please see Appendix N of the Crown Court Fee Guidance.
+        lgfs_redet_rep_order_not_in_place:
+          short: &lgfs_redet_rep_order_not_in_place_short A valid Representation Order is not in place
+          long: &lgfs_redet_rep_order_not_in_place_long We have refused your appeal because our records show that there isn’t a valid representation order in place for your firm.
+        lgfs_redet_request_info:
+          short: &lgfs_redet_request_info_short Request for information, not a request for redetermination
+          long: &lgfs_redet_request_info_long We have refused your appeal because you have not asked that we redetermine any element of this claim. Your request was for further information only.
+        lgfs_redet_relevance_electronic_material:
+          short: &lgfs_redet_relevance_electronic_material_short No Submissions on relevance of electronic material
+          long: &lgfs_redet_relevance_electronic_material_long We have refused your appeal because you have not provided submission explaining the relevance of the electronic material to the case. Electronic material is subject to a qualitative assessment in which the determining officer must take into account the nature of the document and any other relevant circumstances. To do this we need an explanation of how the material was of central importance to the prosecution’s case.
+        lgfs_redet_no_exlectronic_material:
+          short: &lgfs_redet_no_exlectronic_material_short Electronic material has not been provided for assessment
+          long: &lgfs_redet_no_exlectronic_material_long We have refused your appeal because the electronic material being claimed has not been provide for assessment. Electronic material is subject to a qualitative assessment in which the determining officer must take into account the nature of the document and any other relevant circumstances. To do this we need to see the electronic material to consider if it is appropriate to include as PPE.
+        lgfs_redet_offence_class:
+          short: &lgfs_redet_offence_class_short Incorrect Offence Class claimed
+          long: &lgfs_redet_offence_class_long We have refused your appeal because the offences on the indictment does not fall under the classification of offence claimed. Offence classifications are dictated by the Table of Offences in The Criminal Legal Aid (Remuneration) Regulations 2013. If the offence does not appear in the Table of Offences then is defaults to class H.
+        lgfs_redet_written_reasons:
+          short: &lgfs_redet_written_reasons_short Formal Written Reasons already provided
+          long: &lgfs_redet_written_reasons_long We have refused your appeal because we have already provided you with our formal written reasons on the point/s in dispute. You can appeal the determining officer's decision to the Senior Courts Cost Office (SCCO). Guidance on how to do so is included at the bottom of our written reasons letter.
+        lgfs_redet_ppe:
+          short: &lgfs_redet_ppe_short No additional pages eligible to be included as PPE
+          long: &lgfs_redet_ppe_long We have refused your appeal because we do not consider that any more pages from the material claimed should be included as PPE. Cover and Index pages does not meet the definition of PPE and duplicated documents cannot be included within the page count. In the case of electronically served material, only the data of central importance to the case can be included as PPE.
+        lgfs_redet_incorrect_case_type:
+          short: &lgfs_redet_incorrect_case_type_short Incorrect Case Type claimed
+          long: &lgfs_redet_incorrect_case_type_long We have refused your appeal because available court records do not support the case type you have claimed and the events in the Crown Court more appropriately fit another.
       rejected:
         no_indictment:
           short: &no_indictment_short No indictment attached
@@ -253,6 +310,65 @@ en:
       other_refuse:
         short: *other
         long: *blank
+    refused_litigator_new_claims:
+      lgfs_second_fee:
+        short: *lgfs_second_fee_short
+        long: *lgfs_second_fee_long
+      lgfs_unjustified_disbursement:
+        short: *lgfs_unjustified_disbursement_short
+        long: *lgfs_unjustified_disbursement_long
+      lgfs_wrong_maat_ref:
+        short: *lgfs_wrong_maat_ref_short
+        long: *lgfs_wrong_maat_ref_long
+      lgfs_proceed_of_crime_act:
+        short: *lgfs_proceed_of_crime_act_short
+        long: *lgfs_proceed_of_crime_act_long
+      lgfs_prescribed_proceedings:
+        short: *lgfs_prescribed_proceedings_short
+        long: *lgfs_prescribed_proceedings_long
+      lgfs_rep_order_not_in_place:
+        short: *lgfs_rep_order_not_in_place_short
+        long: *lgfs_rep_order_not_in_place_long
+    refused_litigator_redetermination_claims:
+      lgfs_redet_second_fee:
+        short: *lgfs_redet_second_fee_short
+        long: *lgfs_redet_second_fee_long
+      lgfs_redet_unjustified_disbursement:
+        short: *lgfs_redet_unjustified_disbursement_short
+        long: *lgfs_redet_unjustified_disbursement_long
+      lgfs_redet_wrong_maat_ref:
+        short: *lgfs_redet_wrong_maat_ref_short
+        long: *lgfs_redet_wrong_maat_ref_long
+      lgfs_redet_proceed_of_crime_act:
+        short: *lgfs_redet_proceed_of_crime_act_short
+        long: *lgfs_redet_proceed_of_crime_act_long
+      lgfs_redet_prescribed_proceedings:
+        short: *lgfs_redet_prescribed_proceedings_short
+        long: *lgfs_redet_prescribed_proceedings_long
+      lgfs_redet_rep_order_not_in_place:
+        short: *lgfs_redet_rep_order_not_in_place_short
+        long: *lgfs_redet_rep_order_not_in_place_long
+      lgfs_redet_request_info:
+        short: *lgfs_redet_request_info_short
+        long: *lgfs_redet_request_info_long
+      lgfs_redet_relevance_electronic_material:
+        short: *lgfs_redet_relevance_electronic_material_short
+        long: *lgfs_redet_relevance_electronic_material_long
+      lgfs_redet_no_exlectronic_material:
+        short: *lgfs_redet_no_exlectronic_material_short
+        long: *lgfs_redet_no_exlectronic_material_long
+      lgfs_redet_offence_class:
+        short: *lgfs_redet_offence_class_short
+        long: *lgfs_redet_offence_class_long
+      lgfs_redet_written_reasons:
+        short: *lgfs_redet_written_reasons_short
+        long: *lgfs_redet_written_reasons_long
+      lgfs_redet_ppe:
+        short: *lgfs_redet_ppe_short
+        long: *lgfs_redet_ppe_long
+      lgfs_redet_incorrect_case_type:
+        short: *lgfs_redet_incorrect_case_type_short
+        long: *lgfs_redet_incorrect_case_type_long
     rejected_advocate_claims:
       no_indictment:
         short: *no_indictment_short

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -56,7 +56,8 @@ RSpec.describe ClaimStateTransitionReason do
     end
 
     let(:lgfs_reasons) do
-      %w[no_indictment no_rep_order time_elapsed no_amend_rep_order case_still_live wrong_case_no wrong_maat_ref other]
+      %w[no_indictment no_rep_order time_elapsed no_amend_rep_order case_still_live wrong_case_no wrong_maat_ref
+         lgfs_litigator_request lgfs_no_breakdown lgfs_no_reference lgfs_breach_or_appeal other]
     end
 
     let(:disbursement_only_reasons) { %w[no_prior_authority no_invoice] }

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -97,6 +97,13 @@ RSpec.describe ClaimStateTransitionReason do
          lgfs_prescribed_proceedings lgfs_rep_order_not_in_place other_refuse]
     end
 
+    let(:common_agfs_reasons) do
+      %w[wrong_ia duplicate_claim agfs_stayed_quashed_indictment agfs_predate_rep_order agfs_paid_elsewhere
+         agfs_continuation_of_trial agfs_prescribed_proceedings agfs_incorrect_supplemental_case other_refuse]
+    end
+
+    let(:interim_reasons) { %w[no_effective_pcmh no_effective_trial short_trial] }
+
     context 'with a litigator final claim' do
       let(:claim) { create(:litigator_claim, :fixed_fee, fixed_fee: create(:fixed_fee, :lgfs)) }
 
@@ -112,7 +119,7 @@ RSpec.describe ClaimStateTransitionReason do
     context 'with a litigator interim claim' do
       let(:claim) { create(:interim_claim, interim_fee: build(:interim_fee)) }
 
-      it { is_expected.to match_array(common_lgfs_reasons + %w[no_effective_pcmh no_effective_trial short_trial]) }
+      it { is_expected.to match_array(common_lgfs_reasons + interim_reasons) }
     end
 
     context 'with a litigator hardship claim' do
@@ -145,7 +152,7 @@ RSpec.describe ClaimStateTransitionReason do
       context 'with a litigator interim claim' do
         let(:claim) { create(:interim_claim, :redetermination, interim_fee: build(:interim_fee)) }
 
-        it { is_expected.to match_array(common_lgfs_reasons + %w[no_effective_pcmh no_effective_trial short_trial]) }
+        it { is_expected.to match_array(common_lgfs_reasons + interim_reasons) }
       end
 
       context 'with a litigator hardship claim' do
@@ -159,42 +166,25 @@ RSpec.describe ClaimStateTransitionReason do
       let(:basic_fee) { build(:basic_fee, :baf_fee, quantity: 1, amount: 21.01) }
       let(:claim) { create(:advocate_claim, :with_graduated_fee_case, basic_fees: [basic_fee]) }
 
-      it {
-        is_expected.to match_array %w[wrong_ia duplicate_claim agfs_stayed_quashed_indictment agfs_predate_rep_order
-                                      agfs_paid_elsewhere agfs_continuation_of_trial agfs_prescribed_proceedings
-                                      agfs_incorrect_supplemental_case other_refuse]
-      }
+      it { is_expected.to match_array(common_agfs_reasons) }
     end
 
     context 'with an advocate interim claim' do
       let(:claim) { create(:advocate_interim_claim) }
 
-      it {
-        is_expected.to match_array %w[duplicate_claim no_effective_pcmh no_effective_trial short_trial
-                                      agfs_stayed_quashed_indictment agfs_predate_rep_order agfs_paid_elsewhere
-                                      agfs_continuation_of_trial agfs_prescribed_proceedings
-                                      agfs_incorrect_supplemental_case other_refuse]
-      }
+      it { is_expected.to match_array(common_agfs_reasons + interim_reasons - ['wrong_ia']) }
     end
 
     context 'with an advocate supplementary claim' do
       let(:claim) { create(:advocate_supplementary_claim) }
 
-      it {
-        is_expected.to match_array %w[wrong_ia duplicate_claim agfs_stayed_quashed_indictment agfs_predate_rep_order
-                                      agfs_paid_elsewhere agfs_continuation_of_trial agfs_prescribed_proceedings
-                                      agfs_incorrect_supplemental_case other_refuse]
-      }
+      it { is_expected.to match_array(common_agfs_reasons) }
     end
 
     context 'with an advocate hardship claim' do
       let(:claim) { create(:advocate_hardship_claim) }
 
-      it {
-        is_expected.to match_array %w[wrong_ia agfs_stayed_quashed_indictment agfs_predate_rep_order agfs_paid_elsewhere
-                                      agfs_continuation_of_trial agfs_prescribed_proceedings
-                                      agfs_incorrect_supplemental_case]
-      }
+      it { is_expected.to match_array(common_agfs_reasons - %w[duplicate_claim other_refuse]) }
     end
   end
 

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -92,23 +92,66 @@ RSpec.describe ClaimStateTransitionReason do
   describe '.refuse_reasons_for' do
     subject(:refuse_reasons_for) { described_class.refuse_reasons_for(claim).map(&:code) }
 
+    let(:common_lgfs_reasons) do
+      %w[duplicate_claim lgfs_second_fee lgfs_unjustified_disbursement lgfs_wrong_maat_ref lgfs_proceed_of_crime_act
+         lgfs_prescribed_proceedings lgfs_rep_order_not_in_place other_refuse]
+    end
+
     context 'with a litigator final claim' do
       let(:claim) { create(:litigator_claim, :fixed_fee, fixed_fee: create(:fixed_fee, :lgfs)) }
 
-      it { is_expected.to match_array %w[duplicate_claim other_refuse] }
+      it { is_expected.to match_array(common_lgfs_reasons) }
     end
 
     context 'with a litigator transfer claim' do
       let(:claim) { create(:transfer_claim, transfer_fee: build(:transfer_fee)) }
 
-      it { is_expected.to match_array %w[duplicate_claim other_refuse] }
+      it { is_expected.to match_array(common_lgfs_reasons) }
     end
 
     context 'with a litigator interim claim' do
       let(:claim) { create(:interim_claim, interim_fee: build(:interim_fee)) }
 
-      it do
-        is_expected.to match_array %w[duplicate_claim no_effective_pcmh no_effective_trial short_trial other_refuse]
+      it { is_expected.to match_array(common_lgfs_reasons + %w[no_effective_pcmh no_effective_trial short_trial]) }
+    end
+
+    context 'with a litigator hardship claim' do
+      let(:claim) { create(:litigator_hardship_claim, hardship_fee: build(:hardship_fee)) }
+
+      it { is_expected.to match_array(common_lgfs_reasons) }
+    end
+
+    context 'when a redetermination has been requested' do
+      let(:common_lgfs_reasons) do
+        %w[duplicate_claim lgfs_redet_second_fee lgfs_redet_unjustified_disbursement lgfs_redet_wrong_maat_ref
+           lgfs_redet_proceed_of_crime_act lgfs_redet_prescribed_proceedings lgfs_redet_rep_order_not_in_place
+           lgfs_redet_request_info lgfs_redet_relevance_electronic_material lgfs_redet_no_exlectronic_material
+           lgfs_redet_offence_class lgfs_redet_written_reasons lgfs_redet_ppe lgfs_redet_incorrect_case_type
+           other_refuse]
+      end
+
+      context 'with a litigator final claim' do
+        let(:claim) { create(:litigator_claim, :fixed_fee, :redetermination, fixed_fee: create(:fixed_fee, :lgfs)) }
+
+        it { is_expected.to match_array(common_lgfs_reasons) }
+      end
+
+      context 'with a litigator transfer claim' do
+        let(:claim) { create(:transfer_claim, :redetermination, transfer_fee: build(:transfer_fee)) }
+
+        it { is_expected.to match_array(common_lgfs_reasons) }
+      end
+
+      context 'with a litigator interim claim' do
+        let(:claim) { create(:interim_claim, :redetermination, interim_fee: build(:interim_fee)) }
+
+        it { is_expected.to match_array(common_lgfs_reasons + %w[no_effective_pcmh no_effective_trial short_trial]) }
+      end
+
+      context 'with a litigator hardship claim' do
+        let(:claim) { create(:litigator_hardship_claim, :redetermination, hardship_fee: build(:hardship_fee)) }
+
+        it { is_expected.to match_array(common_lgfs_reasons) }
       end
     end
 


### PR DESCRIPTION
#### What

Add new LGFS refuse/reject reasons

#### Ticket

[CTSKF0-1029](https://dsdmoj.atlassian.net/browse/CTSKF-1029)

#### Why

Caseworkers require additional reasons to select when refusing or rejecting an LGFS claim, to reduce the use of the 'Other' option.

#### How

* Adds the new refuse and reject reasons to `config/locales/claim_state_transition_reason.en.yml`.
* Some complexity is added by the requirement to display one set of refusal reasons for new claims and another set for redeterminations. To handle this, extra functionality is added to the `refuse_reasons_for` method in the`ClaimStateTransitionReason` model.