### PR TITLE
Mark time sensitive tests as pending

### DIFF
--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with a completed journey' do
         before do
-          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
+          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -276,7 +276,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with an uncompleted journey' do
         before do
-          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
+          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do


### PR DESCRIPTION
#### What

Further fix for the MI bug which occurs during BST 

#### Ticket

[CTSKF-321](https://dsdmoj.atlassian.net/browse/CTSKF-321)

#### Why

These tests use claim data backdated one week, so did not start failing immediately when we moved from GMT to BST. They are now failing. 

#### How

Mark failing tests as `pending`, so they now pass during BST.

[CTSKF-321]: https://dsdmoj.atlassian.net/browse/CTSKF-321?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

See #5536 