### PR TITLE
[CTSKF-592] Fix expense duplication

### DIFF
--- a/app/webpack/javascripts/modules/external_users/claims/DuplicateExpenseCtrl.js
+++ b/app/webpack/javascripts/modules/external_users/claims/DuplicateExpenseCtrl.js
@@ -69,12 +69,14 @@ moj.Modules.DuplicateExpenseCtrl = {
 
     this.setInputValue($el, '.fx-travel-location input', data.location)
 
-    // select the option by the data.location value
-    $el.find('.fx-establishment-select select option').filter(function (idx, el) { // eslint-disable-line
-      if ($(el).text() === data.location) {
-        $(el).prop('selected', true)
-      }
-    })
+    setTimeout(() => {
+      // select the option by the data.location value
+      $el.find('.fx-establishment-select select option').filter(function (idx, el) { // eslint-disable-line
+        if ($(el).text() === data.location) {
+          $(el).prop('selected', true)
+        }
+      })
+    }, 50)
 
     this.setRadioValue($el, '.fx-travel-mileage input', data.mileage_rate_id)
 
@@ -87,7 +89,7 @@ moj.Modules.DuplicateExpenseCtrl = {
 
   setRadioValue: function ($el, selector, val) {
     if (val) {
-      $el.find(selector + '[id$=mileage_rate_id_' + val + ']').prop('checked', true).trigger('click')
+      $el.find(selector + '[value=' + val + ']').prop('checked', true).trigger('click')
     }
   },
 

--- a/spec/javascripts/modules-DuplicateExpenseCtrl_spec.js
+++ b/spec/javascripts/modules-DuplicateExpenseCtrl_spec.js
@@ -147,5 +147,75 @@ describe('Modules.DuplicateExpenseCtrl', function () {
         domFixture.empty()
       })
     })
+
+    describe('...setSelectValue', function () {
+      it('...should select the correct option based on value', function () {
+        const travelReasonHtml = ['<div class="fx-travel-reason">',
+          '                    <select>',
+          '                    <option value="1">Court hearing (Crown court)</option>',
+          '                    <option value="2">Court hearing (Magistrates court)</option>',
+          '                    </select>',
+          '                  </div>'].join('')
+        $('body').append(travelReasonHtml)
+
+        moj.Modules.DuplicateExpenseCtrl.setSelectValue($('.fx-travel-reason'), 'select', '2')
+
+        expect($('.fx-travel-reason select').val()).toBe('2')
+
+        $('.fx-travel-reason').remove()
+      })
+
+      it('...should select the correct option based on data-location-type', function () {
+        const travelReasonHtml = ['<div class="fx-travel-reason">',
+          '                    <select>',
+          '                      <option value="1" data-location-type="crown_court">Court hearing (Crown court)</option>',
+          '                      <option value="2" data-location-type="magistrates_court">Court hearing (Magistrates court)</option>',
+          '                    </select>',
+          '                  </div>'].join('')
+        $('body').append(travelReasonHtml)
+
+        moj.Modules.DuplicateExpenseCtrl.setSelectValue($('.fx-travel-reason'), 'select', '', 'magistrates_court')
+
+        expect($('.fx-travel-reason select').val()).toBe('2')
+
+        $('.fx-travel-reason').remove()
+      })
+    })
+
+    describe('...populateNewItem', function () {
+      it('...should select the correct establishment option based on data.location', function (done) {
+        const locationHtml = ['<select class="fx-establishment-select">',
+          '                      <option value="1">Aylesbury</option>',
+          '                      <option value="2">Basildon</option>',
+          '                    </select>'].join('')
+        $('body').append(locationHtml)
+
+        const data = { location: 'Aylesbury' }
+
+        moj.Modules.DuplicateExpenseCtrl.populateNewItem(data)
+
+        setTimeout(() => {
+          expect($('.fx-establishment-select').val()).toBe('1')
+          $('.fx-establishment-select').remove()
+          done()
+        }, 50)
+      })
+    })
+
+    describe('...setRadioValue', function () {
+      it('...should select the correct radio button based on value', function () {
+        const mileageHtml = ['<div class="fx-travel-mileage">',
+          '                     <input type="radio" value="1" name="mileage_rate">',
+          '                     <input type="radio" value="2" name="mileage_rate">',
+          '                   </div>'].join('')
+        $('body').append(mileageHtml)
+
+        moj.Modules.DuplicateExpenseCtrl.setRadioValue($('.fx-travel-mileage'), 'input', '1')
+
+        expect($('input[value="1"]').prop('checked')).toBe(true)
+
+        $('.fx-travel-mileage').remove()
+      })
+    })
   })
 })


### PR DESCRIPTION
#### What

When duplicating an expense claim, the location and mileage rate are not selected on the new claim. This fix ensures that the location and mileage are correctly duplicated. 

NB: the date of the expense is not duplicated. It appears this is the intended functionality rather than a bug, possibly because it is likely that expense claims will usually be incurred on different dates, so no changes have been made to alter this behaviour.

#### Ticket

[CCCD: Court/Prison not copied when duplicating expense](https://dsdmoj.atlassian.net/browse/CTSKF-592)

#### Why

To improve the user experience, and save time.

#### How

* sets a slight delay (50ms) on the selection of the location to allow the drop down enough time to populate
* selects the mileage radio button by `value` instead of by `id`, which was consistently failing
* adds tests for the affected functions.