### PR TITLE
Update the frequency of the injection response job

### DIFF
--- a/config/sidekiq.yml
+++ b/config/sidekiq.yml
@@ -17,7 +17,7 @@ production:
 :scheduler:
   :schedule:
     poll_injection_responses:
-      cron: '0/30 * * * * *'
+      cron: '0/10 * * * * *'
       class: Schedule::PollInjectionResponses
     document_cleaner:
       cron: '0 0 4 * * *'


### PR DESCRIPTION
#### What

Run the job 6 times every minute instead of just twice.

#### Ticket

N/A

#### Why

When a large number of claim injections happen over a short period the response queue can build up and then take a long time to clear.

#### How

Set the schedule in Sidekiq scheduler.