### PR TITLE
Implement skipped jasmine tests 

### DIFF
--- a/app/webpack/javascripts/modules/case_worker/admin/Modules.ManagementInformation.js
+++ b/app/webpack/javascripts/modules/case_worker/admin/Modules.ManagementInformation.js
@@ -1,7 +1,6 @@
 moj.Modules.ManagementInformation = {
   el: '.fx-dates-chooser',
   download: '#provisional_assessments_date_download',
-  disableDownload: true,
 
   init: function () {
     if ($(this.el).length) {
@@ -55,19 +54,19 @@ moj.Modules.ManagementInformation = {
 
   disableDownloadButton: function () {
     if (!this.$download.hasClass('disabled')) {
-      this.$download
-        .addClass('disabled')
-        .attr('aria-disabled', true)
+      this.$download.addClass('disabled')
     }
-    this.$download
-      .removeAttr('href')
-      .attr('aria-disabled', false)
+    this.$download.removeAttr('href')
+    this.$download.attr('disabled', true)
+    this.$download.attr('aria-disabled', true)
   },
 
   enableDownloadButton: function () {
     const url = '/api/mi/provisional_assessments?' + this.buildAttributes()
     this.$download.attr('href', url)
     this.$download.removeClass('disabled')
+    this.$download.removeAttr('disabled')
+    this.$download.attr('aria-disabled', false)
   },
 
   activateDownload: function () {

--- a/app/webpack/javascripts/modules/case_worker/admin/Modules.ManagementInformation.js
+++ b/app/webpack/javascripts/modules/case_worker/admin/Modules.ManagementInformation.js
@@ -53,9 +53,6 @@ moj.Modules.ManagementInformation = {
   },
 
   disableDownloadButton: function () {
-    if (!this.$download.hasClass('disabled')) {
-      this.$download.addClass('disabled')
-    }
     this.$download.removeAttr('href')
     this.$download.attr('disabled', true)
     this.$download.attr('aria-disabled', true)
@@ -64,7 +61,6 @@ moj.Modules.ManagementInformation = {
   enableDownloadButton: function () {
     const url = '/api/mi/provisional_assessments?' + this.buildAttributes()
     this.$download.attr('href', url)
-    this.$download.removeClass('disabled')
     this.$download.removeAttr('disabled')
     this.$download.attr('aria-disabled', false)
   },
@@ -93,7 +89,7 @@ moj.Modules.ManagementInformation = {
   blockDisabledLinkClick: function () {
     const self = this
     this.$download.on('click', function (e) {
-      if (self.$download.hasClass('disabled')) {
+      if (self.$download.attr('disabled')) {
         e.preventDefault()
         return false
       }

--- a/spec/javascripts/Helpers.API.Establishments_spec.js
+++ b/spec/javascripts/Helpers.API.Establishments_spec.js
@@ -1,5 +1,21 @@
 describe('Helpers.API.Establishments.js', function () {
   const helper = moj.Helpers.API.Establishments
+  const fixtureData = [{
+    id: 1,
+    name: 'HMP One',
+    category: 'hospital',
+    postcode: 'L9 7LH'
+  }, {
+    id: 2,
+    name: 'HMP Two',
+    category: 'prison',
+    postcode: 'L9 7LH'
+  }, {
+    id: 3,
+    name: 'HMP Three',
+    category: 'crown_court',
+    postcode: 'L9 7LH'
+  }]
 
   it('should exist', function () {
     expect(moj.Helpers.API.Establishments).toBeDefined()
@@ -80,22 +96,6 @@ describe('Helpers.API.Establishments.js', function () {
     })
 
     it('should return all the data with no params passed', function (done) {
-      const fixtureData = [{
-        id: 1,
-        name: 'HMP One',
-        category: 'hospital',
-        postcode: 'L9 7LH'
-      }, {
-        id: 2,
-        name: 'HMP Two',
-        category: 'prison',
-        postcode: 'L9 7LH'
-      }, {
-        id: 3,
-        name: 'HMP Three',
-        category: 'crown_court',
-        postcode: 'L9 7LH'
-      }]
       spyOn(moj.Helpers.API._CORE, 'query').and.returnValue(Promise.resolve(fixtureData))
 
       helper.init().then(function () {
@@ -105,28 +105,10 @@ describe('Helpers.API.Establishments.js', function () {
     })
 
     it('should filter the results', function (done) {
-      const fixtureData = [{
-        id: 1,
-        name: 'HMP One',
-        category: 'hospital',
-        postcode: 'L9 7LH'
-      }, {
-        id: 2,
-        name: 'HMP Two',
-        category: 'prison',
-        postcode: 'L9 7LH'
-      }, {
-        id: 3,
-        name: 'HMP Three',
-        category: 'crown_court',
-        postcode: 'L9 7LH'
-      }]
-
       spyOn(moj.Helpers.API._CORE, 'query').and.returnValue(Promise.resolve(fixtureData))
 
       helper.init().then(function () {
         expect(helper.getLocationByCategory('prison')).toEqual([fixtureData[2]])
-
         expect(helper.getLocationByCategory('crown_court')).toEqual([fixtureData[1]])
         done()
       })
@@ -142,33 +124,25 @@ describe('Helpers.API.Establishments.js', function () {
     })
 
     it('should filter the results', function (done) {
-      const fixtureData = [{
-        id: 1,
-        name: 'HMP One',
-        category: 'hospital',
-        postcode: 'L9 7LH'
-      }, {
-        id: 2,
-        name: 'HMP Two',
-        category: 'prison',
-        postcode: 'L9 7LH'
-      }, {
-        id: 3,
-        name: 'HMP Three',
-        category: 'crown_court',
-        postcode: 'L9 7LH'
-      }]
       spyOn(moj.Helpers.API._CORE, 'query').and.returnValue(Promise.resolve(fixtureData))
 
       helper.init().then(function () {
-        helper.getAsOptions('prison').then(function (el) {
-          expect(el).toEqual(['<option value="">Please select</option>', '<option value="2" data-postcode="L9 7LH">HMP Two</option>'])
-        })
-        helper.getAsOptions('crown_court').then(function (el) {
-          expect(el).toEqual(['<option value="">Please select</option>', '<option value="3" data-postcode="L9 7LH">HMP Three</option>'])
-        })
+        return Promise.all([
+          helper.getAsOptions('prison'),
+          helper.getAsOptions('crown_court')
+        ])
+      }).then(function (results) {
+        const [prisonOptions, crownCourtOptions] = results
+        expect(prisonOptions).toEqual([
+          '<option value="">Please select</option>',
+          '<option value="2" data-postcode="L9 7LH">HMP Two</option>'
+        ])
+        expect(crownCourtOptions).toEqual([
+          '<option value="">Please select</option>',
+          '<option value="3" data-postcode="L9 7LH">HMP Three</option>'
+        ])
         done()
-      })
+      }).catch(done.fail)
     })
   })
 })

--- a/spec/javascripts/Modules.MangementInformation_spec.js
+++ b/spec/javascripts/Modules.MangementInformation_spec.js
@@ -231,9 +231,9 @@ describe('Modules.ManagementInformation.js', function () {
         controller.init()
         controller.disableDownloadButton()
 
-        expect(controller.$download.hasClass('disabled')).toBeTrue()
         expect(controller.$download.attr('aria-disabled')).toBe('true')
         expect(controller.$download.attr('href')).toBeUndefined()
+        expect(controller.$download.attr('disabled')).toBe('disabled')
       })
     })
 
@@ -260,8 +260,8 @@ describe('Modules.ManagementInformation.js', function () {
 
         expect(controller.buildAttributes).toHaveBeenCalled()
         expect(controller.$download.attr('href')).toEqual('/api/mi/provisional_assessments?api_key=abcABC&start_date=2017-2-1&end_date=2018-4-3&format=csv')
-        expect(controller.$download.hasClass('disabled')).toBeFalse()
         expect(controller.$download.attr('aria-disabled')).toBe('false')
+        expect(controller.$download.attr('disabled')).toBeUndefined()
       })
     })
 

--- a/spec/javascripts/modules-amountAssessed_spec.js
+++ b/spec/javascripts/modules-amountAssessed_spec.js
@@ -83,15 +83,11 @@ describe('Modules.AmountAssessedBlock.js', function () {
 
   describe('Methods..', function () {
     describe('...slider', function () {
-      it('should call correct $.fn', function () {
+      it('should call addClass with "hidden"', function () {
         const block = moj.Modules.AmountAssessed.blocks[0]
-        let x = false
-        $.fn.addClass = function () {
-          x = true
-        }
-        expect(x).toEqual(false)
+        const addClassSpy = spyOn($.fn, 'addClass')
         block.slider(false, $('<div />'))
-        expect(x).toEqual(true)
+        expect(addClassSpy).toHaveBeenCalledWith('hidden')
       })
     })
   })


### PR DESCRIPTION
#### What

Four jasmine tests in `Modules.MangementInformation_spec.js` have never been implemented and are marked as TODO.

Additionally, one test in `Helpers.API.Establishments_spec.js` completes with the warning `SPEC HAS NO EXPECTATIONS`. Although it does not fail it is not accurately testing the functionality and needs rewriting.

#### Why

To improve the test coverage of our javascript code (and for me to practice writing more javascript).

#### How

* adds tests for the `blockDisabledLinkClick`, `dateInputEvent`,`disableDownloadButton` and `activateDownload` functions in `Modules.MangementInformation_spec.js`
* this highlights an issue with the `disableDownloadButton` function in the `ManagementInformation` module, which, when the disable button is clicked, adds sets `aria-disabled` to be `true` and then immediately sets it to be `false` again. This removes the instruction to set it to `false`, and tidies up the code to try and introduce some consistency between the `disableDownloadButton` and `enableDownloadButton` functions
* fixes a problem in `modules-amountAssessed_spec.js` where a test overrides the jQuery method `$.fn.addClass` without resetting it, which then pollutes the use of that method in other tests, leading to intermittent failures. This commit replaces that overriding with a spy
* rewrites the `Helpers.API.Establishments.js ...getAsOptions` spec to use `Promise.all` to ensure that all asynchronous calls have completed before the expectations are asserted
