### PR TITLE
Modify the location column to be a status column

### DIFF
--- a/app/views/case_workers/admin/case_workers/index.html.haml
+++ b/app/views/case_workers/admin/case_workers/index.html.haml
@@ -18,7 +18,7 @@
 
       = govuk_table_thead_collection [t('.surname'),
       t('.name'),
-      t('.location'),
+      t('.status'),
       t('.actions')]
 
       = govuk_table_tbody do
@@ -27,13 +27,10 @@
             = govuk_table_td('data-label': t('.surname')) { case_worker.user.last_name }
 
             = govuk_table_td('data-label': t('.name')) { case_worker.user.first_name }
-
-            = govuk_table_td('data-label': t('.location')) { case_worker.location.name }
+            = govuk_table_td('data-label': t('.status')) { govuk_tag_active_user?(case_worker.user) }
 
             = govuk_table_td('data-label': t('.actions')) do
               - if case_worker.active?
                 .app-link-group
-                  = govuk_link_to(t('.edit_caseworker_html', case_worker: case_worker.name), edit_case_workers_admin_case_worker_path(case_worker))
-                  = govuk_link_to(t('.delete_caseworker_html', case_worker: case_worker.name), case_workers_admin_case_worker_path(case_worker), method: :delete, data: { confirm: t('.confirmation') })
-              - else
-                = t('.inactive')
+                  .div= govuk_link_to t('.edit_caseworker_html', case_worker: case_worker.name), edit_case_workers_admin_case_worker_path(case_worker)
+                  .div= govuk_link_to t('.delete_caseworker_html', case_worker: case_worker.name), case_workers_admin_case_worker_path(case_worker), method: :delete, data: { confirm: t('.confirmation') }

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2668,8 +2668,8 @@ en:
           case_workers_list: List of case workers
           surname: Surname
           name: Name
-          location: Location
-          actions: Manage details
+          status: Status
+          actions: Actions
           confirmation: Are you sure?
           delete_caseworker_html: 'Delete <span class="govuk-visually-hidden">case worker: %{case_worker}</span>'
           edit_caseworker_html: 'Edit <span class="govuk-visually-hidden">case worker: %{case_worker}</span>'


### PR DESCRIPTION
#### What
Implement GDS styles and styling tweaks to the ‘Manage Users’ page for Caseworkers

Use [GDS tags](https://design-system.service.gov.uk/components/tag/multiple-tags/) to style inactive/active to make it visually clear which is active or inactive

Rename ‘Manage details’ to ‘Actions' 

#### Why

To make the page more accessible and legible

#### Ticket

[CCCD - Tidy up and standardise 'Manage Users' table - Caseworkers page](https://dsdmoj.atlassian.net/browse/CTSKF-984)

#### How

Modify the location column to be a status column
Edit the text to display updated content
Add the tag helper method to display the status tag Remove the Inactive text from the Actions column when inactive Put the Edit and Delete links under one another