### PR TITLE
Fix logic to display LGFS redet refusal reasons

### DIFF
--- a/app/models/claim_state_transition_reason.rb
+++ b/app/models/claim_state_transition_reason.rb
@@ -34,7 +34,7 @@ class ClaimStateTransitionReason
     def refuse_reasons_for(claim)
       reasons = reasons_for("refused_#{claim.class.to_s.demodulize.tableize}")
       if claim.lgfs?
-        reason_key = if claim.redetermination? || claim.awaiting_written_reasons?
+        reason_key = if claim.opened_for_redetermination? || claim.written_reasons_outstanding?
                        :refused_litigator_redetermination_claims
                      else
                        :refused_litigator_new_claims

--- a/spec/models/claim_state_transition_reason_spec.rb
+++ b/spec/models/claim_state_transition_reason_spec.rb
@@ -137,6 +137,8 @@ RSpec.describe ClaimStateTransitionReason do
            other_refuse]
       end
 
+      before { claim.allocate! }
+
       context 'with a litigator final claim' do
         let(:claim) { create(:litigator_claim, :fixed_fee, :redetermination, fixed_fee: create(:fixed_fee, :lgfs)) }
 
@@ -157,6 +159,44 @@ RSpec.describe ClaimStateTransitionReason do
 
       context 'with a litigator hardship claim' do
         let(:claim) { create(:litigator_hardship_claim, :redetermination, hardship_fee: build(:hardship_fee)) }
+
+        it { is_expected.to match_array(common_lgfs_reasons) }
+      end
+    end
+
+    context 'when written reasons have been requested' do
+      let(:common_lgfs_reasons) do
+        %w[duplicate_claim lgfs_redet_second_fee lgfs_redet_unjustified_disbursement lgfs_redet_wrong_maat_ref
+           lgfs_redet_proceed_of_crime_act lgfs_redet_prescribed_proceedings lgfs_redet_rep_order_not_in_place
+           lgfs_redet_request_info lgfs_redet_relevance_electronic_material lgfs_redet_no_exlectronic_material
+           lgfs_redet_offence_class lgfs_redet_written_reasons lgfs_redet_ppe lgfs_redet_incorrect_case_type
+           other_refuse]
+      end
+
+      before { claim.allocate! }
+
+      context 'with a litigator final claim' do
+        let(:claim) do
+          create(:litigator_claim, :fixed_fee, :awaiting_written_reasons, fixed_fee: create(:fixed_fee, :lgfs))
+        end
+
+        it { is_expected.to match_array(common_lgfs_reasons) }
+      end
+
+      context 'with a litigator transfer claim' do
+        let(:claim) { create(:transfer_claim, :awaiting_written_reasons, transfer_fee: build(:transfer_fee)) }
+
+        it { is_expected.to match_array(common_lgfs_reasons) }
+      end
+
+      context 'with a litigator interim claim' do
+        let(:claim) { create(:interim_claim, :awaiting_written_reasons, interim_fee: build(:interim_fee)) }
+
+        it { is_expected.to match_array(common_lgfs_reasons + interim_reasons) }
+      end
+
+      context 'with a litigator hardship claim' do
+        let(:claim) { create(:litigator_hardship_claim, :awaiting_written_reasons, hardship_fee: build(:hardship_fee)) }
 
         it { is_expected.to match_array(common_lgfs_reasons) }
       end


### PR DESCRIPTION
#### What

The ClaimStateTransitionReason class contains logic used to display specific refuasal reasons for LGFS claims where a redetermination or written reasons have been requested.

Incorrect methods were used to identify such claims, meaning not all expected refusal reasons are displayed. `claim.redetermination?` and `claim.awaiting_written_reasons?` correctly identify a claim based on its state _before_ it has been allocated to a caseworker, however do not work _after_ it has been allocated to a caseworker, which is when the refusal reasons need to be available.

#### How

Replace `claim.redetermination?` and `claim.awaiting_written_reasons?` with `claim.opened_for_redetermination?` and `claim.written_reasons_outstanding?` to fix this, and update tests so that they accurately reflect the state of the claims being tested.