### PR TITLE
Fix version of rspec-mocks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -110,7 +110,10 @@ group :test do
   gem 'launchy', '~> 3.1.1'
   gem 'rails-controller-testing'
   gem 'rspec-html-matchers', '~> 0.10.0'
-  gem 'rspec-mocks'
+  # There is a bug in rspec-mocks regarding `allow_any_instance_of` that some
+  # of our tests depend on and was fixed in version 3.13.3 of rspec-mocks (see
+  # https://github.com/rspec/rspec-mocks/pull/1596)
+  gem 'rspec-mocks', '<= 3.13.2'
   gem 'shoulda-matchers', '~> 6.5'
   gem 'simplecov', require: false
   gem 'timecop'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -824,7 +824,7 @@ DEPENDENCIES
   remotipart (~> 1.4)
   rspec-collection_matchers
   rspec-html-matchers (~> 0.10.0)
-  rspec-mocks
+  rspec-mocks (<= 3.13.2)
   rspec-rails (~> 7.1.1)
   rspec_junit_formatter
   rubocop (~> 1.75)


### PR DESCRIPTION
#### What

Prevent rspec-mocks from upgrading.

#### Ticket

N/A

#### Why

Version 3.13.3 of the `rspec-mocks` fixes a bug that some of our tests depend on. A longer term solution is to refactor our tests but for the moment the gem is pinned.

See https://github.com/rspec/rspec-mocks/pull/1596 and #8594

#### How

Pin the version of the gem in `Gemfile`.