### PR TITLE
Update to show transfer details

### DIFF
--- a/app/views/shared/_new_claim_transfer_details.html.haml
+++ b/app/views/shared/_new_claim_transfer_details.html.haml
@@ -1,17 +1,7 @@
-- trial_detail_translations = 'external_users.claims.case_details.trial_detail_fields'
+= govuk_summary_list_row do
+  = govuk_summary_list_key { t('common.transfer_detail_summary') }
+  = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { claim.transfer_detail_summary rescue '' }
 
 = govuk_summary_list_row do
-  = govuk_summary_list_key { t("#{trial_detail_translations}.first_day_of_trial") }
-  = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { claim.first_day_of_trial.strftime(Settings.date_format) rescue '' }
-
-= govuk_summary_list_row do
-  = govuk_summary_list_key { t("#{trial_detail_translations}.estimated_trial_length") }
-  = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { claim.estimated_trial_length rescue '' }
-
-= govuk_summary_list_row do
-  = govuk_summary_list_key { t("#{trial_detail_translations}.actual_trial_length") }
-  = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { claim.actual_trial_length rescue '' }
-
-= govuk_summary_list_row do
-  = govuk_summary_list_key { t("#{trial_detail_translations}.trial_concluded_at") }
-  = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { claim.trial_concluded_at.strftime(Settings.date_format) rescue '' }
+  = govuk_summary_list_key { t('common.transfer_date') }
+  = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { claim.transfer_date rescue '' }


### PR DESCRIPTION
#### What

Display details of transfer on claim summary.

#### Ticket

N/A

#### Why

The details of the transfer need to be visible to case workers assessing a claim. It appears that different details were being shown accidentally.

#### How

Fix the partial to show the correct details.