### PR TITLE
Enable the run_after_transaction_callbacks_in_order_defined in the Ra…

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -214,7 +214,7 @@ Rails.application.config.precompile_filter_parameters = true
 # This matches the behaviour of all other callbacks.
 # In previous versions of Rails, they ran in the inverse order.
 #++
-# Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
+Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined = true
 
 ###
 # Whether a `transaction` block is committed or rolled back when exited via `return`, `break` or `throw`.


### PR DESCRIPTION
#### What
Enable the run_after_transaction_callbacks_in_order_defined in the Rails config as a default value for Rails 7.1

#### Ticket

[CCCD - Set active_record.run_after_transaction_callbacks_in_order_defined](https://dsdmoj.atlassian.net/browse/CTSKF-1146)

#### Why
As part of a Rails 7.1 upgrade so that it matches the behaviour of all other callbacks as previously they ran in the inverse order

#### How

Comment out this line `Rails.application.config.active_record.run_after_transaction_callbacks_in_order_defined` in the Rails config
