### PR TITLE
CTSKF-1073 - CCCD - Update heading within 'report a fault' in CCCD

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -3014,7 +3014,7 @@ en:
   feedback:
     bug_report:
       page_title: Bug report
-      page_heading: Help us improve this service
+      page_heading: Report a fault
       error_summary: 'The form you submitted has '
       intro: |
         Tell us about your experience of using this service today. Your answers to the following questions will help us improve the service.


### PR DESCRIPTION
#### Ticket
[CCCD - Update heading within 'report a fault' in CCCD](https://dsdmoj.atlassian.net/browse/CTSKF-1073)

#### Why
Currently, the heading within the ‘report a fault’ link in CCCD says, 'Help us improve this service’. This current heading is more aligned to providing feedback rather than reporting a fault. Therefore, we need to update this heading to better reflect what we are asking the user for.

#### How
Update the heading to ‘Report a fault’.

This change will ensure users report faults accurately rather than using the link to provide feedback, thereby improving efficiency within Zendesk.

