### PR TITLE
CTSKF-1109 Reinstate option to view documents

### DIFF
--- a/app/views/shared/_new_evidence_list.html.haml
+++ b/app/views/shared/_new_evidence_list.html.haml
@@ -16,13 +16,20 @@
             = govuk_table_th { t('.name_of_file') }
             = govuk_table_th_numeric { t('.file_size') }
             = govuk_table_th_numeric { t('.date_added') }
+            = govuk_table_th { t('.actions') }
 
         = govuk_table_tbody do
           - @claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
             = govuk_table_row do
-              = govuk_table_td { govuk_link_to document.document_file_name, download_document_path(document) }
+              = govuk_table_td do
+                = document.document_file_name
               = govuk_table_td_numeric { number_to_human_size(document.document_file_size) }
               = govuk_table_td_numeric { document.created_at.strftime(Settings.date_format) }
+              = govuk_table_td do
+                .app-link-group
+                  - if document.converted_preview_document.present?
+                    = govuk_link_to t('common.view_html', context: "#{document.document_file_name}"), document_path(document), target: :_blank
+                  = govuk_link_to t('common.download_html', context: "#{document.document_file_name}"), download_document_path(document)
 
 - if claim.additional_information.present?
   = render partial: 'shared/new_additional_information', locals: { claim: claim }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2187,6 +2187,7 @@ en:
       name_of_file: File
       file_size: File size
       date_added: Date added
+      actions: Actions
     new_basic_and_additional_fees_details:
       caption: Basic and additional fees
       fee_category: Fee category


### PR DESCRIPTION
#### What

Enable caseworkers to view uploaded evidence documents in the browser, rather than having to download them first

#### Ticket

[CTSKF-1109](https://dsdmoj.atlassian.net/browse/CTSKF-1109)

#### Why

The recent redesign of the caseworker view of the claim summary screen has changed the way that caseworkers interact with uploaded evidence documents. Previously the caseworker was able to choose between downloading the document or viewing it in the browser, now they are only able to download it. This increases the time it takes for caseworkers to review documents.

#### How

Updates the `Claim-for-Crown-Court-Defence/app/views/shared/_new_evidence_list.html.haml` partial to 
* remove the download link from the filename
* restore the 'Actions' column with 'View' and 'Download' options 
* add `target: :_blank` to the 'View' link to force documents to be opened in a new tab, to prevent caseworkers accidentally navigating away from CCCD

#### Screenshots

Original design:

![image](https://github.com/user-attachments/assets/3c472a86-44c3-4e45-add1-c94e219051d4)

Redesigned version: 

![image](https://github.com/user-attachments/assets/e7d32c27-ac9a-455c-98ff-10fd4e3996b1)

New version:

<img width="923" alt="image" src="https://github.com/user-attachments/assets/be0add47-41c7-4e1b-8c1b-35f697651354" />


[CTSKF-1109]: https://dsdmoj.atlassian.net/browse/CTSKF-1109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ