### PR TITLE
[CTSKF-769] Update brakeman ignore files

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -68,27 +68,8 @@
         22
       ],
       "note": "Caseworkers need to identify the downloads correspond to the cases they are processing"
-    },
-    {
-      "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
-      "check_name": "EOLRails",
-      "message": "Support for Rails 7.0.8.7 ends on 2025-04-01",
-      "file": "Gemfile.lock",
-      "line": 460,
-      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
-      "code": null,
-      "render_path": null,
-      "location": null,
-      "user_input": null,
-      "confidence": "Medium",
-      "cwe_id": [
-        1104
-      ],
-      "note": ""
     }
   ],
-  "updated": "2025-03-03 09:44:57 +0000",
+  "updated": "2025-03-25 09:17:08 +0000",
   "brakeman_version": "6.2.2"
 }


### PR DESCRIPTION
#### What

Update the brakeman ignore file.

#### Ticket

[CCCD: Upgrade Rails to 7.1](https://dsdmoj.atlassian.net/browse/CTSKF-769)

#### Why

#8290 upgraded the version of Rails 7.1 so it is no longer necessary to ignore the 'Unmaintained Dependency' warning.

#### How

```bash
bundle exec brakeman -I
```