### PR TITLE
Test cleanup

### DIFF
--- a/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/final_claim_spec.rb
@@ -40,7 +40,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::FinalClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'advocate claim test setup'
   include_examples 'malformed or not iso8601 compliant dates',
                    action: :validate, attributes: %i[first_day_of_trial
                                                      trial_concluded_at

--- a/spec/api/v1/external_users/claims/advocates/hardship_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/hardship_claim_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::HardshipClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'advocate claim test setup'
   include_examples 'malformed or not iso8601 compliant dates',
                    action: :validate,
                    attributes: %i[first_day_of_trial trial_concluded_at main_hearing_date],

--- a/spec/api/v1/external_users/claims/advocates/interim_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/interim_claim_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::InterimClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'advocate claim test setup'
   include_examples 'malformed or not iso8601 compliant dates', action: :validate, attributes: %i[main_hearing_date],
                                                                relative_endpoint: ADVOCATE_INTERIM_VALIDATE_ENDPOINT
   include_examples 'optional parameter validation', optional_parameters: %i[main_hearing_date],

--- a/spec/api/v1/external_users/claims/advocates/supplementary_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/advocates/supplementary_claim_spec.rb
@@ -26,7 +26,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::Advocates::SupplementaryClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'advocate claim test setup'
   include_examples 'malformed or not iso8601 compliant dates', action: :validate,
                                                                attributes: %i[main_hearing_date],
                                                                relative_endpoint: ADVOCATE_SUPP_VALIDATE_ENDPOINT

--- a/spec/api/v1/external_users/claims/final_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/final_claim_spec.rb
@@ -30,7 +30,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::FinalClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'litigator claim test setup'
   include_examples 'malformed or not iso8601 compliant dates', action: :validate,
                                                                attributes: %i[case_concluded_at main_hearing_date],
                                                                relative_endpoint: LITIGATOR_FINAL_VALIDATE_ENDPOINT

--- a/spec/api/v1/external_users/claims/interim_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/interim_claim_spec.rb
@@ -28,7 +28,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::InterimClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'litigator claim test setup'
   include_examples 'malformed or not iso8601 compliant dates', action: :validate,
                                                                attributes: %i[main_hearing_date],
                                                                relative_endpoint: LITIGATOR_INTERIM_VALIDATE_ENDPOINT

--- a/spec/api/v1/external_users/claims/litigators/hardship_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/litigators/hardship_claim_spec.rb
@@ -29,7 +29,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::Litigators::HardshipClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'litigator claim test setup'
   include_examples 'malformed or not iso8601 compliant dates', action: :validate,
                                                                attributes: %i[main_hearing_date],
                                                                relative_endpoint: LITIGATOR_HARDSHIP_VALIDATE_ENDPOINT

--- a/spec/api/v1/external_users/claims/transfer_claim_spec.rb
+++ b/spec/api/v1/external_users/claims/transfer_claim_spec.rb
@@ -34,7 +34,6 @@ RSpec.describe API::V1::ExternalUsers::Claims::TransferClaim do
 
   after(:all) { clean_database }
 
-  include_examples 'litigator claim test setup'
   include_examples 'malformed or not iso8601 compliant dates', action: :validate,
                                                                attributes: %i[case_concluded_at
                                                                               main_hearing_date

--- a/spec/support/shared_examples_for_api.rb
+++ b/spec/support/shared_examples_for_api.rb
@@ -141,22 +141,6 @@ RSpec.shared_examples 'optional parameter validation' do |options|
   end
 end
 
-RSpec.shared_examples 'advocate claim test setup' do
-  describe 'test setup' do
-    it 'vendor should belong to same provider as advocate' do
-      expect(vendor.provider).to eql(advocate.provider)
-    end
-  end
-end
-
-RSpec.shared_examples 'litigator claim test setup' do
-  describe 'test setup' do
-    it 'vendor should belong to same provider as litigator' do
-      expect(vendor.provider).to eql(litigator.provider)
-    end
-  end
-end
-
 RSpec.shared_examples 'a claim endpoint' do |options|
   context 'when sending non-permitted verbs' do
     ClaimApiEndpoints.for(options[:relative_endpoint]).all.each do |endpoint|


### PR DESCRIPTION
#### What

Removal of unnecessary tests.

#### Why

The tests in the shared examples 'advocate claim test setup' and 'litigator claim test setup' are checking that the tests have been set up correctly. The do not add any value and so have been removed.