### PR TITLE
Update message controller to allow all documents to be available by the claim

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -66,6 +66,8 @@ class MessagesController < ApplicationController
     documents = Document.where(id: params[:message][:document_ids], creator_id: current_user.id)
     documents.each do |doc|
       message.attachments.attach(doc.document.blob)
+      doc.claim = message.claim
+      doc.save_and_verify
     end
   end
 

--- a/spec/requests/messages_spec.rb
+++ b/spec/requests/messages_spec.rb
@@ -90,6 +90,8 @@ RSpec.describe 'Messages' do
         expect(Message.last.attachments.count).to eq(2)
       end
 
+      it { expect { submit }.to change(claim.reload.documents, :count).by(2) }
+
       context 'when some documents do not belong to the creator' do
         let(:documents) { [create(:document, creator_id: creator.user.id), create(:document)] }
 


### PR DESCRIPTION
#### What
Caseworkers want to be able to see any new evidence that has been uploaded in the message box directly evidence table. Currently it only displays documents that have been uploaded by the provider prior to messages. 

#### Ticket
[New Evidence Uploads added to the table in CCCD](https://dsdmoj.atlassian.net/browse/CTSKF-1162)

#### Why
To prevent them spending unnecessary time browsing through messages to identify any new evidence uploads.

#### How
Update the Message controller **`attach_documents`** action by adding:

```
doc.claim = message.claim
```
Adding this to the Message controller action will set the document’s associated claim to be the same as the message’s claim. When the documents are iterated through in the evidence table it will display documents uploaded in the message as well. 

```
 = govuk_table_tbody do
  - @claim.documents.includes(:document_blob, :converted_preview_document_attachment).each do |document|
    = govuk_table_row do
      = govuk_table_td do
        = document.document_file_name
      = govuk_table_td_numeric { number_to_human_size(document.document_file_size) }
      = govuk_table_td_numeric { document.created_at.strftime(Settings.date_format) }
      = govuk_table_td do
```

