### PR TITLE
[CTSKF-1110] Restrict document linking

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -63,7 +63,7 @@ class MessagesController < ApplicationController
   end
 
   def attach_documents(message)
-    documents = Document.where(id: params[:message][:document_ids])
+    documents = Document.where(id: params[:message][:document_ids], creator_id: current_user.id)
     documents.each do |doc|
       message.attachments.attach(doc.document.blob)
     end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -24,58 +24,6 @@ RSpec.describe MessagesController do
       sign_in sender.user
     end
 
-    describe 'POST #create' do
-      let(:claim) { create(:advocate_claim) }
-      let(:message_params) do
-        {
-          claim_id: claim.id,
-          sender_id: sender.user.id,
-          body: 'lorem ipsum'
-        }
-      end
-
-      it 'renders the create js template' do
-        post :create, params: { message: message_params }, xhr: true
-        expect(response).to render_template(:create)
-      end
-
-      context 'when valid' do
-        it 'creates a message' do
-          expect {
-            post :create, params: { message: message_params }
-          }.to change(Message, :count).by(1)
-        end
-
-        context 'when redetermining/awaiting written reasons' do
-          before do
-            claim.submit!
-            claim.allocate!
-            claim.refuse!
-          end
-
-          it 'redirects to external users claim show path with messages param and accordion anchor' do
-            Settings.claim_actions.each do |action|
-              post :create, params: { message: message_params.merge(claim_action: action) }
-              expect(response).to redirect_to(external_users_claim_path(claim, messages: true) + '#claim-accordion')
-            end
-          end
-        end
-      end
-
-      context 'when invalid' do
-        before do
-          message_params.delete(:claim_id)
-        end
-
-        # TODO: We must handle the fact that if the message cannot be created, there will not be ID to redirect to (redirect_to_url)
-        xit 'does not create a message' do
-          expect {
-            post :create, params: { message: message_params }
-          }.to_not change(Message, :count)
-        end
-      end
-    end
-
     describe 'GET #download_attachment' do
       subject(:download_attachment) do
         get :download_attachment, params: {

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -81,13 +81,29 @@ RSpec.describe 'Messages' do
 
     context 'when there are documents attached' do
       let(:message_params) { { claim_id: claim.id, body: 'lorem ipsum', document_ids: documents.map(&:id) } }
-      let(:documents) { create_list(:document, 2, creator_id: creator.id) }
+      let(:documents) { create_list(:document, 2, creator_id: creator.user.id) }
 
       it { expect { submit }.to change(Message, :count).by(1) }
 
       it do
         submit
         expect(Message.last.attachments.count).to eq(2)
+      end
+
+      context 'when some documents do not belong to the creator' do
+        let(:documents) { [create(:document, creator_id: creator.user.id), create(:document)] }
+
+        it { expect { submit }.to change(Message, :count).by(1) }
+
+        it do
+          submit
+          expect(Message.last.attachments.count).to eq(1)
+        end
+
+        it do
+          submit
+          expect(Message.last.attachments.first.blob).to eq(documents.first.document.blob)
+        end
       end
     end
   end

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -1,0 +1,94 @@
+require 'rails_helper'
+
+RSpec.describe 'Messages' do
+  describe 'POST /messages' do
+    subject(:submit) { post messages_path, params: { message: message_params } }
+
+    let(:creator) { create(:external_user) }
+    let(:sender) { creator }
+    let(:message_params) { { claim_id: claim.id, body: 'lorem ipsum' } }
+    let(:claim) { create(:advocate_claim, creator: creator) }
+
+    before { sign_in sender.user }
+
+    context 'when the claim belongs to the currently logged in user' do
+      it { expect { submit }.to change(Message, :count).by(1) }
+    end
+
+    context 'when the logged in user is a case worker' do
+      let(:sender) { create(:case_worker) }
+
+      it { expect { submit }.to change(Message, :count).by(1) }
+    end
+
+    context 'when the logged in user is an external user of the same provider as the creator' do
+      let(:sender) { create(:external_user, provider: creator.provider) }
+
+      it { expect { submit }.to change(Message, :count).by(1) }
+    end
+
+    context 'when the logged in user is an external user from a different provider' do
+      let(:sender) { create(:external_user) }
+
+      before { pending 'Messages not yet restricted to current user' }
+
+      it { expect { submit }.not_to change(Message, :count) }
+    end
+
+    context 'when the message is blank' do
+      let(:message_params) { { claim_id: claim.id, body: '' } }
+
+      it { expect { submit }.not_to change(Message, :count) }
+    end
+
+    context 'when the claim does not exist' do
+      let(:message_params) { { claim_id: 0, body: 'lorem ipsum' } }
+
+      it { expect { submit }.not_to change(Message, :count) }
+    end
+
+    context 'when the claim id is missing' do
+      let(:message_params) { { body: 'lorem ipsum' } }
+
+      it { expect { submit }.not_to change(Message, :count) }
+    end
+
+    context 'with a refused claim' do
+      before do
+        claim.submit!
+        claim.allocate!
+        claim.refuse!
+      end
+
+      context 'when redetermining' do
+        let(:message_params) { { claim_id: claim.id, body: 'lorem ipsum', claim_action: 'Apply for redetermination' } }
+
+        it do
+          submit
+          expect(response).to redirect_to(external_users_claim_path(claim, messages: true) + '#claim-accordion')
+        end
+      end
+
+      context 'when requesting written reasons' do
+        let(:message_params) { { claim_id: claim.id, body: 'lorem ipsum', claim_action: 'Request written reasons' } }
+
+        it do
+          submit
+          expect(response).to redirect_to(external_users_claim_path(claim, messages: true) + '#claim-accordion')
+        end
+      end
+    end
+
+    context 'when there are documents attached' do
+      let(:message_params) { { claim_id: claim.id, body: 'lorem ipsum', document_ids: documents.map(&:id) } }
+      let(:documents) { create_list(:document, 2, creator_id: creator.id) }
+
+      it { expect { submit }.to change(Message, :count).by(1) }
+
+      it do
+        submit
+        expect(Message.last.attachments.count).to eq(2)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

Prevent unauthorised access to data.

#### Ticket

[CCCD - Restrict linking of documents to claims (security vulnerability)](https://dsdmoj.atlassian.net/browse/CTSKF-1110)

#### Why

When creating a message it is possible, by editing the form, to attach a document from another claim.

#### How

Validate the creator of documents before attaching them to messages.