### PR TITLE
[CTSKF 1169] Update ingressClassName for non-prod environments

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -22,7 +22,7 @@ metadata:
   name: cccd-app-ingress-v1
   namespace: cccd-api-sandbox
 spec:
-  ingressClassName: modsec
+  ingressClassName: modsec-non-prod
   rules:
     - host: api-sandbox.claim-crown-court-defence.service.justice.gov.uk
       http:

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -24,7 +24,7 @@ metadata:
   name: cccd-app-ingress-v1
   namespace: cccd-dev-lgfs
 spec:
-  ingressClassName: modsec
+  ingressClassName: modsec-non-prod
   rules:
     - host: dev-lgfs.claim-crown-court-defence.service.justice.gov.uk
       http:

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -24,7 +24,7 @@ metadata:
   name: cccd-app-ingress-v1
   namespace: cccd-dev
 spec:
-  ingressClassName: modsec
+  ingressClassName: modsec-non-prod
   rules:
     - host: dev.claim-crown-court-defence.service.justice.gov.uk
       http:

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -24,7 +24,7 @@ metadata:
   name: cccd-app-ingress-v1
   namespace: cccd-staging
 spec:
-  ingressClassName: modsec
+  ingressClassName: modsec-non-prod
   rules:
     - host: staging.claim-crown-court-defence.service.justice.gov.uk
       http:


### PR DESCRIPTION
#### What

Set the version of modsec for testing.

#### Ticket

[[CCCD] Update modsec in non-prod](https://dsdmoj.atlassian.net/browse/CTSKF-1169)

#### Why

ModSec is being updated and a test ingress controller has been provided.

#### How

Change `ingressClassName: modsec` to `ingressClassName: modsec-non-prod` in all non-prod environments.