### PR TITLE
SPIKE: Restrict access to allowlist

### DIFF
--- a/.circleci/deploy.sh
+++ b/.circleci/deploy.sh
@@ -80,6 +80,14 @@ function _circleci_deploy() {
     -f .k8s/${cluster_dir}/cron_jobs/archive_stale.yaml \
     -f .k8s/${cluster_dir}/cron_jobs/vacuum_db.yaml
 
+  # get ip addresses for allowlists
+  LAA_IPS=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',')
+  PINGDOM_IPS=$(curl -s https://my.pingdom.com/probes/ipv4 | tr -d ' ' | tr '\n' ',')
+  COMBINED_IPS="${PINGDOM_IPS}${LAA_IPS}"
+
+  # populate ingress file with ip addresses
+  sed -i -e "s#<allowlist-populated-by-deploy-script>#${COMBINED_IPS}#" .k8s/${cluster_dir}/${environment}/ingress.yaml;
+
   # apply non-image specific config
   kubectl apply \
   -f .k8s/${cluster_dir}/${environment}/service.yaml \

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
+    nginx.ingress.kubernetes.io/whitelist-source-range: <allowlist-populated-by-deploy-script>
   name: cccd-app-ingress-v1
   namespace: cccd-dev-lgfs
 spec:

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -21,6 +21,7 @@ metadata:
       if ($http_spider_name ~* "crawlergo") {
         return 403;
       }
+    nginx.ingress.kubernetes.io/whitelist-source-range: <allowlist-populated-by-deploy-script>
   name: cccd-app-ingress-v1
   namespace: cccd-dev
 spec:

--- a/.k8s/live/scripts/deploy.sh
+++ b/.k8s/live/scripts/deploy.sh
@@ -75,6 +75,14 @@ function _deploy() {
   -f .k8s/${context}/cron_jobs/archive_stale.yaml \
   -f .k8s/${context}/cron_jobs/vacuum_db.yaml
 
+  # get ip addresses for allowlists
+  LAA_IPS=$(curl -s https://raw.githubusercontent.com/ministryofjustice/laa-ip-allowlist/main/cidrs.txt | tr -d ' ' | tr '\n' ',')
+  PINGDOM_IPS=$(curl -s https://my.pingdom.com/probes/ipv4 | tr -d ' ' | tr '\n' ',')
+  COMBINED_IPS="${PINGDOM_IPS}${LAA_IPS}"
+
+  # populate ingress file with ip addresses
+  sed -i -e "s#<allowlist-populated-by-deploy-script>#${COMBINED_IPS}#" .k8s/${context}/${environment}/ingress.yaml;
+
   # apply non-image specific config
   kubectl apply \
     -f .k8s/${context}/${environment}/service.yaml \


### PR DESCRIPTION
#### What

Spike an approach to restricting access to CCCD to a defined allowlist of IP addresses.

#### Ticket

[CTSKF-1210](https://dsdmoj.atlassian.net/browse/CTSKF-1210)

#### Why

To improve security of LAA applications.

#### How

As part of the deploy process:
* get lists of allowed LAA and Pingdom IP addresses
* combine those lists
* amend the `ingress.yaml` file to set `nginx.ingress.kubernetes.io/whitelist-source-range` to that combined list

[CTSKF-1210]: https://dsdmoj.atlassian.net/browse/CTSKF-1210?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ