### PR TITLE
[CTSKF-1108] Display full defendant name on caseworker claim summary screen

### DIFF
--- a/app/views/shared/_new_claim_defendant_details.html.haml
+++ b/app/views/shared/_new_claim_defendant_details.html.haml
@@ -6,12 +6,8 @@
   .govuk-summary-card__content
     = govuk_summary_list do
       = govuk_summary_list_row do
-        = govuk_summary_list_key { t('.first_name') }
-        = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { defendant.first_name }
-
-      = govuk_summary_list_row do
-        = govuk_summary_list_key { t('.last_name') }
-        = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { defendant.last_name }
+        = govuk_summary_list_key { t('.full_name') }
+        = govuk_summary_list_value(class: 'govuk-!-width-one-quarter') { defendant.name }
 
       = govuk_summary_list_row do
         = govuk_summary_list_key { t('.date_of_birth') }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2161,8 +2161,7 @@ en:
       case_type: *case_type
     new_claim_defendant_details:
       title_defendant: Defendant
-      first_name: First name
-      last_name: Last name
+      full_name: Full name
       date_of_birth: Date of birth
       order_of_judicial_apportionment: Order of judicial apportionment
       reporders: Represention order


### PR DESCRIPTION
#### What

The recent redesign of the caseworker view of the claim summary screen has changed the way that defendant names are displayed. Previously the full name was displayed on a single line, now it is split over two lines. This causes additional work for caseworkers when they need to copy and paste the defendant’s name. We received the following feedback:

> Changing the defendant's name to 2 lines from one line has made it slightly inconvenient when copy/pasting defendant details for record purposes. 

This change replaces the two lines for First name and Last name with a single Full name, returning to previous functionality.

#### Ticket

[CTSKF-1108](https://dsdmoj.atlassian.net/browse/CTSKF-1108)


#### How

Update view and translations.


#### Screenshots

Before:

<img width="975" alt="image" src="https://github.com/user-attachments/assets/b55183e1-81ed-44c5-92c9-fff27833fffa" />

After:

<img width="975" alt="image" src="https://github.com/user-attachments/assets/5783e176-5dbd-485a-8023-50a8f76b3672" />


[CTSKF-1108]: https://dsdmoj.atlassian.net/browse/CTSKF-1108?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ