### PR TITLE
Future proof tests by dynamically calculated dates so only dates with…

### DIFF
--- a/features/claims/litigator/scheme_nine/transfer_claim_draft_submit.feature
+++ b/features/claims/litigator/scheme_nine/transfer_claim_draft_submit.feature
@@ -15,7 +15,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     Then I choose the litigator type option 'New'
     And I choose the elected case option 'No'
     And I select the transfer stage 'Before trial transfer'
-    And I enter the transfer date '2015-05-21'
+    And I enter the transfer date 3 years ago
     And I select a case conclusion of 'Cracked'
 
     And I click "Continue" in the claim form
@@ -125,7 +125,7 @@ Feature: Litigator partially fills out a draft transfer claim, then later edits 
     Then I choose the litigator type option 'New'
     And I choose the elected case option 'Yes'
     And I select the transfer stage 'Before trial transfer'
-    And I enter the transfer date '2015-05-21'
+    And I enter the transfer date 3 years ago
 
     When I click "Continue" in the claim form
     Then I should see a page title "Enter case details for litigator transfer fees claim"

--- a/features/step_definitions/litigator_transfer_claim_steps.rb
+++ b/features/step_definitions/litigator_transfer_claim_steps.rb
@@ -23,6 +23,11 @@ And(/^I enter the transfer date '(.*)'$/) do |date_string|
   @litigator_transfer_claim_form_page.transfer_detail.transfer_date.set_date date_string
 end
 
+And('I enter the transfer date {int} years ago') do |years|
+  date = years.years.ago.strftime('%d-%m-%Y')
+  @litigator_transfer_claim_form_page.transfer_detail.transfer_date.set_date date
+end
+
 And(/^I select a case conclusion of '(.*)'$/) do |name|
   @litigator_transfer_claim_form_page.wait_until_case_conclusion_visible
   @litigator_transfer_claim_form_page.case_conclusion.choose_autocomplete_option(name)

--- a/spec/controllers/external_users/advocates/claims_controller_spec.rb
+++ b/spec/controllers/external_users/advocates/claims_controller_spec.rb
@@ -2,6 +2,8 @@ require 'rails_helper'
 
 RSpec.describe ExternalUsers::Advocates::ClaimsController do
   let!(:advocate) { create(:external_user, :advocate) }
+  let(:date) { Time.zone.today - 1.year }
+  let(:trial_concluded_date) { date + 2.days }
 
   before { sign_in advocate.user }
 
@@ -488,12 +490,11 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController do
         put :update, params: {
           id: subject,
           claim: {
-            'first_day_of_trial(1i)' => '2015',
+            'first_day_of_trial(1i)' => date.year,
             'first_day_of_trial(2i)' => 'JAN',
             'first_day_of_trial(3i)' => '4'
           },
           commit_submit_claim: 'Submit to LAA'
-
         }
 
         expect(assigns(:claim).first_day_of_trial).to be_nil
@@ -503,13 +504,13 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController do
         put :update, params: {
           id: subject,
           claim: {
-            'first_day_of_trial(1i)' => '2015',
+            'first_day_of_trial(1i)' => date.year,
             'first_day_of_trial(2i)' => '11',
             'first_day_of_trial(3i)' => '4'
           },
           commit_submit_claim: 'Submit to LAA'
         }
-        expect(assigns(:claim).first_day_of_trial).to eq Date.new(2015, 11, 4)
+        expect(assigns(:claim).first_day_of_trial).to eq Date.new(date.year, 11, 4)
       end
     end
   end
@@ -525,14 +526,14 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController do
       'advocate_category' => 'QC',
       'offence_class_id' => '2',
       'offence_id' => offence.id.to_s,
-      'first_day_of_trial(3i)' => '13',
-      'first_day_of_trial(2i)' => '5',
-      'first_day_of_trial(1i)' => '2015',
+      'first_day_of_trial(3i)' => date.day,
+      'first_day_of_trial(2i)' => date.month,
+      'first_day_of_trial(1i)' => date.year,
       'estimated_trial_length' => '2',
       'actual_trial_length' => '2',
-      'trial_concluded_at(3i)' => '15',
-      'trial_concluded_at(2i)' => '05',
-      'trial_concluded_at(1i)' => '2015',
+      'trial_concluded_at(3i)' => trial_concluded_date,
+      'trial_concluded_at(2i)' => date.month,
+      'trial_concluded_at(1i)' => date.year,
       'evidence_checklist_ids' => ['1', '5', ''],
       'defendants_attributes' => {
         '0' => {
@@ -544,9 +545,9 @@ RSpec.describe ExternalUsers::Advocates::ClaimsController do
           '_destroy' => 'false',
           'representation_orders_attributes' => {
             '0' => {
-              'representation_order_date_dd' => '13',
-              'representation_order_date_mm' => '05',
-              'representation_order_date_yyyy' => '2015',
+              'representation_order_date_dd' => date.day,
+              'representation_order_date_mm' => date.month,
+              'representation_order_date_yyyy' => date.year,
               'maat_reference' => '1594851269'
             }
           }

--- a/spec/models/date_attended_spec.rb
+++ b/spec/models/date_attended_spec.rb
@@ -15,22 +15,24 @@
 require 'rails_helper'
 
 RSpec.describe DateAttended do
+  let(:date) { Time.zone.today - 1.year }
+
   it { should belong_to(:attended_item) }
 
   describe '#to_s' do
     context 'when date_to present' do
-      subject { create(:date_attended, date: Date.parse('1/1/2015'), date_to: Date.parse('5/1/2015')) }
+      subject { create(:date_attended, date: Date.parse("1/1/#{date.year}"), date_to: Date.parse("5/1/#{date.year}")) }
 
       it 'formats the date and date_to' do
-        expect(subject.to_s).to eq('01/01/2015 - 05/01/2015')
+        expect(subject.to_s).to eq("01/01/#{date.year} - 05/01/#{date.year}")
       end
     end
 
     context 'when only date present' do
-      subject { create(:date_attended, date: Date.parse('1/1/2015'), date_to: nil) }
+      subject { create(:date_attended, date: Date.parse("1/1/#{date.year}"), date_to: nil) }
 
       it 'formats the date' do
-        expect(subject.to_s).to eq('01/01/2015')
+        expect(subject.to_s).to eq("01/01/#{date.year}")
       end
     end
   end

--- a/spec/models/representation_order_spec.rb
+++ b/spec/models/representation_order_spec.rb
@@ -132,13 +132,14 @@ RSpec.describe RepresentationOrder do
   end
 
   describe '#detail' do
+    let(:date) { (Time.zone.today - 30.days).strftime('%d/%m/%Y') }
     let(:rep_order) do
-      create(:representation_order, maat_reference: '1234567', representation_order_date: Date.parse('20150925'))
+      create(:representation_order, maat_reference: '1234567', representation_order_date: date)
     end
 
     context 'when rep order date present' do
       it 'returns a string with the MAAT reference and rep order date' do
-        expect(rep_order.detail).to eq('25/09/2015 1234567')
+        expect(rep_order.detail).to eq("#{date} 1234567")
       end
     end
 

--- a/spec/models/stats/stats_report_spec.rb
+++ b/spec/models/stats/stats_report_spec.rb
@@ -86,7 +86,8 @@ RSpec.describe Stats::StatsReport do
 
     describe '.record_start' do
       it 'creates and incomplete record' do
-        frozen_time = Time.zone.local(2015, 3, 16, 13, 36, 12)
+        date = Time.zone.today - 1.year
+        frozen_time = Time.zone.local(date.year, 3, 16, 13, 36, 12)
         travel_to(frozen_time) do
           record = described_class.record_start(:my_new_report)
           expect(record.report_name).to eq 'my_new_report'

--- a/spec/requests/super_admins/stats_request_spec.rb
+++ b/spec/requests/super_admins/stats_request_spec.rb
@@ -142,14 +142,16 @@ RSpec.describe 'Stats' do
     end
 
     describe 'POST stats' do
+      let(:date) { Time.zone.today - 1.year }
+
       describe 'valid parameters' do
         before do
-          travel_to Time.zone.local(2015, 6, 10) do
+          travel_to Time.zone.local(date.year, 6, 10) do
             create(:advocate_final_claim, :submitted)
             create(:litigator_final_claim, :submitted)
             create(:litigator_final_claim, :submitted)
           end
-          post_with_params('1/6/2015', '30/6/2015')
+          post_with_params("1/6/#{date.year}", "30/6/#{date.year}")
         end
 
         it 'returns http success' do


### PR DESCRIPTION
Dynamically calculated dates so only dates within the last 10 years are used.

#### What
CCCD contains suites of rspec and cucumber tests, which run as part of the deployment pipeline.

These tests contain hard-coded dates in many places, often using dates in 2015 or subsequent years. CCCD only allows dates within the last 10 years to be used.

#### What I have not done:

In CCCD their are lots of json files which contain 2015 dates
````Claim-for-Crown-Court-Defence/spec/examples/exported_claim.json````

That look a bit like this:

````
{
    "claim": {
      "creator_email": "advocateadmin@example.com",
      "advocate_email": "advocate@example.com",
      "case_number": "A20161234",
      "case_type_id": 1,
      "first_day_of_trial": "2015-06-01",
      "estimated_trial_length": 3,
      "actual_trial_length": 3,
      "trial_concluded_at": "2015-06-03",
      "advocate_category": "QC",
      "offence_id": 1,
      "court_id": 1,
      "cms_number": "12345678",
      "additional_information": "string",
      "apply_vat": true,
      "trial_fixed_notice_at": "2015-06-01",
      "trial_fixed_at": "2015-06-01",
      "trial_cracked_at": "2015-06-01",
      "defendants": [
      
````
I have left those. Should I be converting them too though? 

#### Ticket
[CCCD: Future-proof tests](https://dsdmoj.atlassian.net/browse/CTSKF-1090)

#### Why
 A failure in any of these tests blocks the pipeline, meaning no changes to CCCD can be deployed.

#### How

Set date dynamically to 1 year previously 
 `date = (Time.zone.today - 1.year).strftime('%d-%m-%Y')`
