### PR TITLE
Uncomment the rails config to allow callbacks on all enrolled records…

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -188,7 +188,7 @@ Rails.application.config.precompile_filter_parameters = true
 # The previous behavior was to only run the callbacks on the first copy of a record
 # if there were multiple copies of the same record enrolled in the transaction.
 #++
-# Rails.application.config.active_record.before_committed_on_all_records = true
+Rails.application.config.active_record.before_committed_on_all_records = true
 
 ###
 # Disable automatic column serialization into YAML.


### PR DESCRIPTION
#### What

Enable before_committed! callbacks on all enrolled records in a transaction.

#### Ticket

[CCCD - Set active_record.before_committed_on_all_records](https://dsdmoj.atlassian.net/browse/CTSKF-1143)

#### Why
 To allow callbacks on all enrolled records in a transaction

#### How
Uncomment  Rails.application.config.active_record.before_committed_on_all_records = true in the Rails config
