### PR TITLE
Add disbursements without VAT section

### DIFF
--- a/app/views/shared/_new_lgfs_disbursements.html.haml
+++ b/app/views/shared/_new_lgfs_disbursements.html.haml
@@ -1,7 +1,10 @@
 .govuk-summary-card
   .govuk-summary-card__title-wrapper
     %h2.govuk-summary-card__title
-      = t('.disbursements_gross')
+      - if vat_total
+        = t('.disbursements_gross')
+      - else
+        = t('.disbursements_without_vat')
   .govuk-summary-card__content
     = govuk_table(class: 'govuk-table--custom govuk-!-margin-bottom-0') do
       = govuk_table_caption(class: 'govuk-visually-hidden') do
@@ -15,14 +18,15 @@
           = govuk_table_th_numeric do
             = t('.net_amount')
 
-          = govuk_table_th_numeric do
-            = t('.vat_amount')
+          - if vat_total
+            = govuk_table_th_numeric do
+              = t('.vat_amount')
 
           = govuk_table_th_numeric do
             = t('.gross_amount')
 
       = govuk_table_tbody do
-        - present_collection(claim.disbursements.with_vat).each do |disbursement|
+        - present_collection(disbursements).each do |disbursement|
           = govuk_table_row do
             = govuk_table_td('data-label': t('.disbursement_type')) do
               = disbursement.name
@@ -30,8 +34,9 @@
             = govuk_table_td_numeric('data-label': t('.net_amount')) do
               = disbursement.net_amount
 
-            = govuk_table_td_numeric('data-label': t('.vat')) do
-              = disbursement.vat_amount
+            - if vat_total
+              = govuk_table_td_numeric('data-label': t('.vat')) do
+                = disbursement.vat_amount
 
             = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
               = disbursement.total
@@ -39,13 +44,18 @@
       = govuk_table_tfoot do
         = govuk_table_row(class: 'govuk-table__row--no-bottom-border') do
           = govuk_table_th(scope: 'row', 'data-label': t('shared.disbursement_type')) do
-            = t('shared.disbursements_gross')
+            - if vat_total
+              = t('.disbursements_gross')
+            - else
+              = t('.disbursements_without_vat')
+
 
           = govuk_table_td_numeric('data-label': t('shared.net_amount')) do
-            = claim.disbursements_with_vat_net
+            = net_total
 
-          = govuk_table_td_numeric('data-label': t('shared.vat')) do
-            = claim.disbursements_vat
+          - if vat_total
+            = govuk_table_td_numeric('data-label': t('shared.vat')) do
+              = vat_total
 
           = govuk_table_td_numeric('data-label': t('shared.gross_amount')) do
-            = claim.disbursements_with_vat_gross
+            = gross_total

--- a/app/views/shared/_new_summary_lgfs.html.haml
+++ b/app/views/shared/_new_summary_lgfs.html.haml
@@ -10,16 +10,16 @@
     = render partial:'shared/new_warrant_fees_details', locals: { claim: claim }
 
   - if claim.can_have_disbursements?
-    - if claim.disbursements.empty?
-      %h2.govuk-heading-l
-        = t('common.disbursements')
+    %h2.govuk-heading-l
+      = t('common.disbursements')
 
+    - if claim.disbursements.empty?
       %p.govuk-body
         = t('shared.summary.no_values.disbursements')
 
     - else
       - if claim.disbursements.with_vat.any?
-        %h2.govuk-heading-l
-          = t('shared.disbursements_gross')
-        = render partial: 'shared/new_lgfs_disbursements', locals: { claim: claim }
+        = render partial: 'shared/new_lgfs_disbursements', locals: { disbursements: claim.disbursements.with_vat, net_total: claim.disbursements_with_vat_net, vat_total: claim.disbursements_vat, gross_total: claim.disbursements_with_vat_gross }
+      - if claim.disbursements.without_vat.any?
+        = render partial: 'shared/new_lgfs_disbursements', locals: { disbursements: claim.disbursements.without_vat, net_total: claim.disbursements_without_vat_net, vat_total: nil, gross_total: claim.disbursements_without_vat_gross }
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2240,6 +2240,7 @@ en:
       days_claimed: 'Days'
     new_lgfs_disbursements:
       disbursements_gross: 'Disbursements with VAT'
+      disbursements_without_vat: 'Disbursements without VAT'
       disbursements_caption: 'Disbursements: A detailed list Type including amounts'
       disbursement_type: "Disbursement type"
       net_amount: *net_amount


### PR DESCRIPTION
#### What

Put the disbursements without vat back on the the claim summary page.

#### Ticket

N/A

#### Why

As part of the claim summary page refresh the disbursements section was accidentally dropped.

#### How

The partial for display the disbursements has been adjusted so that it can be used for both with and without VAT.