### PR TITLE
use default query log tags format

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -108,7 +108,7 @@ Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default
 # (https://open-telemetry.github.io/opentelemetry-sqlcommenter/), or using the legacy format.
 # Options are `:legacy` and `:sqlcommenter`.
 #++
-# Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
+Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 
 ###
 # Specify the default serializer used by `MessageEncryptor` and `MessageVerifier`


### PR DESCRIPTION
#### What
Specify Query Logs will format tags using the default SQLCommenter format

#### Ticket

[CCCD - Set query_log_tags_format (rails 7.1)](https://dsdmoj.atlassian.net/browse/CTSKF-1137?atlOrigin=eyJpIjoiMzAxNjExOWVkYjJkNDIwMzgwOWIwNjRiZDcyODM4YmUiLCJwIjoiaiJ9)

#### Why
To migrate to Rails 7.1

#### How
Uncommenting the default config in `new_framework_defaults_7_1.rb` file

