### PR TITLE
CTSKF-1151 - CCCD - Set action_text.sanitizer_vendor

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -261,7 +261,7 @@ end
 #
 # In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor.
 #++
-# Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_text.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 ###
 # Configure the log level used by the DebugExceptions middleware when logging


### PR DESCRIPTION
#### Ticket

[Set the Rails.application.config.action_text.sanitizer_vendor setting as the default value for Rails 7.1.](https://dsdmoj.atlassian.net/browse/CTSKF-1151)

#### Why
In previous versions of Rails, Action Text always used `Rails::HTML4::Sanitizer` as its vendor

#### How
`Rails::HTML::Sanitizer.best_supported_vendor` will cause Action Text to use HTML5-compliant sanitizers if they are supported, else fall back to HTML4 sanitizers.

