### PR TITLE
[CTSKF-1129] Set add_autoload_paths_to_load_path

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -18,6 +18,16 @@ module AdvocateDefencePayments
   class Application < Rails::Application
     config.load_defaults 7.0
 
+    ### New default configuration for Rails 7.1. To be removed when load_defaults is updated.
+    # No longer add autoloaded paths into `$LOAD_PATH`. This means that you won't be able
+    # to manually require files that are managed by the autoloader, which you shouldn't do anyway.
+    #
+    # This will reduce the size of the load path, making `require` faster if you don't use bootsnap, or reduce the size
+    # of the bootsnap cache if you use it.
+    #
+    # To set this configuration, add the following line to `config/application.rb` (NOT this file):
+    config.add_autoload_paths_to_load_path = false
+
     config.middleware.use Rack::Deflater
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -9,7 +9,7 @@
 # Read the Guide for Upgrading Ruby on Rails for more info on each option.
 # https://guides.rubyonrails.org/upgrading_ruby_on_rails.html
 
-###
+### Updated in config/application.rb
 # No longer add autoloaded paths into `$LOAD_PATH`. This means that you won't be able
 # to manually require files that are managed by the autoloader, which you shouldn't do anyway.
 #

--- a/spec/helpers/claims_helper_spec.rb
+++ b/spec/helpers/claims_helper_spec.rb
@@ -81,7 +81,6 @@ RSpec.describe ClaimsHelper do
   describe '#show_message_controls?' do
     subject(:subj_show_message_controls?) { show_message_controls?(claim) }
 
-    require 'application_helper'
     let(:claim) { build(:claim, state:) }
 
     RSpec.configure do |c|


### PR DESCRIPTION
#### What

Set the `add_autoload_paths_to_load_path` setting to the Rails 7.1 default.

#### Ticket

[board ticket description](https://dsdmoj.atlassian.net/browse/CTSKF-1129)

#### Why

Post Rails 7.1 migration setup.

#### How

Add

```
config.add_autoload_paths_to_load_path = false
```

to config/application.rb
