### PR TITLE
Remove breaking nokogiri gemfile.lock change

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -268,7 +268,6 @@ GEM
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
     ffi (1.17.1-arm64-darwin)
-    ffi (1.17.1-x86_64-darwin)
     ffi (1.17.1-x86_64-linux-gnu)
     fugit (1.11.1)
       et-orbi (~> 1, >= 1.2.11)
@@ -412,8 +411,6 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.4)
-    nokogiri (1.18.2-x86_64-darwin)
-      racc (~> 1.4)
     nokogiri (1.18.3-arm64-darwin)
       racc (~> 1.4)
     nokogiri (1.18.3-x86_64-linux-gnu)
@@ -695,7 +692,6 @@ GEM
 PLATFORMS
   arm64-darwin-23
   arm64-darwin-24
-  x86_64-darwin-22
   x86_64-linux-gnu
 
 DEPENDENCIES


### PR DESCRIPTION
#### What

Reverts 615021cb37748e95bfddc9a0a2d6fc3f1d781650 which introduced a breaking change to the gemfile.lock
