### PR TITLE
Update brakeman ignore list

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,25 +24,6 @@
       "note": ""
     },
     {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.0.8.7 ends on 2025-04-01",
-      "file": "Gemfile.lock",
-      "line": 458,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        1104
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Redirect",
       "warning_code": 18,
       "fingerprint": "463781a59c65a58aad10746c6698db3f169b58a20435304888eff3fe9449b2ec",
@@ -87,8 +68,27 @@
         22
       ],
       "note": "Caseworkers need to identify the downloads correspond to the cases they are processing"
+    },
+    {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.0.8.7 ends on 2025-04-01",
+      "file": "Gemfile.lock",
+      "line": 460,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Medium",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
     }
   ],
-  "updated": "2025-01-31 09:19:56 +0000",
+  "updated": "2025-03-03 09:44:57 +0000",
   "brakeman_version": "6.2.2"
 }


### PR DESCRIPTION
#### What

Update the brakeman ignore file.

#### Ticket

N/A

#### Why

The brakeman warning for the EOS of Rails 7.0 has been upgraded from 'weak' to 'medium' so the ignore list needs to be updated.

#### How

`bundle exec brakeman -I`