### PR TITLE
CTSKF-1142 - CCCD - Set precompile_filter_parameters

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -181,7 +181,7 @@ end
 # Enable precompilation of `config.filter_parameters`. Precompilation can
 # improve filtering performance, depending on the quantity and types of filters.
 #++
-# Rails.application.config.precompile_filter_parameters = true
+Rails.application.config.precompile_filter_parameters = true
 
 ###
 # Enable before_committed! callbacks on all enrolled records in a transaction.


### PR DESCRIPTION
#### What
Set the Rails.application.config.precompile_filter_parameters setting as the default value for Rails 7.1.

#### Ticket

[CCCD - Set precompile_filter_parameters](https://dsdmoj.atlassian.net/browse/CTSKF-1142)

#### Why
When true, will precompile config.filter_parameters using ActiveSupport::ParameterFilter.precompile_filters.

The default value depends on the config.load_defaults target version

#### How
Enable the configuration in `config/initializers/new_framework_defaults_7_1.rb`

