### PR TITLE
[CTSKF-899] Task to check validity of previous version of claims

### DIFF
--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -141,4 +141,23 @@ namespace :claims do
     RakeHelpers::ArchivedClaims.write args[:filename]
     puts 'Done'.green
   end
+
+  desc 'Check the validity of the previous versions of claims'
+  task check_previous_versions: :environment do |_task, args|
+    claims = Claim::BaseClaim.active
+
+    good = bad = 0
+    claims.each do |claim|
+      print "Claim ID: #{claim.id}      \r"
+      test_claim = claim
+      until test_claim.nil? do
+        test_claim = test_claim.paper_trail.previous_version
+      end
+      good += 1
+    rescue ActiveRecord::SerializationTypeMismatch
+      puts "Claim ID: #{claim.id} has a previous version that is invalid"
+      bad += 1
+    end
+    puts "Good: #{good}, Bad: #{bad}"
+  end
 end


### PR DESCRIPTION
#### What

Check which claims in the database have an invalid previous version.

#### Ticket

[CCCD - Investigate if PreviousVersionOfClaim class is still required](https://dsdmoj.atlassian.net/browse/CTSKF-899)

#### Why

At [some point in the past](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/2405) the `PreviousVersionOfClaim` service class was created to assist with a breaking change in the [`paper_trail` gem](https://rubygems.org/gems/paper_trail) where the serialisation of data stored by the gem was changed. `PreviousVersionofClaim.new(claim).call` returns the `paper_trail` previous version after checking and, if necessary, repairing the serialisation. 

#### How

Create a Rake task that will iterate over all the active claims in the database and check that the paper trails previous versions can be fetched without raising an exception until the version returned is `nil`.
