### PR TITLE
[CTSKF-899] Task to fix previous versions of claim

### DIFF
--- a/lib/previous_version_of_claim.rb
+++ b/lib/previous_version_of_claim.rb
@@ -21,14 +21,15 @@ class PreviousVersionOfClaim
   private
 
   def reset
-    version = PaperTrail::Version.where(item_type: 'Claim::BaseClaim', item_id: @claim.id).last
-    new_object = version.object_deserialized.transform_values do |value|
-      if value.present? && value.is_a?(Array)
-        PaperTrail.serializer.dump value
-      else
-        value
+    PaperTrail::Version.where(item_type: 'Claim::BaseClaim', item_id: @claim.id).find_each do |version|
+      new_object = version.object_deserialized.transform_values do |value|
+        if value.present? && value.is_a?(Array)
+          PaperTrail.serializer.dump value
+        else
+          value
+        end
       end
+      version.update_columns object: PaperTrail.serializer.dump(new_object)
     end
-    version.update_columns object: PaperTrail.serializer.dump(new_object)
   end
 end


### PR DESCRIPTION
#### What

Fix the previous versions of claims, as managed by the [`paper_trail` gem.](https://rubygems.org/gems/paper_trail)

#### Ticket

[CCCD - Investigate if PreviousVersionOfClaim class is still required](https://dsdmoj.atlassian.net/browse/CTSKF-899)

#### Why

We will shortly be removing the `PreviousVersionOfClaim` that mitigates a breaking change in `paper_trail` some time ago. There are still a few records in the database that cause issues due to this change.

#### How

Update the `check_previous_versions` task to output a file containing the list of claim ids that need updating and then create a new task, `fix_previous_versions`, to repair these claims.