### PR TITLE
Create a summary-card helper method

### DIFF
--- a/app/views/shared/_new_additional_information.html.haml
+++ b/app/views/shared/_new_additional_information.html.haml
@@ -1,7 +1,1 @@
-.govuk-summary-card
-  .govuk-summary-card__title-wrapper
-    %h2.govuk-summary-card__title
-      = t('shared.new_claim_accordion.additional_information')
-
-  .govuk-summary-card__content
-    = format_multiline(claim.additional_information)
+= govuk_summary_card(t('shared.new_claim_accordion.additional_information'), claim.additional_information )

--- a/app/views/shared/summary/_new_expenses.html.haml
+++ b/app/views/shared/summary/_new_expenses.html.haml
@@ -12,10 +12,4 @@
     = render template: 'shared/summary/expenses/new_index', locals: { claim: claim, vat: false }
 
   - if claim.travel_expense_additional_information.present?
-    .govuk-summary-card
-      .govuk-summary-card__title-wrapper
-        %h2.govuk-summary-card__title
-          = t('shared.summary.expenses.travel_expense_additional_information')
-
-      .govuk-summary-card__content
-        = claim.travel_expense_additional_information
+    = govuk_summary_card(t('shared.summary.expenses.travel_expense_additional_information'), claim.travel_expense_additional_information )

--- a/lib/govuk_component/railtie.rb
+++ b/lib/govuk_component/railtie.rb
@@ -75,5 +75,11 @@ module GovukComponent
         ActiveSupport.on_load(:action_view) { include GovukComponent::WarningTextHelpers }
       end
     end
+
+    initializer 'govuk_component.summary_card_helpers' do
+      config.after_initialize do
+        ActiveSupport.on_load(:action_view) { include GovukComponent::SummaryCardHelpers }
+      end
+    end
   end
 end

--- a/lib/govuk_component/summary_card_helpers.rb
+++ b/lib/govuk_component/summary_card_helpers.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+# Component Reference: https://design-system.service.gov.uk/components/summary-list/
+
+module GovukComponent
+  module SummaryCardHelpers
+    def govuk_summary_card(title = '', content = '')
+      tag.div(class: 'govuk-summary-card') do
+        concat(tag.div(class: 'govuk-summary-card__title-wrapper') do
+          content_tag(:h2, title, class: 'govuk-summary-card__title')
+        end)
+        concat(content_tag(:div, format_multiline(content), class: 'govuk-summary-card__content'))
+      end
+    end
+  end
+end

--- a/spec/lib/govuk_component/summary_card_helpers_spec.rb
+++ b/spec/lib/govuk_component/summary_card_helpers_spec.rb
@@ -11,11 +11,19 @@ RSpec.describe GovukComponent::SummaryCardHelpers, type: :helper do
 
     it 'adds div tags with govuk class abd displays a title and content' do
       is_expected.to have_tag(:div, with: { class: 'govuk-summary-card' }) do
-        with_tag(:div, with: { class: 'govuk-summary-card__title-wrapper' }) do
-          with_tag(:h2, with: { class: 'govuk-summary-card__title' }, text: title)
-        end
-        with_tag(:div, with: { class: 'govuk-summary-card__content' }, text: content)
+        check_title
+        check_content
       end
+    end
+
+    def check_title
+      with_tag(:div, with: { class: 'govuk-summary-card__title-wrapper' }) do
+        with_tag(:h2, with: { class: 'govuk-summary-card__title' }, text: title)
+      end
+    end
+
+    def check_content
+      with_tag(:div, with: { class: 'govuk-summary-card__content' }, text: content)
     end
   end
 end

--- a/spec/lib/govuk_component/summary_card_helpers_spec.rb
+++ b/spec/lib/govuk_component/summary_card_helpers_spec.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+RSpec.describe GovukComponent::SummaryCardHelpers, type: :helper do
+  include RSpecHtmlMatchers
+
+  describe '#govuk_summary_card' do
+    subject(:markup) { helper.govuk_summary_card(title, content) }
+
+    let(:title) { 'Additional information' }
+    let(:content) { 'Lorem ipsum dolor sit amet' }
+
+    it 'adds div tags with govuk class abd displays a title and content' do
+      is_expected.to have_tag(:div, with: { class: 'govuk-summary-card' }) do
+        with_tag(:div, with: { class: 'govuk-summary-card__title-wrapper' }) do
+          with_tag(:h2, with: { class: 'govuk-summary-card__title' }, text: title)
+        end
+        with_tag(:div, with: { class: 'govuk-summary-card__content' }, text: content)
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What
This PR create a new summary card helper method. 

- initialise new helper method in Railtie so that it is available to use
- Create a helper method that takes a title and content using ActionView::Helpers::TagHelper
- Updates code to use the new helper method

#### Ticket
[CCCD - Summary Page summary cards - refactor additional info into a partial.](https://dsdmoj.atlassian.net/browse/CTSKF-1088)

#### Why
Reduce duplication
