### PR TITLE
[CTSKF-1130] CCCD - Set action_dispatch.default_headers

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -23,13 +23,13 @@
 # Remove the default X-Download-Options headers since it is used only by Internet Explorer.
 # If you need to support Internet Explorer, add back `"X-Download-Options" => "noopen"`.
 #++
-# Rails.application.config.action_dispatch.default_headers = {
-#   "X-Frame-Options" => "SAMEORIGIN",
-#   "X-XSS-Protection" => "0",
-#   "X-Content-Type-Options" => "nosniff",
-#   "X-Permitted-Cross-Domain-Policies" => "none",
-#   "Referrer-Policy" => "strict-origin-when-cross-origin"
-# }
+Rails.application.config.action_dispatch.default_headers = {
+  "X-Frame-Options" => "SAMEORIGIN",
+  "X-XSS-Protection" => "0",
+  "X-Content-Type-Options" => "nosniff",
+  "X-Permitted-Cross-Domain-Policies" => "none",
+  "Referrer-Policy" => "strict-origin-when-cross-origin"
+}
 
 ###
 # Do not treat an `ActionController::Parameters` instance


### PR DESCRIPTION
#### What
Set default Rails.application.config.action_dispatch.default_headers according to rails 7.1 recommendations.

#### Ticket

[board ticket description](https://dsdmoj.atlassian.net/browse/CTSKF-1130)

#### Why
Updating to the new Rails 7.1 default configurations following upgrade.

#### How
Set in config/initializers/new_framework_defaults_7_1.rb
