### PR TITLE
[CTSKF-1084] Use summary cards to display default text for empty states

### DIFF
--- a/app/views/shared/_new_claim.html.haml
+++ b/app/views/shared/_new_claim.html.haml
@@ -31,13 +31,7 @@
       - if claim.main_hearing_date
         = render partial: 'shared/new_main_hearing_date_details', locals: { claim: claim }
 
-- if claim.defendants.any?
-  = render partial: 'shared/new_claim_defendants', locals: { defendants: claim.defendants }
--else
-  .govuk-grid-row
-    .govuk-grid-column-two-thirds
-      %p.govuk-body
-        = t('.no_defendant')
+= render partial: 'shared/new_claim_defendants', locals: { claim: claim }
 
 - unless claim.fixed_fee_case?
   = render partial: 'shared/offence_details/new_summary', locals: { claim: claim }

--- a/app/views/shared/_new_claim_defendants.html.haml
+++ b/app/views/shared/_new_claim_defendants.html.haml
@@ -1,5 +1,8 @@
 %h2.govuk-heading-l{ class:'govuk-!-static-margin-bottom-6'}
   = t('.h2_defendant_details')
 
-- defendants.each_with_index do | defendant, index |
-  = render partial: 'shared/new_claim_defendant_details', locals: { defendant: present(defendant, CaseWorkers::DefendantPresenter), index: index += 1 }
+- if claim.defendants.any?
+  - claim.defendants.each_with_index do | defendant, index |
+    = render partial: 'shared/new_claim_defendant_details', locals: { defendant: present(defendant, CaseWorkers::DefendantPresenter), index: index += 1 }
+- else
+  = govuk_summary_card(t('.h2_defendant_details'), t('.no_defendant'))

--- a/app/views/shared/_new_evidence_list.html.haml
+++ b/app/views/shared/_new_evidence_list.html.haml
@@ -1,8 +1,7 @@
 = render partial: 'shared/new_evidence_checklist'
 
 - if current_user_persona_is?(CaseWorker) && @claim.documents.none?
-  %p.govuk-body
-    = t('.no_documents_uploaded')
+  = govuk_summary_card(t('.existing_evidence'), t('.no_documents_uploaded'))
 
 - else
   .govuk-summary-card

--- a/app/views/shared/_new_summary_agfs.html.haml
+++ b/app/views/shared/_new_summary_agfs.html.haml
@@ -1,8 +1,7 @@
 -# AGFS fees accordion content
 - present(@claim) do |claim|
   - if @claim.fees_total == 0
-    %p.govuk-body
-      = t('shared.summary.no_values.fees')
+    = govuk_summary_card(t('common.fees'), t('shared.summary.no_values.fees'))
 
   - else
     = render partial: 'shared/new_agfs_fee_details', locals: { claim: claim }

--- a/app/views/shared/_new_summary_lgfs.html.haml
+++ b/app/views/shared/_new_summary_lgfs.html.haml
@@ -13,8 +13,7 @@
       = t('common.disbursements')
 
     - if claim.disbursements.empty?
-      %p.govuk-body
-        = t('shared.summary.no_values.disbursements')
+      = govuk_summary_card(t('common.disbursements'), t('shared.summary.no_values.disbursements'))
 
     - else
       - if claim.disbursements.with_vat.any?

--- a/app/views/shared/_new_summary_lgfs.html.haml
+++ b/app/views/shared/_new_summary_lgfs.html.haml
@@ -1,7 +1,6 @@
 - present(@claim) do |claim|
   - if @claim.fees_total == 0
-    %p.govuk-body
-      = t('shared.summary.no_values.fees')
+    = govuk_summary_card(t('common.fees'), t('shared.summary.no_values.fees'))
 
   - else
     = render partial: 'shared/new_lgfs_fee_details', locals: { claim: claim }

--- a/app/views/shared/offence_details/_new_summary.html.haml
+++ b/app/views/shared/offence_details/_new_summary.html.haml
@@ -3,9 +3,12 @@
     %h2.govuk-summary-card__title
       = t('.header')
 
-  .govuk-summary-card__content
-    - if claim.agfs_reform?
-      = render partial: 'shared/offence_details/new_fee_reform_summary', locals: { claim: claim }
-
-    - else
-      = render partial: 'shared/offence_details/new_default_summary', locals: { claim: claim }
+  - if claim.offence
+    .govuk-summary-card__content
+      - if claim.agfs_reform?
+        = render partial: 'shared/offence_details/new_fee_reform_summary', locals: { claim: claim }
+      - else
+        = render partial: 'shared/offence_details/new_default_summary', locals: { claim: claim }
+  - else
+    .govuk-summary-card__content
+      = t('shared.summary.no_values.offence_details')

--- a/app/views/shared/summary/_new_expenses.html.haml
+++ b/app/views/shared/summary/_new_expenses.html.haml
@@ -1,6 +1,6 @@
 - if claim.expenses.empty?
   %p.govuk-body
-    = t('shared.summary.no_values.expenses')
+    = govuk_summary_card(t('shared.summary.expenses.travel_expenses'), t('shared.summary.no_values.expenses'))
 - else
   - if current_user_is_caseworker? && claim.expenses.map(&:distance_gt_calculated?).any?
     = render partial: 'shared/summary/expenses/distance_warnings', locals: { expenses: claim.expenses }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2141,7 +2141,6 @@ en:
       j_a: Judicial apportionment
       offence: Offence
       offence_class: Offence class
-      no_defendant: *no_defendant
     new_claim_accordion:
       additional_information: Additional information
       created_by: 'Created by:'
@@ -2169,6 +2168,7 @@ en:
       no_reporder: No representation orders have been supplied for this defendant.
     new_claim_defendants:
       h2_defendant_details: Defendant details
+      no_defendant: *no_defendant
     new_claim_retrial_details:
       retrial_started_at: 'First day of retrial'
       retrial_estimated_length: 'Estimated retrial length'


### PR DESCRIPTION
#### What

Update formatting of the text that is displayed on the caseworker claim summary page when a section is empty, so that it is contained in a summary card. 

The ticket suggests doing this for the following sections of the page:

* Basic claim details
* Defendant details
* Offence details
* Evidence
* Fees 
* Travel expenses
* Disbursements 

This has been done for all sections apart from Basic claim details. It is not possible for a claim to be saved without those details, and so it should never be possible for a user (either a caseworker or a provider) to view the claim summary page for a claim without those details. No change has been made for that section of the page.

#### Ticket

[CTSKF-1084](https://dsdmoj.atlassian.net/browse/CTSKF-1084)

#### Why

For consistency with the rest of the page and to improve readability for users.

#### How

Updates the following partials to display default text using the `govuk_summary_card` helper method.

`app/views/shared/_new_claim_defendants.html.haml`
`app/views/shared/_new_evidence_list.html.haml`
`app/views/shared/_new_summary_agfs.html.haml`
`app/views/shared/_new_summary_lgfs.html.haml`
`app/views/shared/offence_details/_new_summary.html.haml`
`app/views/shared/summary/_new_expenses.html.haml`


[CTSKF-1084]: https://dsdmoj.atlassian.net/browse/CTSKF-1084?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ