### PR TITLE
[CTSKF-1189] Fix 'no method error' error

### DIFF
--- a/app/validators/concerns/claim/defendant_uplift_validations.rb
+++ b/app/validators/concerns/claim/defendant_uplift_validations.rb
@@ -80,6 +80,7 @@ module Claim
 
       def defendant_uplifts_counts_for(defendant_uplifts)
         defendant_uplifts.each_with_object({}) do |fee, res|
+          next if fee.quantity.blank?
           res[fee.fee_type.unique_code] ||= []
           res[fee.fee_type.unique_code] << fee.quantity
         end.values.map(&:sum)


### PR DESCRIPTION
The defendant uplift validations raises an exception when the quantity on a fee is `nil` as these quantities are summed. This was probably masked prior to Rails 7.1 as the Rails version of the `sum` method ignored blank values in. In Rails 7.1 the Rails version of `sum` is removed in favour of the Ruby version and this fails if the array does not contain only numbers.

It is unclear how the quantity on a fee can be set to `nil`.

#### What

Fix 'no method' error.

#### Ticket

[CCCD Bug - Internal server error submitting claim](https://dsdmoj.atlassian.net/browse/CTSKF-1189)

#### Why

Providers are unable to submit claims due to an internal server error when viewing a claim summary. This comes from the defendant uplift validations and it seems to be a result of the Rails 7.1 upgrade.

Prior to Rails 7.1 the Ruby `Enumerable#sum` method was overridden by Active Support. This has been removed and so the original Ruby version of the method is used instead. The Active Support version of the method treated `nil` values as zero while the Ruby version raises an exception.

#### How

Use a guard clause to prevent blank values being added to the list to be summed.