### PR TITLE
Fix indentation

### DIFF
--- a/app/views/shared/_new_claim.html.haml
+++ b/app/views/shared/_new_claim.html.haml
@@ -32,7 +32,7 @@
         = render partial: 'shared/new_main_hearing_date_details', locals: { claim: claim }
 
 
-  = render partial: 'shared/new_claim_defendants', locals: { claim: claim }
+= render partial: 'shared/new_claim_defendants', locals: { claim: claim }
 
 - unless claim.fixed_fee_case?
   = render partial: 'shared/offence_details/new_summary', locals: { claim: claim }


### PR DESCRIPTION
#### What
The summary page for the caseworkers was displaying incorrectly as the defendant details was squished inside basic claim section. 

#### How
It just needed the indentation to be shifted so that it sat at the same level as the basic claim section. 