### PR TITLE
[CTSKF-1131] Set allow_deprecated_parameters_hash_equality

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -35,7 +35,7 @@
 # Do not treat an `ActionController::Parameters` instance
 # as equal to an equivalent `Hash` by default.
 #++
-# Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
+Rails.application.config.action_controller.allow_deprecated_parameters_hash_equality = false
 
 ###
 # Active Record Encryption now uses SHA-256 as its hash digest algorithm.


### PR DESCRIPTION
#### What

Do not treat an `ActionController::Parameters` instance as equal to an equivalent `Hash` by default.

#### Ticket

[board ticket description](https://dsdmoj.atlassian.net/browse/CTSKF-1131)

#### Why

Updating to the new Rails 7.1 default configurations following upgrade.

#### How

Set in `config/initializers/new_framework_defaults_7_1.rb`