### PR TITLE
Refactor clearing of upload file list

### DIFF
--- a/app/views/messages/create.js.erb
+++ b/app/views/messages/create.js.erb
@@ -14,10 +14,6 @@
     $('.written-reasons-checkbox').hide();
   <% end %>
 
-  document.querySelector('.govuk-summary-list.moj-multi-file-upload__list').innerHTML = '';
-  const errorContainer = document.querySelector('.govuk-error-summary').classList.add('govuk-visually-hidden');
-  errorContainer.querySelector('.govuk-list.govuk-error-summary__list').innerHTML = '';
-
 <% else %>
   var data = {
     success : false,

--- a/app/webpack/javascripts/modules/Modules.Messaging.js
+++ b/app/webpack/javascripts/modules/Modules.Messaging.js
@@ -39,7 +39,14 @@ moj.Modules.Messaging = {
       $('.file-to-be-uploaded').hide()
       $('#message-attachment-field').val('')
       this.messagesList.html(rorData.sentMessage).scrollTop(this.messagesList.prop('scrollHeight'))
-    // If there was an error
+
+      document.querySelector('.govuk-summary-list.moj-multi-file-upload__list').innerHTML = ''
+      const errorContainer = document.querySelector('.govuk-error-summary')
+      if (errorContainer) {
+        errorContainer.classList.add('govuk-visually-hidden')
+        errorContainer.querySelector('.govuk-list.govuk-error-summary__list').innerHTML = ''
+      }
+      // If there was an error
     } else {
       $('.message-column').addClass('govuk-form-group--error')
       $('.govuk-textarea').addClass('govuk-textarea--error')


### PR DESCRIPTION
#### What

Bug fix; When two messages are submitted on a claim without fully reloading the page the second message does not get displayed automatically.

#### Ticket

[CCCD - Failure to refresh messages after submitting](https://dsdmoj.atlassian.net/browse/CTSKF-1106)

#### Why

A Javascript error prevents the page from being updated fully meaning that, although a message has been created and added to a claim, it does not appear on the page. This causes confusion for the user and results in multiple duplicate messages being created.

#### How

The error results from a constant being created in the global scope each time a message is submitted. As a constant cannot be redefined this results in a fatal error the second and subsequent times this is executed. To fix, this code is moved inside the `processMsg` method in `moj.Modules.Messaging`.