### PR TITLE
Uncomment the rails active record commit_transaction_on_non_local_return

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -219,7 +219,7 @@ end
 ###
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.
 #++
-# Rails.application.config.active_record.commit_transaction_on_non_local_return = true
+Rails.application.config.active_record.commit_transaction_on_non_local_return = true
 
 ###
 # Controls when to generate a value for <tt>has_secure_token</tt> declarations.


### PR DESCRIPTION
#### What
Set the Rails.application.config.active_record.commit_transaction_on_non_local_return setting as the default value for Rails 7.1.

#### Ticket

[CCCD - Set active_record.commit_transaction_on_non_local_return](https://dsdmoj.atlassian.net/browse/CTSKF-1147)

#### Why
To align with with Rails 7.1 update
#### How
