### PR TITLE
Improve labelling of VAT fields on determination table

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2837,9 +2837,8 @@ en:
         total_inc_vat: Total (including VAT)
         vat: VAT
       determination_agfs_vat_fields:
-        total_inc_vat_rate: 'Total inc VAT rate:'
         vat_rate: "VAT (%{vat_rate})"
-        vat_rate: "Total (including %{vat_rate} VAT)"
+        total_inc_vat_rate: "Total (including %{vat_rate} VAT)"
       index:
         page_heading: Your claims
         page_title: View your allocated claims list


### PR DESCRIPTION
#### What

Improve labelling of VAT fields on determination table

#### Why

When assessing an AGFS claim, a caseworker sees three fields relating to VAT:

* The value of the claim, before VAT - labelled as "Total excluding VAT"
* The VAT value for the claim - labelled as "Total (including 20% VAT)"
* The total value for the claim - labelled as "Total inc VAT rate:"

The second line makes no sense, as this displays the VAT value not the total. The third line could be worded better, ideally using the current wording from the second line.

#### How

Updates the relevant translation file to use the correct wordings in the correct places.

#### Screenshots

Before:

![image](https://github.com/user-attachments/assets/3b9a46b9-76d7-449f-8174-3b98cbf55aa4)


After: 

![image](https://github.com/user-attachments/assets/b9785e61-f956-4aab-9544-519dadc683c0)
 