### PR TITLE
Restore Offence header on claim summary screen

### DIFF
--- a/app/views/shared/offence_details/_new_summary.html.haml
+++ b/app/views/shared/offence_details/_new_summary.html.haml
@@ -1,3 +1,6 @@
+%h2.govuk-heading-l{ class:'govuk-!-static-margin-bottom-6'}
+  = t('.header')
+
 .govuk-summary-card
   .govuk-summary-card__title-wrapper
     %h2.govuk-summary-card__title


### PR DESCRIPTION
#### What

During the redesign of the caseworker claim summary screen, the header of the Offence section seems to have been lost, so the offence details appear under the Defendants header.

This reinstates the header.

#### Why

To improve clarity and understanding, in line with designs: https://www.figma.com/design/ji0NwMxvla3H2x8XhXT4ZN/CLAIR-Taskforce-s.28-file?node-id=1935-4711

#### How

Adds the relevant code to `app/views/shared/offence_details/_new_summary.html.haml`

#### Screenshots

Before:

<img width="923" alt="image" src="https://github.com/user-attachments/assets/341e9fec-9d85-4e32-8615-d812f7ab71b3" />

After:

<img width="924" alt="image" src="https://github.com/user-attachments/assets/91d710b0-415b-4c1d-a813-1b7f782efc35" />

