### PR TITLE
 Fix linting issues in Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -5,7 +5,7 @@ FROM base AS builder
 
 RUN set -ex
 
-ENV APP_HOME /usr/src/app
+ENV APP_HOME=/usr/src/app
 WORKDIR $APP_HOME
 
 RUN apk --update-cache upgrade \
@@ -16,11 +16,13 @@ RUN apk --update-cache upgrade \
                    yaml-dev \
                    yarn
 
-ENV RAILS_ENV production
+ENV RAILS_ENV=production
 
 COPY Gemfile Gemfile.lock .ruby-version $APP_HOME/
 
-RUN gem install bundler -v $(cat Gemfile.lock | tail -1 | tr -d " ") \
+SHELL ["/bin/ash", "-eo", "pipefail", "-c"]
+
+RUN gem install bundler -v "$(tail -1 Gemfile.lock | tr -d " ")" \
 && bundle config without test development \
 && bundle install --jobs 4 --retry 3 \
 && rm -rf /usr/local/bundle/cache/*.gem \
@@ -40,14 +42,14 @@ RUN rm -rf node_modules
 
 # Stage 2: copies dependencies from the build stage and creates final image for running the application
 FROM base
-LABEL Organisation="Ministry of Justice"
-LABEL Service="Claim for Crown Court Defence"
-LABEL Contact="crowncourtdefence@digital.justice.gov.uk"
+LABEL organisation="Ministry of Justice"
+LABEL service="Claim for Crown Court Defence"
+LABEL contact="crowncourtdefence@digital.justice.gov.uk"
 
 RUN set -ex
 
-ENV RAILS_ENV production
-ENV APP_HOME /usr/src/app
+ENV RAILS_ENV=production
+ENV APP_HOME=/usr/src/app
 WORKDIR $APP_HOME
 
 RUN apk --update-cache upgrade \
@@ -85,4 +87,4 @@ USER 1000
 # Create tmp/pids/ needed for puma
 RUN mkdir -p $APP_HOME/tmp/pids
 
-CMD "./docker/docker-entrypoint.sh"
+CMD ["./docker/docker-entrypoint.sh"]


### PR DESCRIPTION
#### What

Fixes linting issues in `docker/Dockerfile` identified by the `hadolint` tool.

#### Why

To improve overall code quality

#### How

* Installed and ran `hadolint docker/Dockerfile` locally to lint the Dockerfile.

* Fixed the following issues highlighted by `hadolint`:

```
docker/Dockerfile:23 DL4006 warning: Set the SHELL option -o pipefail before RUN with a pipe in it. If you are using /bin/sh in an alpine image or if your shell is symlinked to busybox then consider explicitly setting your SHELL to /bin/ash, or disable this check
docker/Dockerfile:23 SC2002 style: Useless cat. Consider 'cmd < file | ..' or 'cmd file | ..' instead.
docker/Dockerfile:43 DL3048 style: Invalid label key.
docker/Dockerfile:44 DL3048 style: Invalid label key.
docker/Dockerfile:45 DL3048 style: Invalid label key.
docker/Dockerfile:88 DL3025 warning: Use arguments JSON notation for CMD and ENTRYPOINT arguments
```

The following issue has not beed fixed this issue, as it causes a build failure if `RUN rm -rf node_modules` is moved into the preceeding `RUN` block.

```
docker/Dockerfile:39 DL3059 info: Multiple consecutive `RUN` instructions. Consider consolidation.
```

Also the following issues have not been fixed as they may require further discussion on how to manage dependency updates before adopting:

```
docker/Dockerfile:11 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
docker/Dockerfile:53 DL3018 warning: Pin versions in apk add. Instead of `apk add <package>` use `apk add <package>=<version>`
```