### PR TITLE
CTSKF-1064 - CCCD: Adopt govuk-components gem for cookie banner

### DIFF
--- a/app/views/layouts/_cookie_banner.html.haml
+++ b/app/views/layouts/_cookie_banner.html.haml
@@ -1,29 +1,14 @@
 - unless @cookies_preferences_set
-  .govuk-cookie-banner{ role: 'region', 'aria-label': t('.title'), 'tab-index': '-1', 'data-nosnippet': true }
-    .govuk-cookie-banner__message.govuk-width-container
+  = govuk_cookie_banner do |cb|
+    - cb.with_message(heading_text: t('.title')) do |m|
+      - m.with_action { govuk_button_link_to(t('.accept_button'), '?usage_opt_in=true&show_confirmation=true') }
+      - m.with_action { govuk_button_link_to(t('.reject_button'), '?usage_opt_in=false&show_confirmation=true') }
+      - m.with_action { govuk_link_to(t('.view_cookies'), cookies_path) }
 
-      .govuk-grid-row
-        .govuk-grid-column-two-thirds
-          %h2.govuk-cookie-banner__heading.govuk-heading-m
-            = t('.title')
-
-          .govuk-cookie-banner__content
-            = t('.content_html')
-
-      .govuk-button-group
-        = govuk_button_link_to(t('.accept_button'), '?usage_opt_in=true&show_confirmation=true')
-        = govuk_button_link_to(t('.reject_button'), '?usage_opt_in=false&show_confirmation=true')
-
-        = govuk_link_to(t('.view_cookies'), cookies_path)
+      .govuk-cookie-banner__content
+        = t('.content_html')
 
 - if @show_confirm_banner == "true"
-  .govuk-cookie-banner{ role: 'alert', 'aria-label': t('.title'), 'tab-index': '-1', 'data-nosnippet': true }
-    .govuk-cookie-banner__confirmation.govuk-width-container
-      .govuk-grid-row
-        .govuk-grid-column-two-thirds
-
-          .govuk-cookie-banner__content
-            = t('.cookie_confirmation_html', link: cookies_path)
-
-      .govuk-button-group
-        = govuk_button_link_to(t('.hide_button'), '?show_confirmation=false')
+  = govuk_cookie_banner do |cb|
+    - cb.with_message(text: t('.cookie_confirmation_html', link: cookies_path)) do |m|
+      - m.with_action { govuk_button_link_to(t('.hide_button'), '?show_confirmation=false') }

--- a/features/page_objects/cookie_page.rb
+++ b/features/page_objects/cookie_page.rb
@@ -4,8 +4,6 @@ class CookiePage < BasePage
       element :accept_cookies, '.govuk-button-group a[href="?usage_opt_in=true&show_confirmation=true"]'
       element :reject_cookies, '.govuk-button-group a[href="?usage_opt_in=false&show_confirmation=true"]'
       element :view_cookies, '.govuk-button-group a[href="/help/cookies"]'
-    end
-    section :confirmation, '.govuk-cookie-banner__confirmation' do
       element :hide, '.govuk-button-group a[href="?show_confirmation=false"]'
     end
   end

--- a/features/step_definitions/cookies_steps.rb
+++ b/features/step_definitions/cookies_steps.rb
@@ -13,12 +13,12 @@ When('I reject the cookies') do
 end
 
 Then('I see the cookie confirmation message') do
-  expect(@cookie_page.banner.confirmation).to be_visible
-  expect(@cookie_page.banner.confirmation).to have_content 'Your cookie settings were saved'
+  expect(@cookie_page.banner).to be_visible
+  expect(@cookie_page.banner).to have_content 'Your cookie settings were saved'
 end
 
 Then('I hide the cookie confirmation message') do
-  @cookie_page.banner.confirmation.hide.click
+  @cookie_page.banner.message.hide.click
 end
 
 Then('the cookie banner is not available') do


### PR DESCRIPTION
#### What
We can use the govuk-components gem to simplify the CCCD codebase and improve maintainability of the application.

#### Ticket
[CCCD: Adopt govuk-components gem for cookie banner](https://dsdmoj.atlassian.net/browse/CTSKF-1064)

#### How
Code in /app/views/layouts/_cookie_banner.html.haml used to create the cookie banner is replaced with the helper method from the gem: [Cookie banner - GOV.UK Components for Ruby on Rails](https://govuk-components.netlify.app/components/cookie-banner/)

