### PR TITLE
CTSKF 1223 password strength

### DIFF
--- a/app/views/devise/passwords/edit.html.haml
+++ b/app/views/devise/passwords/edit.html.haml
@@ -10,6 +10,13 @@
 
       = f.hidden_field :reset_password_token
 
+      = govuk_inset_text do
+        %p
+          =t('.password_help')
+
+      %p
+        =t('.password_length')
+
       = f.govuk_password_field :password,
         label: { text: t('.new_password') },
         autofocus: true

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -6,4 +6,4 @@
     .govuk-error-summary__body
       %ul.govuk-list.govuk-error-summary__list
         - resource.errors.each do |error|
-          %li= "#{error.attribute.to_s.humanize} #{error.message}"
+          %li= "#{error.message}"

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -6,4 +6,4 @@
     .govuk-error-summary__body
       %ul.govuk-list.govuk-error-summary__list
         - resource.errors.each do |error|
-          %li= "#{error.message}"
+          %li= "#{error.attribute.to_s.humanize} #{error.message}"

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -140,7 +140,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 8..128
+  config.password_length = 12..64
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -44,8 +44,8 @@ en:
         new_password: New password
         page_heading: Change your password
         page_title: Change your password for claim for Crown court defence
-        password_length: Your password must be between 12 and 64 characters.
-        password_help: To create a strong memorable password, consider using a combination of three random words. These words should be of different lengths and from different categories, such as a noun, a verb and an object.
+        password_length: Your password must be at least 12 characters long.
+        password_help: To create a strong, memorable password, consider combining three words. Avoid common words or phrases, predictable patterns, or personal information.
       new:
         email: *email
         page_heading: Forgot your password?

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -44,6 +44,8 @@ en:
         new_password: New password
         page_heading: Change your password
         page_title: Change your password for claim for Crown court defence
+        password_length: Your password must be between 12 and 64 characters.
+        password_help: To create a strong memorable password, consider using a combination of three random words. These words should be of different lengths and from different categories, such as a noun, a verb and an object.
       new:
         email: *email
         page_heading: Forgot your password?

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,7 +312,7 @@ en:
               invalid: Enter the current password
             password:
               blank: Enter a password
-              too_short: Password must be at least 12 characters
+              too_short: must be at least 12 characters
             password_confirmation:
               blank: Enter a password confirmation
               confirmation: Password and confirmation must match

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -312,7 +312,7 @@ en:
               invalid: Enter the current password
             password:
               blank: Enter a password
-              too_short: Password must be at least 8 characters
+              too_short: Password must be at least 12 characters
             password_confirmation:
               blank: Enter a password confirmation
               confirmation: Password and confirmation must match

--- a/features/step_definitions/caseworker_claim_allocation_steps.rb
+++ b/features/step_definitions/caseworker_claim_allocation_steps.rb
@@ -1,5 +1,5 @@
 Given(/^case worker "(.*?)" exists$/) do |name|
-  @password = "password"
+  @password = "password1234"
   first_name = name.split.first
   last_name = name.split.last
   @case_worker_user = create(:user, first_name: first_name, last_name: last_name,

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -1,5 +1,5 @@
 def make_accounts(role, number = 1)
-  @password = 'password'
+  @password = 'password1234'
   case role
     when 'advocate'
       @advocates = create_list(:external_user, number)
@@ -43,7 +43,7 @@ Given(/^I am a signed in advocate$/) do
   @advocate = @current_user = create(:external_user, :advocate)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@advocate.user, 'password')
+  sign_in(@advocate.user, 'password1234')
 end
 
 Given('I am a signed in advocate with final claim {string}') do |case_number|
@@ -51,7 +51,7 @@ Given('I am a signed in advocate with final claim {string}') do |case_number|
   create(:advocate_claim, creator: @advocate, external_user: @advocate, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@advocate.user, 'password')
+  sign_in(@advocate.user, 'password1234')
 end
 
 Given('I am a signed in advocate with fixed fee claim {string}') do |case_number|
@@ -59,21 +59,21 @@ Given('I am a signed in advocate with fixed fee claim {string}') do |case_number
   create(:advocate_claim, :with_fixed_fee_case, creator: @advocate, external_user: @advocate, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@advocate.user, 'password')
+  sign_in(@advocate.user, 'password1234')
 end
 
 Given(/^I am a signed in advocate admin$/) do
   @advocate = @current_user = create(:external_user, :advocate_and_admin)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@advocate.user, 'password')
+  sign_in(@advocate.user, 'password1234')
 end
 
 Given(/^I am a signed in litigator$/) do
   @litigator = @current_user = create(:external_user, :litigator)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@litigator.user, 'password')
+  sign_in(@litigator.user, 'password1234')
 end
 
 Given('I am a signed in litigator with final claim {string}') do |case_number|
@@ -81,28 +81,28 @@ Given('I am a signed in litigator with final claim {string}') do |case_number|
   create(:litigator_claim, creator: @litigator, external_user: @litigator, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@litigator.user, 'password')
+  sign_in(@litigator.user, 'password1234')
 end
 
 Given(/^I am a signed in litigator admin$/) do
   @litigator = @current_user = create(:external_user, :litigator_and_admin)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@litigator.user, 'password')
+  sign_in(@litigator.user, 'password1234')
 end
 
 Given(/^I am a signed in admin for an AGFS and LGFS firm$/) do
   @admin = @current_user = create(:external_user, :agfs_lgfs_admin)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@admin.user, 'password')
+  sign_in(@admin.user, 'password1234')
 end
 
 Given(/^I am a signed in case worker$/) do
   @case_worker = @current_user = create(:case_worker)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@case_worker.user, 'password')
+  sign_in(@case_worker.user, 'password1234')
 end
 
 Given(/^I am signed in as the case worker$/) do
@@ -118,11 +118,11 @@ When(/^I sign in as the case worker$/) do
 end
 
 When(/^I attempt to sign in again as the deleted caseworker$/) do
-  sign_in(@case_worker.user, 'password')
+  sign_in(@case_worker.user, 'password1234')
 end
 
 When(/^I attempt to sign in again as the advocate$/) do
-  sign_in(@advocate.user, 'password')
+  sign_in(@advocate.user, 'password1234')
 end
 
 Given('a case worker admin user account exists') do
@@ -130,23 +130,23 @@ Given('a case worker admin user account exists') do
 end
 
 When('I sign in as the case worker admin') do
-  sign_in(@case_worker.user, 'password')
+  sign_in(@case_worker.user, 'password1234')
 end
 
 Given(/^I am a signed in case worker admin$/) do
   @case_worker = create(:case_worker, :admin)
-  sign_in(@case_worker.user, 'password')
+  sign_in(@case_worker.user, 'password1234')
 end
 
 Given(/^I am a signed in case worker provider manager$/) do
   @case_worker = create(:case_worker, :provider_manager)
-  sign_in(@case_worker.user, 'password')
+  sign_in(@case_worker.user, 'password1234')
 end
 
 Given(/^I am a signed in super admin$/) do
   make_accounts('super admin')
   visit new_user_session_path
-  sign_in(@super_admin.user, 'password')
+  sign_in(@super_admin.user, 'password1234')
 end
 
 Then(/^I should see an Manage advocates link and it should work$/) do

--- a/features/users/user_signup_on_api_sandbox.feature
+++ b/features/users/user_signup_on_api_sandbox.feature
@@ -23,8 +23,8 @@ Feature: User signup on api-sandbox
     Then I fill in 'First name' with 'Jim'
     And I fill in 'Last name' with 'Bob'
     And I fill in 'Email' with 'jim.bob@example.com'
-    And I fill in 'Password' with 'my-password'
-    And I fill in 'Password confirmation' with 'my-password'
+    And I fill in 'Password' with 'password1234'
+    And I fill in 'Password confirmation' with 'password1234'
     And I click the button 'Sign up'
 
     Then My new claim should be displayed

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -146,13 +146,13 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController do
 
   describe 'PUT #update_password' do
     before do
-      subject.user.update(password: 'password', password_confirmation: 'password')
+      subject.user.update(password: 'password1234', password_confirmation: 'password1234')
       sign_in subject.user # need to sign in again after password change
     end
 
     context 'when valid' do
       before do
-        put :update_password, params: { id: subject, case_worker: { user_attributes: { current_password: 'password', password: 'password123', password_confirmation: 'password123' } } }
+        put :update_password, params: { id: subject, case_worker: { user_attributes: { current_password: 'password1234', password: 'password5678', password_confirmation: 'password5678' } } }
       end
 
       it 'redirects to case_worker show action' do

--- a/spec/controllers/external_users/admin/external_users_controller_spec.rb
+++ b/spec/controllers/external_users/admin/external_users_controller_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
             external_user: {
               user_attributes: {
                 email: 'foo@foobar.com',
-                password: 'password',
-                password_confirmation: 'password',
+                password: 'password1234',
+                password_confirmation: 'password1234',
                 first_name: 'John',
                 last_name: 'Smith',
                 email_notification_of_message: 'true'
@@ -124,7 +124,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
           params = {
             external_user: {
               user_attributes: {
-                email: 'foo@foobar.com', password: 'password', password_confirmation: 'password', first_name: 'John', last_name: 'Smith'
+                email: 'foo@foobar.com', password: 'password1234', password_confirmation: 'password1234', first_name: 'John', last_name: 'Smith'
               },
               roles: ['advocate'],
               supplier_number: 'XY123'
@@ -138,7 +138,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
           params = {
             external_user: {
               user_attributes: {
-                email: 'foo@foobar.com', password: 'password', password_confirmation: 'password', first_name: 'John', last_name: 'Smith'
+                email: 'foo@foobar.com', password: 'password1234', password_confirmation: 'password1234', first_name: 'John', last_name: 'Smith'
               },
               roles: ['advocate'],
               supplier_number: 'XY123'
@@ -154,7 +154,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
           expect {
             post :create,
                  params: { external_user: {
-                   user_attributes: { email: 'foo@foobar.com', password: 'password',
+                   user_attributes: { email: 'foo@foobar.com', password: 'password1234',
                                       password_confirmation: 'xxx' }, roles: ['advocate']
                  } }
           }.to_not change(User, :count)
@@ -163,7 +163,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
         it 'renders the new template' do
           post :create,
                params: { external_user: {
-                 user_attributes: { email: 'foo@foobar.com', password: 'password',
+                 user_attributes: { email: 'foo@foobar.com', password: 'password1234',
                                     password_confirmation: 'xxx' }, roles: ['advocate']
                } }
           expect(response).to render_template(:new)
@@ -200,7 +200,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
 
     describe 'PUT #update_password' do
       before do
-        subject.user.update(password: 'password', password_confirmation: 'password')
+        subject.user.update(password: 'password1234', password_confirmation: 'password1234')
         sign_in subject.user # need to sign in again after password change
       end
 
@@ -208,12 +208,12 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
         before do
           put :update_password,
               params: { id: subject,
-                        external_user: { user_attributes: { current_password: 'password', password: 'password123',
-                                                            password_confirmation: 'password123' } } }
+                        external_user: { user_attributes: { current_password: 'password1234', password: 'password5678',
+                                                            password_confirmation: 'password5678' } } }
         end
 
         it 'redirects to external_user show action' do
-          # put :update_password, id: external_user, external_user: { user_attributes: { current_password: 'password', password: 'password123', password_confirmation: 'password123' } }
+          # put :update_password, id: external_user, external_user: { user_attributes: { current_password: 'password1234', password: 'password5678', password_confirmation: 'password5678' } }
           expect(response).to redirect_to(external_users_admin_external_user_path(subject))
         end
       end
@@ -302,7 +302,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
       it 'redirects to all claims page with Unauthorised in flash' do
         post :create,
              params: { external_user: {
-               user_attributes: { email: 'foo@foobar.com', password: 'password',
+               user_attributes: { email: 'foo@foobar.com', password: 'password1234',
                                   password_confirmation: 'xxx' }, roles: ['advocate']
              } }
         expect(response).to redirect_to(external_users_root_path)

--- a/spec/controllers/super_admins/admin/super_admins_controller_spec.rb
+++ b/spec/controllers/super_admins/admin/super_admins_controller_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe SuperAdmins::Admin::SuperAdminsController do
 
   describe 'PUT #update_password' do
     before do
-      subject.user.update(password: 'password', password_confirmation: 'password')
+      subject.user.update(password: 'password1234', password_confirmation: 'password1234')
       sign_in subject.user # need to sign in again after password change
     end
 
     context 'when valid' do
-      before { put :update_password, params: { id: subject, super_admin: { user_attributes: { current_password: 'password', password: 'password123', password_confirmation: 'password123' } } } }
+      before { put :update_password, params: { id: subject, super_admin: { user_attributes: { current_password: 'password1234', password: 'password5678', password_confirmation: 'password5678' } } } }
 
       it 'redirects to super admin show action' do
         expect(response).to redirect_to(super_admins_admin_super_admin_path(subject))
@@ -83,7 +83,7 @@ RSpec.describe SuperAdmins::Admin::SuperAdminsController do
 
   describe 'PUT #update' do
     before do
-      put :update, params: { id: subject, super_admin: { user_attributes: { first_name: 'Joshua', last_name: 'Dude', password: 'password', email: 'superadmin@bigblackhhole.com' } } }
+      put :update, params: { id: subject, super_admin: { user_attributes: { first_name: 'Joshua', last_name: 'Dude', password: 'password1234', email: 'superadmin@bigblackhhole.com' } } }
     end
 
     context 'when valid' do

--- a/spec/factories/case_workers.rb
+++ b/spec/factories/case_workers.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
 
     after(:build) do |case_worker, evaluator|
       if evaluator.build_user
-        case_worker.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, password: 'password', password_confirmation: 'password')
+        case_worker.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, password: 'password1234', password_confirmation: 'password1234')
         case_worker.user.email = "#{case_worker.first_name}.#{case_worker.last_name}@laa.gov.uk"
       end
     end

--- a/spec/factories/external_users.rb
+++ b/spec/factories/external_users.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
 
     after(:build) do |eu, evaluator|
       if evaluator.build_user
-        eu.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'password', password_confirmation: 'password')
+        eu.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'password1234', password_confirmation: 'password1234')
       end
     end
 

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     claim
 
     after(:build) do |message|
-      message.sender_id ||= (message.sender || create(:user, email: Faker::Internet.unique.email, password: 'password', password_confirmation: 'password')).id
+      message.sender_id ||= (message.sender || create(:user, email: Faker::Internet.unique.email, password: 'password1234', password_confirmation: 'password1234')).id
     end
   end
 

--- a/spec/factories/super_admins.rb
+++ b/spec/factories/super_admins.rb
@@ -10,7 +10,7 @@
 FactoryBot.define do
   factory :super_admin do
     after(:build) do |super_admin|
-      super_admin.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'password', password_confirmation: 'password')
+      super_admin.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'password1234', password_confirmation: 'password1234')
     end
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -30,8 +30,8 @@
 FactoryBot.define do
   factory :user do
     email { Faker::Internet.unique.email }
-    password { 'testing123' }
-    password_confirmation { 'testing123' }
+    password { 'testing12345' }
+    password_confirmation { 'testing12345' }
     first_name { Faker::Name.first_name }
     last_name { Faker::Name.last_name }
     api_key { SecureRandom.uuid }

--- a/spec/lib/utils/account_setter_spec.rb
+++ b/spec/lib/utils/account_setter_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Utils::AccountSetter do
 
   let(:emails) { [email] }
   let(:email) { 'test@example.com' }
-  let(:user) { create(:user, id: 99, email: 'test@example.com', password: 'testing123') }
+  let(:user) { create(:user, id: 99, email: 'test@example.com', password: 'testing12345') }
 
   before { allow($stdout).to receive(:puts) }
 
@@ -191,7 +191,7 @@ RSpec.describe Utils::AccountSetter do
     subject(:change_password) { instance.change_password }
 
     it 'changes the password of the user' do
-      expect { change_password }.to change { user.reload.valid_password?('testing123') }.from(true).to(false)
+      expect { change_password }.to change { user.reload.valid_password?('testing12345') }.from(true).to(false)
     end
 
     context 'with an unknown user' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User do
   it { is_expected.to validate_length_of(:email).is_at_most(80).with_message('Email must be 80 characters or less') }
   it { is_expected.to allow_value('email@addresse.foo').for(:email) }
   it { is_expected.not_to allow_value('foo').for(:email) }
-  it { is_expected.to validate_length_of(:password).is_at_least(8).with_message('Password must be at least 8 characters') }
+  it { is_expected.to validate_length_of(:password).is_at_least(12).with_message('Password must be at least 12 characters') }
 
   context 'with terms_and_conditions_required: false' do
     before { user.terms_and_conditions_required = false }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe User do
   it { is_expected.to validate_length_of(:email).is_at_most(80).with_message('Email must be 80 characters or less') }
   it { is_expected.to allow_value('email@addresse.foo').for(:email) }
   it { is_expected.not_to allow_value('foo').for(:email) }
-  it { is_expected.to validate_length_of(:password).is_at_least(12).with_message('Password must be at least 12 characters') }
+  it { is_expected.to validate_length_of(:password).is_at_least(12).with_message('must be at least 12 characters') }
 
   context 'with terms_and_conditions_required: false' do
     before { user.terms_and_conditions_required = false }

--- a/spec/requests/case_workers/admin/case_workers_spec.rb
+++ b/spec/requests/case_workers/admin/case_workers_spec.rb
@@ -15,8 +15,8 @@ RSpec.describe 'Caseworker admin' do
           case_worker: {
             user_attributes: {
               email: 'foo@foobar.com',
-              password: 'password',
-              password_confirmation: 'password',
+              password: 'testing12345',
+              password_confirmation: 'testing12345',
               first_name: 'John',
               last_name: 'Smith'
             },

--- a/spec/requests/provider_management/external_users_spec.rb
+++ b/spec/requests/provider_management/external_users_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe 'providers external users management' do
     let(:user) { create(:case_worker, :provider_manager).user }
     let(:external_user) { create(:external_user) }
 
-    let(:password) { 'password123' }
+    let(:password) { 'password1234' }
     let(:password_confirm) { password }
 
     before do


### PR DESCRIPTION
#### What
This PR changes the character limit for passwords to 12 - 64 characters following NIST guidelines, and introduces some UI changes to provide advice to users when setting new passwords

#### Ticket

[CTSKF-1223](https://dsdmoj.atlassian.net/browse/CTSKF-1223)

#### Why

Increase security of CCCD password policy in preparation for rotation of all CCCD passwords


[CTSKF-1223]: https://dsdmoj.atlassian.net/browse/CTSKF-1223?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ