### PR TITLE
Revert file utils change

### DIFF
--- a/bin/setup
+++ b/bin/setup
@@ -13,7 +13,7 @@ def copy_sample_file(src, dst)
     puts "\n #{dst} already exists! Skipping..."
   else
     puts "\n Copying #{src} to #{dst}"
-    cp(src, dst)
+    FileUtils.cp(src, dst)
   end
 end
 


### PR DESCRIPTION
#### What

Put 'include FileUtils` back into the setup code.

#### Why
It was removed accidentally during a Rails version upgrade to make future upgrades easier.  It is being returned because when running 'bin/setup' it resulted in an error as it was no longer available in the `copy_sample_file` method. 