### PR TITLE
[CTSKF-1150] Set `action_view.sanitizer_vendor` to `best_supported_vendor`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -250,7 +250,7 @@ Rails.application.config.active_record.commit_transaction_on_non_local_return = 
 #
 # In previous versions of Rails, Action View always used `Rails::HTML4::Sanitizer` as its vendor.
 #++
-# Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
+Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
 
 ###
 # Configure Action Text to use an HTML5 standards-compliant sanitizer when it is supported on your


### PR DESCRIPTION
#### What

As part of the upgrade to rails 7.1, set the `action_view.sanitizer_vendor` setting to `best_supported_vendor`.

#### Ticket

[CTSKF-1150](https://dsdmoj.atlassian.net/browse/CTSKF-1150)

#### Why

To take advantage of new functionality offered by rails 7.1.

#### How

Enable the `Rails.application.config.action_view.sanitizer_vendor = Rails::HTML::Sanitizer.best_supported_vendor
` setting in `/config/initializers/new_framework_defaults_7_1.rb`


[CTSKF-1150]: https://dsdmoj.atlassian.net/browse/CTSKF-1150?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ