### PR TITLE
Add Google Analytics 4 to CSP

### DIFF
--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -4,14 +4,18 @@
 # See the Securing Rails Applications Guide for more information:
 # https://guides.rubyonrails.org/security.html#content-security-policy-header
 
+GOOGLE_ANALYTICS_DOMAIN = "https://*.google-analytics.com".freeze
+GOOGLE_TAG_MANAGER_DOMAIN = "https://*.googletagmanager.com".freeze
+
 Rails.application.configure do
   config.content_security_policy do |policy|
+    policy.connect_src :self, :https, GOOGLE_ANALYTICS_DOMAIN, GOOGLE_TAG_MANAGER_DOMAIN, "https://*.analytics.google.com"
     policy.default_src :self, :https
     policy.font_src    :self, :https, :data
-    policy.img_src     :self, :https, :data
+    policy.img_src     :self, :https, :data, GOOGLE_ANALYTICS_DOMAIN, GOOGLE_TAG_MANAGER_DOMAIN
     policy.object_src  :none
     # TODO: unsafe_inline should be removed but this cannot be done until some Javascript is refactored.
-    policy.script_src  :self, "'wasm-unsafe-eval'", :unsafe_inline, :https
+    policy.script_src  :self, "'wasm-unsafe-eval'", :unsafe_inline, :https, GOOGLE_TAG_MANAGER_DOMAIN
     policy.style_src   :self, :unsafe_inline, :https
     # Specify URI for violation reports
     policy.report_uri "/csp_report"


### PR DESCRIPTION
#### What

Updates the content security policy to allow Google Analytics 4 domains following documentation here: https://developers.google.com/tag-platform/security/guides/csp#google_analytics_4_google_analytics


#### Why

An attempt to reduce some of the noise in the #laa-cccd-alerts slack channel.

Before, we frequently see these alerts:

<img width="676" alt="image" src="https://github.com/user-attachments/assets/317a7a14-803c-461a-bf1e-b23cdc58b710" />

This change means the alerts no longer occur. This won't resolve all CSP alerts in that channel, but will reduce the volume.