### PR TITLE
[CTSKF 833] Allow for multi-file uploads for messages

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -43,6 +43,24 @@ class DocumentsController < ApplicationController
     end
   end
 
+  def upload
+    @document = Document.new(creator_id: current_user.id, document: params[:documents])
+    if @document.save_and_verify
+      render_success_response
+    else
+      render_error_response
+    end
+  end
+
+  def delete
+    # TODO: This does not do any checking to see if the document is owned by the current user
+    @document = Document.find(params[:delete])
+
+    @document.destroy
+
+    render json: { file: { filename: params[:delete] } }
+  end
+
   private
 
   def document
@@ -55,5 +73,22 @@ class DocumentsController < ApplicationController
       :form_id,
       :creator_id
     )
+  end
+
+  def render_success_response
+    render json: {
+      file: { originalname: @document.document.filename, filename: @document.id },
+      success: {
+        messageHtml: "#{@document.document.filename} uploaded"
+      }
+    }, status: :created
+  end
+
+  def render_error_response
+    render json: {
+      error: {
+        message: "#{@document.document.filename} #{@document.errors[:document].join(', ')}"
+      }
+    }, status: :accepted
   end
 end

--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -53,10 +53,8 @@ class DocumentsController < ApplicationController
   end
 
   def delete
-    # TODO: This does not do any checking to see if the document is owned by the current user
-    @document = Document.find(params[:delete])
-
-    @document.destroy
+    document = Document.find_by(id: params[:delete], creator: current_user, claim: nil)
+    document.destroy if document.present?
 
     render json: { file: { filename: params[:delete] } }
   end

--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -21,13 +21,8 @@ class MessagesController < ApplicationController
 
   def create
     @message = Message.new(message_params.merge(sender_id: current_user.id))
-
-    @notification = if @message.save
-                      { notice: 'Message successfully sent' }
-                    else
-                      { alert: 'Message not sent: ' + @message.errors.full_messages.join(', ') }
-                    end
-
+    attach_documents(@message)
+    save_message(@message)
     respond_to do |format|
       format.js
       format.html { redirect_to redirect_to_url, @notification }
@@ -37,7 +32,8 @@ class MessagesController < ApplicationController
   def download_attachment
     raise 'No attachment present on this message' unless message.attachments.attached?
 
-    redirect_to message.attachments.first.blob.url(disposition: 'attachment'), allow_other_host: true
+    attachment = message.attachments.find(params[:attachment_id])
+    redirect_to attachment.blob.url(disposition: 'attachment'), allow_other_host: true
   end
 
   private
@@ -64,5 +60,20 @@ class MessagesController < ApplicationController
       :claim_action,
       :written_reasons_submitted
     )
+  end
+
+  def attach_documents(message)
+    documents = Document.where(id: params[:message][:document_ids])
+    documents.each do |doc|
+      message.attachments.attach(doc.document.blob)
+    end
+  end
+
+  def save_message(message)
+    @notification = if message.save
+                      { notice: 'Message successfully sent' }
+                    else
+                      { alert: 'Message not sent: ' + message.errors.full_messages.join(', ') }
+                    end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -46,6 +46,7 @@ class Ability
 
   def case_worker_admin(persona)
     can %i[index show update archived], Claim::BaseClaim
+    can %i[upload delete], Document
     can %i[show download], Document
     can %i[index new create], CaseWorker
     can %i[show show_message_controls edit change_password update_password update destroy], CaseWorker
@@ -62,6 +63,7 @@ class Ability
       claim.case_workers.include?(persona)
     end
     can_administer_any_provider if persona.roles.include?('provider_management')
+    can %i[upload delete], Document
     can %i[show download], Document
     can %i[index feedback], CourtData
     can_manage_own_password(persona)
@@ -86,7 +88,7 @@ class Ability
   end
 
   def can_administer_documents_in_provider(persona)
-    can %i[index create], Document
+    can %i[index create upload delete], Document
 
     # NOTE: for destroy action, at least, the document may not be persisted/saved
     can %i[show download destroy], Document do |document|
@@ -127,7 +129,7 @@ class Ability
   end
 
   def can_manage_own_documents(persona)
-    can %i[index create], Document
+    can %i[index create upload delete], Document
 
     can %i[show download destroy], Document do |document|
       if document.external_user_id.nil?

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -18,6 +18,9 @@ class Document < ApplicationRecord
               application/msword
               application/vnd.openxmlformats-officedocument.wordprocessingml.document
               application/vnd.oasis.opendocument.text
+              application/vnd.ms-excel
+              application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+              application/vnd.oasis.opendocument.spreadsheet
               application/rtf
               image/jpeg
               image/png

--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -18,6 +18,7 @@ class Message < ApplicationRecord
   belongs_to :claim, class_name: 'Claim::BaseClaim'
   belongs_to :sender, class_name: 'User', inverse_of: :messages_sent
   has_many :user_message_statuses, dependent: :destroy
+  has_many :documents, -> { where verified: true }, foreign_key: :claim_id, dependent: :destroy, inverse_of: :claim
 
   attr_accessor :claim_action, :written_reasons_submitted
 

--- a/app/presenters/message_presenter.rb
+++ b/app/presenters/message_presenter.rb
@@ -24,26 +24,29 @@ class MessagePresenter < BasePresenter
   private
 
   def attachment_field
-    h.concat('Attachment: ')
-    download_file_link
+    h.concat('Attachments: ')
+    message.attachments.each do |attachment|
+      h.concat(h.tag.br)
+      download_file_link(attachment)
+    end
   end
 
-  def download_file_link
+  def download_file_link(attachment)
     h.concat(
       h.tag.a(
-        "#{attachment_file_name} (#{attachment_file_size})",
-        href: "/messages/#{message.id}/download_attachment",
-        title: 'Download ' + attachment_file_name
+        "#{attachment_file_name(attachment)} (#{attachment_file_size(attachment)})",
+        href: "/messages/#{message.id}/download_attachment?attachment_id=#{attachment.id}",
+        title: 'Download ' + attachment_file_name(attachment)
       )
     )
   end
 
-  def attachment_file_name
-    message.attachments.first.filename.to_s
+  def attachment_file_name(attachment)
+    attachment.filename.to_s
   end
 
-  def attachment_file_size
-    h.number_to_human_size(message.attachments.first.byte_size)
+  def attachment_file_size(attachment)
+    h.number_to_human_size(attachment.byte_size)
   end
 
   def hide_author?

--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -13,6 +13,8 @@
   <% unless @message.claim.written_reasons_outstanding? %>
     $('.written-reasons-checkbox').hide();
   <% end %>
+
+  document.querySelector('.govuk-summary-list.moj-multi-file-upload__list').innerHTML = '';
 <% else %>
   var data = {
     success : false,

--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -15,6 +15,9 @@
   <% end %>
 
   document.querySelector('.govuk-summary-list.moj-multi-file-upload__list').innerHTML = '';
+  const errorContainer = document.querySelector('.govuk-error-summary').classList.add('govuk-visually-hidden');
+  errorContainer.querySelector('.govuk-list.govuk-error-summary__list').innerHTML = '';
+
 <% else %>
   var data = {
     success : false,

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -32,7 +32,7 @@
       .moj-multi-file__uploaded-files
         %h2.govuk-headings-m Files added
         .govuk-summary-list.moj-multi-file-upload__list
-      .govuk-error-summary{"aria-labelledby" => "error-summary-title", role: "alert", tabindex: "-1", style: "display: none"}
+      .govuk-error-summary.govuk-visually-hidden{"aria-labelledby" => "error-summary-title", role: "alert", tabindex: "-1"}
         %h2.error-summary-title.govuk-error-summary__title There is a problem
         .govuk-list.govuk-error-summary__list
       .moj-multi-file__uploaded-fields

--- a/app/views/shared/_message_controls.html.haml
+++ b/app/views/shared/_message_controls.html.haml
@@ -28,12 +28,21 @@
             link_errors: true,
             label: { text: t('.written_reasons') }
 
-    = f.govuk_file_field :attachments,
-      label: { text: t('.attachment_label') },
-      hint: { text: t('.accepted_files_help_text') }
+    .moj-multi-file-upload
+      .moj-multi-file__uploaded-files
+        %h2.govuk-headings-m Files added
+        .govuk-summary-list.moj-multi-file-upload__list
+      .govuk-error-summary{"aria-labelledby" => "error-summary-title", role: "alert", tabindex: "-1", style: "display: none"}
+        %h2.error-summary-title.govuk-error-summary__title There is a problem
+        .govuk-list.govuk-error-summary__list
+      .moj-multi-file__uploaded-fields
+      .moj-multi-file-upload__upload
+        .govuk-form-group
+          %label.govuk-label.govuk-label--m{for: "attachments"}
+            Upload a file
+          %input#attachments.govuk-file-upload.moj-multi-file-upload__input{multiple: "multiple", name: "attachments", type: "file"}/
 
-    .file-to-be-uploaded.govuk-form-group
-      %span.filename
-      = govuk_link_to t('.remove_file_html'), '#'
-
-    = f.govuk_submit t('.send'), class: 'govuk-button--secondary'
+        %button.govuk-button.govuk-button--secondary.moj-multi-file-upload__button{"data-module" => "govuk-button", type: "submit"}
+          Upload file
+    %button.govuk-button{"data-module" => "govuk-button", type: "submit"}
+      Send

--- a/app/views/shared/show_message_controls.js.erb
+++ b/app/views/shared/show_message_controls.js.erb
@@ -1,1 +1,2 @@
 $('.js-controls').html('<%=j render partial: 'shared/message_controls', locals: { message: @message } %>')
+moj.Modules.MultiFileUpload.init()

--- a/app/webpack/javascripts/modules/Modules.MultiFileUpload.js
+++ b/app/webpack/javascripts/modules/Modules.MultiFileUpload.js
@@ -17,19 +17,29 @@ moj.Modules.MultiFileUpload = {
         input.value = response.file.filename
         fields.appendChild(input)
       },
-      uploadFileErrorHook: function (_uploader, file, _jqXHR, _textStatus, errorThrown) {
+      uploadFileErrorHook: function (_uploader, file, jqXHR, _textStatus, errorThrown) {
         const input = document.createElement('input')
         input.type = 'hidden'
         input.name = 'message[document_ids][]'
         input.value = errorThrown
         fields.appendChild(input)
 
+        const httpStatus = {
+          408: 'Request timeout',
+          413: 'File is too large',
+          500: 'Internal Server Error',
+          502: 'Bad Gateway',
+          503: 'Service Unavailable',
+          504: 'Gateway Timeout',
+          505: 'HTTP Version Not Supported'
+        }
+
         const errorContainer = document.querySelector('.govuk-error-summary')
         const errors = errorContainer.querySelector('.govuk-list.govuk-error-summary__list')
         errorContainer.style.display = ''
         const error = document.createElement('span')
         error.style = 'color:#d4351c;font-weight:bold'
-        error.innerHTML = file.name + ' is ' + errorThrown + '.<br/>'
+        error.innerHTML = file.name + ': ' + httpStatus[jqXHR.status] + '.<br/>'
         errors.appendChild(error)
       },
       fileDeleteHook: function (_uploader, response) {

--- a/app/webpack/javascripts/modules/Modules.MultiFileUpload.js
+++ b/app/webpack/javascripts/modules/Modules.MultiFileUpload.js
@@ -36,7 +36,7 @@ moj.Modules.MultiFileUpload = {
 
         const errorContainer = document.querySelector('.govuk-error-summary')
         const errors = errorContainer.querySelector('.govuk-list.govuk-error-summary__list')
-        errorContainer.style.display = ''
+        errorContainer.classList.remove('govuk-visually-hidden')
         const error = document.createElement('span')
         error.style = 'color:#d4351c;font-weight:bold'
         error.innerHTML = file.name + ': ' + httpStatus[jqXHR.status] + '.<br/>'

--- a/app/webpack/javascripts/modules/Modules.MultiFileUpload.js
+++ b/app/webpack/javascripts/modules/Modules.MultiFileUpload.js
@@ -1,0 +1,47 @@
+/* global MOJFrontend */
+
+moj.Modules.MultiFileUpload = {
+  init: function () {
+    const container = document.querySelector('.moj-multi-file-upload')
+    if (!container) return
+    const fields = container.querySelector('.moj-multi-file__uploaded-fields')
+
+    return new MOJFrontend.MultiFileUpload({
+      container,
+      uploadUrl: '/documents/upload',
+      deleteUrl: '/documents/delete',
+      uploadFileExitHook: function (_uploader, _file, response) {
+        console.log('Success fields')
+        console.log(fields)
+        const input = document.createElement('input')
+        input.type = 'hidden'
+        input.name = 'message[document_ids][]'
+        input.value = response.file.filename
+        fields.appendChild(input)
+      },
+      uploadFileErrorHook: function (_uploader, file, _jqXHR, _textStatus, errorThrown) {
+        console.log('Error fields')
+        console.log(fields)
+        const input = document.createElement('input')
+        input.type = 'hidden'
+        input.name = 'message[document_ids][]'
+        input.value = errorThrown
+        fields.appendChild(input)
+
+        const errorContainer = document.querySelector('.govuk-error-summary')
+        const errors = errorContainer.querySelector('.govuk-list.govuk-error-summary__list')
+        errorContainer.style.display = ''
+        const error = document.createElement('span')
+        error.style = 'color:#d4351c;font-weight:bold'
+        error.innerHTML = file.name + ' is ' + errorThrown + '.<br/>'
+        errors.appendChild(error)
+      },
+      fileDeleteHook: function (_uploader, response) {
+        const input = fields.querySelector('input[value="' + response.file.filename + '"]')
+        console.log('remove input')
+        console.log(input)
+        input.parentNode.removeChild(input)
+      }
+    })
+  }
+}

--- a/app/webpack/javascripts/modules/Modules.MultiFileUpload.js
+++ b/app/webpack/javascripts/modules/Modules.MultiFileUpload.js
@@ -11,8 +11,6 @@ moj.Modules.MultiFileUpload = {
       uploadUrl: '/documents/upload',
       deleteUrl: '/documents/delete',
       uploadFileExitHook: function (_uploader, _file, response) {
-        console.log('Success fields')
-        console.log(fields)
         const input = document.createElement('input')
         input.type = 'hidden'
         input.name = 'message[document_ids][]'
@@ -20,8 +18,6 @@ moj.Modules.MultiFileUpload = {
         fields.appendChild(input)
       },
       uploadFileErrorHook: function (_uploader, file, _jqXHR, _textStatus, errorThrown) {
-        console.log('Error fields')
-        console.log(fields)
         const input = document.createElement('input')
         input.type = 'hidden'
         input.name = 'message[document_ids][]'
@@ -38,8 +34,6 @@ moj.Modules.MultiFileUpload = {
       },
       fileDeleteHook: function (_uploader, response) {
         const input = fields.querySelector('input[value="' + response.file.filename + '"]')
-        console.log('remove input')
-        console.log(input)
         input.parentNode.removeChild(input)
       }
     })

--- a/app/webpack/packs/application.js
+++ b/app/webpack/packs/application.js
@@ -72,6 +72,7 @@ import '../javascripts/modules/Helpers.Autocomplete.js'
 import '../javascripts/modules/Modules.TableRowClick.js'
 import '../javascripts/modules/Modules.AllocationScheme.js'
 import '../javascripts/modules/Modules.AddEditAdvocate.js'
+import '../javascripts/modules/Modules.MultiFileUpload.js'
 
 import '../javascripts/plugins/jquery.numbered.elements.js'
 

--- a/app/webpack/stylesheets/application.scss
+++ b/app/webpack/stylesheets/application.scss
@@ -1,4 +1,5 @@
 // stylelint-disable scss/at-import-partial-extension
+// stylelint-disable scss/load-no-partial-leading-underscore
 
 $govuk-images-path: "~govuk-frontend/dist/govuk/assets/images/";
 $govuk-fonts-path: "~govuk-frontend/dist/govuk/assets/fonts/";
@@ -7,6 +8,8 @@ $govuk-fonts-path: "~govuk-frontend/dist/govuk/assets/fonts/";
 
 @import "~govuk-frontend/dist/govuk/base";
 @import "~govuk-frontend/dist/govuk/core/typography";
+
+@import "@ministryofjustice/frontend/moj/components/multi-file-upload/_multi-file-upload.scss";
 
 // Project specific
 // Everything below this comment should be project specific.

--- a/config/initializers/assets.rb
+++ b/config/initializers/assets.rb
@@ -14,3 +14,4 @@
 Rails.application.config.assets.paths << Rails.root.join('node_modules', 'govuk-frontend', 'dist', 'govuk', 'assets')
 Rails.application.config.assets.paths << Rails.root.join('node_modules', 'govuk-frontend', 'dist', 'govuk', 'assets', 'images')
 Rails.application.config.assets.paths << Rails.root.join('app', 'webpack', 'packs')
+Rails.application.config.assets.paths << Rails.root.join('node_modules', '@ministryofjustice', 'frontend', 'moj', 'assets')

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -60,6 +60,8 @@ Rails.application.routes.draw do
 
   resources :documents do
     get 'download', on: :member
+    post 'upload', on: :collection
+    post 'delete', on: :collection
   end
 
   resources :messages, only: [:create] do

--- a/config/webpack/webpack.config.js
+++ b/config/webpack/webpack.config.js
@@ -95,7 +95,8 @@ module.exports = {
       jQuery: require.resolve('jquery'),
       jquery: require.resolve('jquery'),
       Dropzone: require.resolve('dropzone/dist/dropzone.js'),
-      Stickyfill: require.resolve('stickyfilljs')
+      Stickyfill: require.resolve('stickyfilljs'),
+      MOJFrontend: require.resolve('@ministryofjustice/frontend/moj/all.js')
     })
   ]
 }

--- a/features/page_objects/claim_show_page.rb
+++ b/features/page_objects/claim_show_page.rb
@@ -30,7 +30,7 @@ class ClaimShowPage < BasePage
     element :send, 'button.govuk-button', text: 'Send'
 
     def upload_file(path)
-      attach_file("message-attachment-field", path)
+      attach_file("attachments", path)
     end
 
     sections :messages, '.message-body' do

--- a/features/step_definitions/messaging_steps.rb
+++ b/features/step_definitions/messaging_steps.rb
@@ -41,8 +41,10 @@ end
 When(/^I upload a file$/) do
   available_docs = Dir.glob "#{Rails.root}/spec/fixtures/files/*.pdf"
   @uploaded_file_path = available_docs.first
-  file_field = page.find('input[type="file"]')
-  file_field.attach_file(@uploaded_file_path)
+  page.execute_script("$('.moj-multi-file-upload__input').css('position','unset')")
+  input_field = page.find("input[name='attachments']")
+  input_field.attach_file(@uploaded_file_path)
+  sleep 1
 end
 
 When(/^I click send$/) do

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@babel/core": "^7.26.9",
     "@babel/plugin-transform-runtime": "^7.26.9",
     "@babel/preset-env": "^7.26.9",
+    "@ministryofjustice/frontend": "^2.2.4",
     "accessible-autocomplete": "^3.0.1",
     "babel-loader": "^9.2.1",
     "babel-plugin-macros": "^3.1.0",

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -77,7 +77,12 @@ RSpec.describe MessagesController do
     end
 
     describe 'GET #download_attachment' do
-      subject(:download_attachment) { get :download_attachment, params: { id: message.id } }
+      subject(:download_attachment) do
+        get :download_attachment, params: {
+          id: message.id,
+          attachment_id: message.attachments.first&.id
+        }
+      end
 
       context 'when message has attachment' do
         let(:message) { create(:message) }

--- a/spec/javascripts/modules-MultiFileUpload_spec.js
+++ b/spec/javascripts/modules-MultiFileUpload_spec.js
@@ -1,5 +1,20 @@
 describe('Modules.MultiFileUpload', () => {
   const module = moj.Modules.MultiFileUpload
+  const multiFileUploadFixtureDOM = $(['<div class="moj-multi-file-upload">',
+    '<div class="moj-multi-file__uploaded-fields"></div>',
+    '<div aria-labelledby="error-summary-title" class="govuk-error-summary" role="alert" style="display: none" tabindex="-1">',
+    '<h2 class="error-summary-title govuk-error-summary__title">There is a problem</h2>',
+    '<div class="govuk-list govuk-error-summary__list"></div>',
+    '</div>',
+    '<div class="moj-multi-file-upload__upload">',
+    '<div class="govuk-form-group">',
+    '<div class="moj-multi-file-upload__dropzone">',
+    '<input class="govuk-file-upload moj-multi-file-upload__input" id="attachments" multiple="multiple" name="attachments" type="file">',
+    '<div aria-live="polite" role="status" class="govuk-visually-hidden"></div>',
+    '</div>',
+    '</div>',
+    '</div>',
+    '</div>'].join(''))
 
   it('...should exist', function () {
     expect(module).toBeDefined()
@@ -7,24 +22,73 @@ describe('Modules.MultiFileUpload', () => {
 
   let container
   let fields
+  let multiFileUpload
 
   beforeEach(() => {
+    $('body').append(multiFileUploadFixtureDOM)
     container = document.querySelector('.moj-multi-file-upload')
-    if (!container) {
-      pending('Container is not defined')
-    }
     fields = container.querySelector('.moj-multi-file__uploaded-fields')
+    multiFileUpload = module.init()
   })
 
   afterEach(() => {
-    // Clean up the mock container element
+    // Clean up the container and fields elements set at the start of the test
     if (container) {
       container.parentNode.removeChild(container)
+    }
+    while (fields.firstChild) {
+      fields.removeChild(fields.firstChild)
     }
   })
 
   it('should initialize the multi-file upload component', () => {
     expect(container).not.toBeNull()
     expect(fields).not.toBeNull()
+  })
+
+  describe('uploadFileExitHook', () => {
+    it('should append a hidden input field with the file name', () => {
+      const response = { file: { filename: 'test-file.txt' } }
+      multiFileUpload.params.uploadFileExitHook(null, null, response)
+      const input = fields.querySelector('input[type="hidden"]')
+      expect(input).not.toBeNull()
+      expect(input.name).toBe('message[document_ids][]')
+      expect(input.value).toBe('test-file.txt')
+    })
+  })
+
+  describe('uploadFileErrorHook', () => {
+    const file = { name: 'test-file.txt' }
+    const jqXHR = { status: 500 }
+    const errorThrown = 'test-file.txt: Internal Server Error.<br>'
+
+    it('should append a hidden input field with the error message', () => {
+      multiFileUpload.params.uploadFileErrorHook(null, file, jqXHR, null, errorThrown)
+      const input = fields.querySelector('input[type="hidden"]')
+      expect(input).not.toBeNull()
+      expect(input.name).toBe('message[document_ids][]')
+      expect(input.value).toBe(errorThrown)
+    })
+
+    it('should display an error message in the error summary', () => {
+      multiFileUpload.params.uploadFileErrorHook(null, file, jqXHR, null, errorThrown)
+      const errorContainer = document.querySelector('.govuk-error-summary')
+      expect(errorContainer.style.display).not.toBe('none')
+      const error = errorContainer.querySelector('.govuk-list.govuk-error-summary__list span')
+      expect(error).not.toBeNull()
+      expect(error.innerHTML).toContain(file.name)
+      expect(error.innerHTML).toContain(errorThrown)
+    })
+  })
+
+  describe('fileDeleteHook', () => {
+    it('should remove the corresponding input field', () => {
+      const response = { file: { filename: 'test-file.txt' } }
+      multiFileUpload.params.uploadFileExitHook(null, null, response)
+      const input = fields.querySelector('input[type="hidden"]')
+      expect(input).not.toBeNull()
+      multiFileUpload.params.fileDeleteHook(null, response)
+      expect(fields.querySelector('input[type="hidden"]')).toBeNull()
+    })
   })
 })

--- a/spec/javascripts/modules-MultiFileUpload_spec.js
+++ b/spec/javascripts/modules-MultiFileUpload_spec.js
@@ -1,0 +1,30 @@
+describe('Modules.MultiFileUpload', () => {
+  const module = moj.Modules.MultiFileUpload
+
+  it('...should exist', function () {
+    expect(module).toBeDefined()
+  })
+
+  let container
+  let fields
+
+  beforeEach(() => {
+    container = document.querySelector('.moj-multi-file-upload')
+    if (!container) {
+      pending('Container is not defined')
+    }
+    fields = container.querySelector('.moj-multi-file__uploaded-fields')
+  })
+
+  afterEach(() => {
+    // Clean up the mock container element
+    if (container) {
+      container.parentNode.removeChild(container)
+    }
+  })
+
+  it('should initialize the multi-file upload component', () => {
+    expect(container).not.toBeNull()
+    expect(fields).not.toBeNull()
+  })
+})

--- a/spec/javascripts/modules-MultiFileUpload_spec.js
+++ b/spec/javascripts/modules-MultiFileUpload_spec.js
@@ -2,7 +2,7 @@ describe('Modules.MultiFileUpload', () => {
   const module = moj.Modules.MultiFileUpload
   const multiFileUploadFixtureDOM = $(['<div class="moj-multi-file-upload">',
     '<div class="moj-multi-file__uploaded-fields"></div>',
-    '<div aria-labelledby="error-summary-title" class="govuk-error-summary" role="alert" style="display: none" tabindex="-1">',
+    '<div aria-labelledby="error-summary-title" class="govuk-error-summary govuk-visually-hidden" role="alert" tabindex="-1">',
     '<h2 class="error-summary-title govuk-error-summary__title">There is a problem</h2>',
     '<div class="govuk-list govuk-error-summary__list"></div>',
     '</div>',
@@ -73,7 +73,7 @@ describe('Modules.MultiFileUpload', () => {
     it('should display an error message in the error summary', () => {
       multiFileUpload.params.uploadFileErrorHook(null, file, jqXHR, null, errorThrown)
       const errorContainer = document.querySelector('.govuk-error-summary')
-      expect(errorContainer.style.display).not.toBe('none')
+      expect(errorContainer).not.toHaveClass('govuk-visually-hidden')
       const error = errorContainer.querySelector('.govuk-list.govuk-error-summary__list span')
       expect(error).not.toBeNull()
       expect(error.innerHTML).toContain(file.name)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -87,8 +87,8 @@ RSpec.describe Ability do
       end
     end
 
-    context 'can index and create documents' do
-      %i[index create].each do |action|
+    context 'can index, create, upload and delete documents' do
+      %i[index create upload delete].each do |action|
         it { should be_able_to(action, Document.new(external_user:)) }
       end
     end
@@ -199,8 +199,8 @@ RSpec.describe Ability do
       end
     end
 
-    context 'can index and create documents' do
-      %i[index create].each do |action|
+    context 'can index, create, upload and delete documents' do
+      %i[index create upload delete].each do |action|
         it { should be_able_to(action, Document.new(external_user:)) }
       end
     end
@@ -291,8 +291,8 @@ RSpec.describe Ability do
       end
     end
 
-    context 'can index and create documents' do
-      %i[index create].each do |action|
+    context 'can index, create, upload and delete documents' do
+      %i[index create upload delete].each do |action|
         it { should be_able_to(action, Document.new(external_user:)) }
       end
     end
@@ -369,8 +369,8 @@ RSpec.describe Ability do
       end
     end
 
-    context 'can index and create documents' do
-      %i[index create].each do |action|
+    context 'can index, create, upload and delete documents' do
+      %i[index create upload delete].each do |action|
         it { should be_able_to(action, Document.new(external_user:)) }
       end
     end
@@ -429,7 +429,13 @@ RSpec.describe Ability do
       end
     end
 
-    context 'can view/download documents' do
+    context 'can upload and delete documents' do
+      %i[upload delete].each do |action|
+        it { should be_able_to(action, Document.new) }
+      end
+    end
+
+    context 'can view and download documents' do
       %i[show download].each do |action|
         it { should be_able_to(action, Document.new) }
       end
@@ -480,7 +486,13 @@ RSpec.describe Ability do
       it { should be_able_to(action, Claim::AdvocateClaim.new) }
     end
 
-    context 'can view/download documents' do
+    context 'can upload and delete documents' do
+      %i[upload delete].each do |action|
+        it { should be_able_to(action, Document.new) }
+      end
+    end
+
+    context 'can view and download documents' do
       %i[show download].each do |action|
         it { should be_able_to(action, Document.new) }
       end

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -27,6 +27,23 @@ require 'rails_helper'
 require 'fileutils'
 
 RSpec.describe Document do
+  let(:valid_mime_types) do
+    %w[
+      application/pdf
+      application/msword
+      application/vnd.openxmlformats-officedocument.wordprocessingml.document
+      application/vnd.oasis.opendocument.text
+      application/vnd.ms-excel
+      application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+      application/vnd.oasis.opendocument.spreadsheet
+      application/rtf
+      image/jpeg
+      image/png
+      image/tiff
+      image/bmp
+    ]
+  end
+
   it { is_expected.to belong_to(:external_user) }
   it { is_expected.to belong_to(:creator).class_name('ExternalUser') }
   it { is_expected.to belong_to(:claim) }
@@ -37,11 +54,9 @@ RSpec.describe Document do
   it { is_expected.to validate_size_of(:document).less_than_or_equal_to(20.megabytes) }
 
   it do
-    is_expected.to validate_content_type_of(:document).allowing(
-      'application/pdf', 'application/msword', 'application/vnd.oasis.opendocument.text', 'application/rtf',
-      'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-      'image/jpeg', 'image/png', 'image/tiff', 'image/bmp'
-    ).rejecting('text/plain', 'text/html')
+    is_expected.to validate_content_type_of(:document)
+      .allowing(*valid_mime_types)
+      .rejecting('text/plain', 'text/html')
   end
 
   it { is_expected.to have_one_attached(:converted_preview_document) }

--- a/spec/models/message_spec.rb
+++ b/spec/models/message_spec.rb
@@ -17,6 +17,23 @@
 require 'rails_helper'
 
 RSpec.describe Message do
+  let(:valid_mime_types) do
+    %w[
+      application/pdf
+      application/msword
+      application/vnd.openxmlformats-officedocument.wordprocessingml.document
+      application/vnd.oasis.opendocument.text
+      application/vnd.ms-excel
+      application/vnd.openxmlformats-officedocument.spreadsheetml.sheet
+      application/vnd.oasis.opendocument.spreadsheet
+      application/rtf
+      image/jpeg
+      image/png
+      image/tiff
+      image/bmp
+    ]
+  end
+
   it { is_expected.to belong_to(:claim) }
   it { is_expected.to belong_to(:sender).class_name('User').inverse_of(:messages_sent) }
   it { is_expected.to have_many(:user_message_statuses) }
@@ -29,20 +46,8 @@ RSpec.describe Message do
 
   it do
     is_expected.to validate_content_type_of(:attachments)
-      .allowing(
-        'application/pdf',
-        'application/msword',
-        'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
-        'application/vnd.oasis.opendocument.text',
-        'application/vnd.ms-excel',
-        'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
-        'application/vnd.oasis.opendocument.spreadsheet',
-        'application/rtf',
-        'image/jpeg',
-        'image/png',
-        'image/tiff',
-        'image/bmp'
-      ).rejecting('text/plain', 'text/html')
+      .allowing(*valid_mime_types)
+      .rejecting('text/plain', 'text/html')
   end
 
   it { is_expected.to validate_size_of(:attachments).less_than_or_equal_to(20.megabytes) }

--- a/spec/presenters/message_presenter_spec.rb
+++ b/spec/presenters/message_presenter_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe MessagePresenter, type: :helper do
 
       it 'includes a download link to the attachment' do
         expect(presenter.body)
-          .to match(%r{Attachment:\s*<a.*>shorter_lorem.docx \(#{file_size}\)</a>})
+          .to match(%r{<div>.*Attachments: <br><a.*>shorter_lorem.docx \(#{file_size}\)</a>.*</div>})
       end
     end
   end

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -178,4 +178,77 @@ RSpec.describe 'Document management' do
       it { expect { delete_document }.not_to change(ActiveStorage::Blob, :count) }
     end
   end
+
+  describe 'POST /documents/upload' do
+    subject(:create_document) { post upload_documents_path, params: }
+
+    let(:params) do
+      {
+        documents: Rack::Test::UploadedFile.new(Rails.root + 'features/examples/longer_lorem.pdf', 'application/pdf')
+      }
+    end
+
+    context 'when the document is valid' do
+      it 'creates a document' do
+        expect { create_document }.to change(Document, :count).by(1)
+      end
+
+      it 'returns status created' do
+        create_document
+        expect(response).to have_http_status(:created)
+      end
+
+      it 'returns the id of the created document' do
+        create_document
+        # The MultiFileUpload uses the filename as the only paramater to identify the document for the delte button
+        # For this reason the 'filename' in the response is the document id
+        expect(response.parsed_body['file']['filename']).to eq Document.last.id
+      end
+
+      it 'returns a success message' do
+        create_document
+        expect(response.parsed_body['success']).to have_key('messageHtml')
+      end
+    end
+
+    context 'when the document is invalid' do
+      let(:params) do
+        {
+          documents: Rack::Test::UploadedFile.new(Rails.root + 'features/examples/longer_lorem.html', 'text/html')
+        }
+      end
+
+      it 'does not create a document' do
+        expect { create_document }.not_to change(Document, :count)
+      end
+
+      it 'returns status unprocessable entity' do
+        create_document
+        expect(response).to have_http_status(:accepted)
+      end
+
+      it 'returns errors in response' do
+        create_document
+        expect(response.parsed_body['error']).to have_key('message')
+      end
+    end
+
+    context 'when the document is missing' do
+      let(:params) { { documents: nil } }
+
+      it 'does not create a document' do
+        expect { create_document }.not_to change(Document, :count)
+      end
+
+      it 'returns status unprocessable entity' do
+        create_document
+        expect(response).to have_http_status(:accepted)
+      end
+
+      it 'returns errors in response' do
+        create_document
+        expect(response.parsed_body['error']).to have_key('message')
+      end
+    end
+  end
 end

--- a/yarn.lock
+++ b/yarn.lock
@@ -933,6 +933,14 @@
   resolved "https://registry.yarnpkg.com/@kurkle/color/-/color-0.3.4.tgz#4d4ff677e1609214fc71c580125ddddd86abcabf"
   integrity sha512-M5UknZPHRu3DEDWoipU6sE8PdkZ6Z/S+v4dD+Ke8IaNlpdSQah50lz1KtcFBa2vsdOnwbbnxJwVM4wty6udA5w==
 
+"@ministryofjustice/frontend@^2.2.4":
+  version "2.2.5"
+  resolved "https://registry.yarnpkg.com/@ministryofjustice/frontend/-/frontend-2.2.5.tgz#e4371759f915db8d0677c03daee72c5cb6ddbd8e"
+  integrity sha512-UR8WTME0vrYhtCxBESd0XaAvfjdi9UujieeooQj1ddQKdcfI/wkXUMJO8hWWvXjeqRxfKB2v62rw1mSRc+Yqrw==
+  dependencies:
+    govuk-frontend "^5.0.0"
+    moment "^2.27.0"
+
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz#7619c2eb21b25483f6d167548b4cfd5a7488c3d5"
@@ -2914,7 +2922,7 @@ gopd@^1.0.1, gopd@^1.2.0:
   resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
   integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
 
-govuk-frontend@^5.8.0:
+govuk-frontend@^5.0.0, govuk-frontend@^5.8.0:
   version "5.8.0"
   resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-5.8.0.tgz#da1b03cb4f2ba1f6036be0dac3c5327c3405174c"
   integrity sha512-6l3f/YhDUCWjpmSW3CL95Hg8B+ZLzTf2WYo25ZtCs2Lb8UIzxxxFI8LxG7Ey/z04UuPhUunqFhTwSkQyJ69XbQ==
@@ -3810,6 +3818,11 @@ minimist@^1.2.0, minimist@^1.2.6:
   version "7.1.2"
   resolved "https://registry.yarnpkg.com/minipass/-/minipass-7.1.2.tgz#93a9626ce5e5e66bd4db86849e7515e92340a707"
   integrity sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==
+
+moment@^2.27.0:
+  version "2.30.1"
+  resolved "https://registry.yarnpkg.com/moment/-/moment-2.30.1.tgz#f8c91c07b7a786e30c59926df530b4eac96974ae"
+  integrity sha512-uEmtNhbDOrWPFS+hdjFCBfy9f2YoyzRpwcl+DqpC6taX21FzsTLQVbMV/W7PzNSX6x/bhC1zA3c2UQ5NzH6how==
 
 ms@2.0.0:
   version "2.0.0"


### PR DESCRIPTION
#### What

Allow users to add multiple files to messages on claims.

#### Ticket

[CCCD - Allow multiple attachments to be added to messages](https://dsdmoj.atlassian.net/browse/CTSKF-833)

#### Why

A frequent request from providers is the ability to attach multiple document to messages sent to case workers. When a claim is submitted case workers sometimes request extra evidence documents and this can only be done with messages. If multiple documents are requested then the provider needs to create multiple messages and this is inefficient.

#### How

By design messages previously only permitted a single document. This is because, prior to Active Storage, the attachment attribute referenced a [paperclip](https://github.com/thoughtbot/paperclip) instance and this did not allow for collections. Active Storage, however, provides a link to either a single documents or [collection of documents.](https://guides.rubyonrails.org/active_storage_overview.html#has-many-attached) This has been facilitated by #7990 and this PR introduces a multi-file upload to the front-end from [the Ministry of Justice Frontend](https://design-patterns.service.justice.gov.uk/components/multi-file-upload/)