### PR TITLE
Update MAAT reference matching

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-cda
-  revision: fd3c677a0cc6c51dfdfab8d6b97f75b2b86f213e
+  revision: 66f4bb3c026dc4a0ce58d74bd9191ecc6e16415d
   specs:
     laa-cda (0.0.1)
       faraday (~> 2.0)

--- a/app/models/court_data.rb
+++ b/app/models/court_data.rb
@@ -51,7 +51,8 @@ class CourtData
     representation_orders = defendant.representation_orders.map(&:maat_reference)
     LAA::Cda::ProsecutionCase.search(name: defendant.name, date_of_birth: defendant.date_of_birth)
                              .find do |prosecution_case|
-      prosecution_case.defendants.map { |d| d.representation_order&.reference }.intersect?(representation_orders)
+      prosecution_case.defendants.map { |d| d.representation_orders.map(&:reference) }.flatten
+                      .intersect?(representation_orders)
     end
   end
 

--- a/app/models/court_data/defendant.rb
+++ b/app/models/court_data/defendant.rb
@@ -6,7 +6,5 @@ class CourtData
       @claim = claim
       @hmcts = hmcts
     end
-
-    def maat_reference = @claim&.maat_reference || @hmcts&.maat_reference
   end
 end

--- a/app/models/court_data/defendant/base.rb
+++ b/app/models/court_data/defendant/base.rb
@@ -7,7 +7,7 @@ class CourtData
         @defendant = defendant
       end
 
-      def ==(other) = maat_reference == other.maat_reference
+      def ==(other) = maat_references.intersect?(other.maat_references)
     end
   end
 end

--- a/app/models/court_data/defendant/claim.rb
+++ b/app/models/court_data/defendant/claim.rb
@@ -2,6 +2,7 @@ class CourtData
   class Defendant
     class Claim < Base
       def maat_reference = @defendant.earliest_representation_order.maat_reference
+      def maat_references = @defendant.representation_orders.map(&:maat_reference)
     end
   end
 end

--- a/app/models/court_data/defendant/claim.rb
+++ b/app/models/court_data/defendant/claim.rb
@@ -1,7 +1,6 @@
 class CourtData
   class Defendant
     class Claim < Base
-      def maat_reference = @defendant.earliest_representation_order.maat_reference
       def maat_references = @defendant.representation_orders.map(&:maat_reference)
     end
   end

--- a/app/models/court_data/defendant/hmcts.rb
+++ b/app/models/court_data/defendant/hmcts.rb
@@ -3,7 +3,6 @@ class CourtData
     class Hmcts < Base
       delegate :id, to: :@defendant
 
-      def maat_reference = @defendant.representation_order&.reference || 'No representation order recorded'
       def maat_references = @defendant.representation_orders.map(&:reference)
       def start = @defendant.representation_order&.start
       def end = @defendant.representation_order&.end

--- a/app/models/court_data/defendant/hmcts.rb
+++ b/app/models/court_data/defendant/hmcts.rb
@@ -4,9 +4,16 @@ class CourtData
       delegate :id, to: :@defendant
 
       def maat_reference = @defendant.representation_order&.reference || 'No representation order recorded'
+      def maat_references = @defendant.representation_orders.map(&:reference)
       def start = @defendant.representation_order&.start
       def end = @defendant.representation_order&.end
       def contract_number = @defendant.representation_order&.contract_number
+
+      def maat_reference_list
+        return 'No representation orders recorded' if maat_references.empty?
+
+        maat_references.join(', ')
+      end
     end
   end
 end

--- a/app/views/case_workers/court_data/_defendant.html.haml
+++ b/app/views/case_workers/court_data/_defendant.html.haml
@@ -2,7 +2,7 @@
   %h2.govuk-heading-m
     = defendant.claim.name
   %p.govuk-body
-    = t('.show_maat_reference', maat: defendant.maat_reference)
+    = t('.show_maat_reference', maat: defendant.claim.maat_references.join(', '))
 - else
   %h2.govuk-heading-m
     = t('.common_platform_only')
@@ -25,7 +25,7 @@
           %dt.govuk-summary-list__key
             = t('.maat_reference')
           %dd.govuk-summary-list__value
-            = defendant.maat_reference
+            = defendant.hmcts.maat_reference_list
         - if defendant.hmcts.start.present?
           .govuk-summary-list__row
             %dt.govuk-summary-list__key

--- a/spec/models/court_data_spec.rb
+++ b/spec/models/court_data_spec.rb
@@ -157,19 +157,17 @@ RSpec.describe CourtData do
                     LAA::Cda::Defendant,
                     id: '12345',
                     name: 'Billy The Kid',
-                    representation_order: instance_double(
-                      LAA::Cda::RepresentationOrder,
-                      reference: '9999999',
-                      start: Date.parse('2024-05-05'),
-                      end: Date.parse('2024-05-06'),
-                      contract_number: 'AA111'
-                    )
+                    representation_order: representation_order,
+                    representation_orders: [representation_order]
                   )
                 ]
               )
             ]
           }
         ]
+      end
+      let(:representation_order) do
+        instance_double(LAA::Cda::RepresentationOrder, reference: '9999999', contract_number: 'AA111')
       end
 
       it { expect(court_data).to have(3).defendants }
@@ -212,19 +210,18 @@ RSpec.describe CourtData do
                     LAA::Cda::Defendant,
                     id: '12345',
                     name: 'Hawley Harvey Crippen',
-                    representation_order: instance_double(
-                      LAA::Cda::RepresentationOrder,
-                      reference: claim_defendants[1].earliest_representation_order.maat_reference,
-                      start: Date.parse('2024-05-05'),
-                      end: Date.parse('2024-05-06'),
-                      contract_number: 'AA111'
-                    )
+                    representation_orders: [representation_order]
                   )
                 ]
               )
             ]
           }
         ]
+      end
+      let(:representation_order) do
+        instance_double(
+          LAA::Cda::RepresentationOrder, reference: claim_defendants[1].earliest_representation_order.maat_reference
+        )
       end
 
       it { expect(court_data).to have(2).defendants }
@@ -251,13 +248,15 @@ RSpec.describe CourtData do
                     LAA::Cda::Defendant,
                     id: '12345',
                     name: 'Hawley Harvey Crippen',
-                    representation_order: nil
+                    representation_order: nil,
+                    representation_orders: []
                   ),
                   instance_double(
                     LAA::Cda::Defendant,
                     id: '12346',
                     name: 'Arthur Justice Raffles',
-                    representation_order: nil
+                    representation_order: nil,
+                    representation_orders: []
                   )
                 ]
               )

--- a/spec/models/court_data_spec.rb
+++ b/spec/models/court_data_spec.rb
@@ -60,8 +60,10 @@ RSpec.describe CourtData do
           defendants: claim_defendants.map do |defendant|
             instance_double(
               LAA::Cda::Defendant,
-              representation_order: instance_double(LAA::Cda::RepresentationOrder,
-                                                    reference: defendant.earliest_representation_order.maat_reference)
+              representation_orders: [
+                instance_double(LAA::Cda::RepresentationOrder,
+                                reference: defendant.earliest_representation_order.maat_reference)
+              ]
             )
           end
         )
@@ -129,7 +131,6 @@ RSpec.describe CourtData do
 
       it do
         is_expected.to include(have_attributes(
-                                 maat_reference: claim_defendants[0].earliest_representation_order.maat_reference,
                                  claim: have_attributes(name: claim_defendants[0].name),
                                  hmcts: nil
                                ))
@@ -137,7 +138,6 @@ RSpec.describe CourtData do
 
       it {
         is_expected.to include(have_attributes(
-                                 maat_reference: claim_defendants[1].earliest_representation_order.maat_reference,
                                  claim: have_attributes(name: claim_defendants[1].name),
                                  hmcts: nil
                                ))
@@ -157,7 +157,6 @@ RSpec.describe CourtData do
                     LAA::Cda::Defendant,
                     id: '12345',
                     name: 'Billy The Kid',
-                    representation_order: representation_order,
                     representation_orders: [representation_order]
                   )
                 ]
@@ -174,7 +173,6 @@ RSpec.describe CourtData do
 
       it do
         is_expected.to include(have_attributes(
-                                 maat_reference: claim_defendants[0].earliest_representation_order.maat_reference,
                                  claim: have_attributes(name: claim_defendants[0].name),
                                  hmcts: nil
                                ))
@@ -182,7 +180,6 @@ RSpec.describe CourtData do
 
       it {
         is_expected.to include(have_attributes(
-                                 maat_reference: claim_defendants[1].earliest_representation_order.maat_reference,
                                  claim: have_attributes(name: claim_defendants[1].name),
                                  hmcts: nil
                                ))
@@ -190,7 +187,6 @@ RSpec.describe CourtData do
 
       it {
         is_expected.to include(have_attributes(
-                                 maat_reference: '9999999',
                                  claim: nil,
                                  hmcts: have_attributes(name: 'Billy The Kid')
                                ))
@@ -248,14 +244,12 @@ RSpec.describe CourtData do
                     LAA::Cda::Defendant,
                     id: '12345',
                     name: 'Hawley Harvey Crippen',
-                    representation_order: nil,
                     representation_orders: []
                   ),
                   instance_double(
                     LAA::Cda::Defendant,
                     id: '12346',
                     name: 'Arthur Justice Raffles',
-                    representation_order: nil,
                     representation_orders: []
                   )
                 ]
@@ -269,7 +263,6 @@ RSpec.describe CourtData do
 
       it do
         is_expected.to include(have_attributes(
-                                 maat_reference: claim_defendants[0].earliest_representation_order.maat_reference,
                                  claim: have_attributes(name: claim_defendants[0].name),
                                  hmcts: nil
                                ))
@@ -277,7 +270,6 @@ RSpec.describe CourtData do
 
       it {
         is_expected.to include(have_attributes(
-                                 maat_reference: claim_defendants[1].earliest_representation_order.maat_reference,
                                  claim: have_attributes(name: claim_defendants[1].name),
                                  hmcts: nil
                                ))
@@ -285,7 +277,6 @@ RSpec.describe CourtData do
 
       it {
         is_expected.to include(have_attributes(
-                                 maat_reference: 'No representation order recorded',
                                  claim: nil,
                                  hmcts: have_attributes(name: 'Hawley Harvey Crippen')
                                ))
@@ -293,7 +284,6 @@ RSpec.describe CourtData do
 
       it {
         is_expected.to include(have_attributes(
-                                 maat_reference: 'No representation order recorded',
                                  claim: nil,
                                  hmcts: have_attributes(name: 'Arthur Justice Raffles')
                                ))


### PR DESCRIPTION
#### What

Update how MAAT reference is found in Court Data.

#### Ticket

N/A

#### Why

The MAAT reference from Court Data was being taken from the 'representation_order' field of the defendant. This is not always present and it should instead come from the 'laa_reference' option of the offence summaries. If I understand correctly, the 'representation_order' field is added at a later part of the process and this is why it is not always present.

The offence summaries of a defendant is a list and the representation order (laa_reference) may appear multiple times. Also, it is possible that a defendant may have multiple representation orders on different items in the offence summary list, although I haven't seen this yet.

#### How

* Update the version of the `laa-cda` gem. See https://github.com/ministryofjustice/laa-cda/commit/66f4bb3c026dc4a0ce58d74bd9191ecc6e16415d
* Consider a case to be matching if any MAAT reference in CCCD correspond to any in Court Data.
* Display all MAAT references for the defendant as recorded in CCCD and Court Data, not just the earliers
