### PR TITLE
[CTSKF-1107] Remove hidden fields created by multi-file upload

### DIFF
--- a/app/webpack/javascripts/modules/Modules.Messaging.js
+++ b/app/webpack/javascripts/modules/Modules.Messaging.js
@@ -24,8 +24,7 @@ moj.Modules.Messaging = {
     const status = rorData.success
     const adpMsg = this
 
-    // if successful
-    if (status === true) {
+    if (status === true) { // if successful
       $('.message-column').removeClass('govuk-form-group--error')
       $('.govuk-textarea').removeClass('govuk-textarea--error')
 
@@ -40,14 +39,17 @@ moj.Modules.Messaging = {
       $('#message-attachment-field').val('')
       this.messagesList.html(rorData.sentMessage).scrollTop(this.messagesList.prop('scrollHeight'))
 
-      document.querySelector('.govuk-summary-list.moj-multi-file-upload__list').innerHTML = ''
+      // Clear multi-file upload details
+      const fileList = document.querySelector('.govuk-summary-list.moj-multi-file-upload__list')
+      if (fileList) { fileList.innerHTML = '' }
+      const fileFields = document.querySelector('.moj-multi-file__uploaded-fields')
+      if (fileFields) { fileFields.innerHTML = '' }
       const errorContainer = document.querySelector('.govuk-error-summary')
       if (errorContainer) {
         errorContainer.classList.add('govuk-visually-hidden')
         errorContainer.querySelector('.govuk-list.govuk-error-summary__list').innerHTML = ''
       }
-      // If there was an error
-    } else {
+    } else { // If there was an error
       $('.message-column').addClass('govuk-form-group--error')
       $('.govuk-textarea').addClass('govuk-textarea--error')
 


### PR DESCRIPTION
#### What

Stop attachments being linked to multiple messages on a claim.

#### Ticket

[CCCD - Duplicate attachments on messages](https://dsdmoj.atlassian.net/browse/CTSKF-1107)

#### Why

There is a bug that causes attachments to become linked to multiple messages on a claim. This is because the hidden fields that are added to allow a message to link to the attachments are not being cleared when the message is submitted. They are therefore still present when the next message is created.

#### How

When a message is successfully submitted the hidden fields for the attachments are removed.