### PR TITLE
Update footer to use the new component 

### DIFF
--- a/app/views/grape_swagger_rails/application/index.html.haml
+++ b/app/views/grape_swagger_rails/application/index.html.haml
@@ -97,42 +97,14 @@
 
         = yield
 
-    -# = render partial: 'layouts/footer'
     -# renderd partial err: undefined local variable or method `contact_us_page_path'
-    %footer.govuk-footer
-      .govuk-width-container
-        .govuk-footer__meta
-          .govuk-footer__meta-item.govuk-footer__meta-item--grow
-            %h2.govuk-visually-hidden
-              = t('layouts.footer.support_link')
 
-            %ul.govuk-footer__inline-list
-              %li.govuk-footer__inline-list-item
-                = govuk_footer_link_to t('layouts.footer.cookies'), 'http://www.gov.uk/help/cookies'
+    - meta_items = [{ text:  t('layouts.footer.cookies'), href: 'http://www.gov.uk/help/cookies', },
+    { text: t('layouts.footer.contact'), href: '/contact_us', },
+    { text: t('layouts.footer.accessibility'), href: 'accessibility-statement', },
+    { text: t('layouts.footer.terms_and_conditions'), href: 'tandcs' },
+    { text: t('layouts.footer.terms_and_conditions'), href:  '/feedback/new'},
+    { text: t('layouts.footer.service_owner_html'),  href: 'https://mojdigital.blog.gov.uk/'},
+    ]
 
-              %li.govuk-footer__inline-list-item
-                = govuk_footer_link_to t('layouts.footer.contact'), '/contact_us'
-
-              %li.govuk-footer__inline-list-item
-                = govuk_footer_link_to t('layouts.footer.accessibility'), 'accessibility-statement'
-
-              %li.govuk-footer__inline-list-item
-                = govuk_footer_link_to t('layouts.footer.terms_and_conditions'), 'tandcs'
-
-              %li.govuk-footer__inline-list-item
-                = govuk_footer_link_to t('layouts.footer.feedback'), '/feedback/new'
-
-              %li.govuk-footer__inline-list-item
-                = t('layouts.footer.service_owner_html', link: 'https://mojdigital.blog.gov.uk/')
-
-            %svg.govuk-footer__licence-logo{ focusable: 'false', height: '17', 'aria-hidden': 'true', viewbox: '0 0 483.2 195.7', width: '41', xmlns: 'http://www.w3.org/2000/svg' }
-              %path{ d: 'M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145', fill: 'currentColor' }
-
-            %span.govuk-footer__licence-description
-              = t('layouts.footer.licence_html')
-
-          .govuk-footer__meta-item
-            %a.govuk-footer__link.govuk-footer__copyright-logo{ href: 'https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/' }
-              = t('layouts.footer.copyright_html')
-
-    = javascript_include_tag 'adp_swagger_application', defer: true
+  = govuk_footer(meta_items_title: t('layouts.footer.support_link'), meta_items: meta_items)

--- a/app/views/layouts/_footer.html.haml
+++ b/app/views/layouts/_footer.html.haml
@@ -1,38 +1,10 @@
-%footer.govuk-footer
-  .govuk-width-container
-    .govuk-footer__meta
-      .govuk-footer__meta-item.govuk-footer__meta-item--grow
-        %h2.govuk-visually-hidden
-          = t('.support_link')
+- meta_items = [{ text: t('.cookies'), href: cookies_path, },
+    { text: t('.contact'), href: contact_us_page_path, },
+    { text: t('.accessibility'), href: accessibility_statement_path, },
+    { text: t('.terms_and_conditions'), href: tandcs_page_path },
+    { text: t('.feedback'), href:  new_feedback_path},
+    { text: t('.research'), href: Settings.research_panel_url},
+    { text: t('.service_owner_html'),  href: 'https://mojdigital.blog.gov.uk/'},
+    ]
 
-        %ul.govuk-footer__inline-list
-          %li.govuk-footer__inline-list-item
-            = govuk_footer_link_to t('.cookies'), cookies_path
-
-          %li.govuk-footer__inline-list-item
-            = govuk_footer_link_to t('.contact'), contact_us_page_path
-
-          %li.govuk-footer__inline-list-item
-            = govuk_footer_link_to t('.accessibility'), accessibility_statement_path
-
-          %li.govuk-footer__inline-list-item
-            = govuk_footer_link_to t('.terms_and_conditions'), tandcs_page_path
-
-          %li.govuk-footer__inline-list-item
-            = govuk_footer_link_to t('.feedback'), new_feedback_path
-
-          %li.govuk-footer__inline-list-item
-            = govuk_footer_link_to t('.research'), Settings.research_panel_url
-
-          %li.govuk-footer__inline-list-item
-            = t('.service_owner_html', link: 'https://mojdigital.blog.gov.uk/')
-
-        %svg.govuk-footer__licence-logo{ focusable: 'false', height: '17', 'aria-hidden': 'true', viewbox: '0 0 483.2 195.7', width: '41', xmlns: 'http://www.w3.org/2000/svg' }
-          %path{ d: 'M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145', fill: 'currentColor' }
-
-        %span.govuk-footer__licence-description
-          = t('.licence_html')
-
-      .govuk-footer__meta-item
-        %a.govuk-footer__link.govuk-footer__copyright-logo{ href: 'https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/' }
-          = t('.copyright_html')
+= govuk_footer(meta_items_title: t('.support_link'), meta_items: meta_items)

--- a/config/locales/en/views/layouts.yml
+++ b/config/locales/en/views/layouts.yml
@@ -23,7 +23,7 @@ en:
       feedback: Feedback
       licence_html: All content is available under the <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
       research: Join our research panel
-      service_owner_html: <span>Built by</span> <a class="govuk-footer__link" href="%{link}"><abbr title="Ministry of Justice">MOJ Digital Services</abbr></a>
+      service_owner_html: Built by <abbr title="Ministry of Justice">MOJ Digital Services</abbr>
       support_link: Support links
       terms_and_conditions: Terms and Conditions
 

--- a/lib/govuk_component/link_helpers.rb
+++ b/lib/govuk_component/link_helpers.rb
@@ -7,11 +7,6 @@ module GovukComponent
       link_to body, url, **tag_options
     end
 
-    def govuk_footer_link_to(body = nil, url = nil, tag_options = {})
-      tag_options = prepend_classes('govuk-footer__link', tag_options)
-      link_to body, url, **tag_options
-    end
-
     def govuk_header_link_to(body = nil, url = nil, tag_options = {})
       tag_options = prepend_classes('govuk-header__link', tag_options)
       link_to body, url, **tag_options

--- a/spec/lib/govuk_component/link_helpers_spec.rb
+++ b/spec/lib/govuk_component/link_helpers_spec.rb
@@ -23,26 +23,6 @@ RSpec.describe GovukComponent::LinkHelpers, type: :helper do
     end
   end
 
-  describe '#govuk_footer_link_to' do
-    subject(:markup) { helper.govuk_footer_link_to(*args) }
-
-    context 'default component' do
-      let(:args) { ['GovUK', 'https://www.gov.uk'] }
-
-      it 'adds link with govuk class' do
-        is_expected.to have_tag(:a, with: { class: 'govuk-footer__link', href: 'https://www.gov.uk' }, text: 'GovUK')
-      end
-    end
-
-    context 'with a custom class' do
-      let(:args) { ['GovUK', 'https://www.gov.uk', { class: 'my-custom-class1 my-custom-class2' }] }
-
-      it 'adds link with custom classes, prepended by govuk class' do
-        is_expected.to have_tag(:a, with: { class: 'govuk-footer__link my-custom-class1 my-custom-class2' })
-      end
-    end
-  end
-
   describe '#govuk_header_link_to' do
     subject(:markup) { helper.govuk_header_link_to(*args) }
 


### PR DESCRIPTION
#### What
This PR updates the customised footer helper method with the govuk-components gem footer method

#### Ticket

[CCCD: Adopt govuk-components gem for footer](https://dsdmoj.atlassian.net/browse/CTSKF-1065)

#### Why

We can use the govuk-components gem to simplify the CCCD codebase and improve maintainability of the application.

#### How

It updates `app/views/layouts/_footer.html.haml` and `app/views/grape_swagger_rails/application/index.html.haml` separately.  For some reason in the index it uses hard coded urls instead of ruby generated ones. It also doesn't contain a research link. So unfortunately it can't be reused. 

It uses the [footer with meta links that have custom HTML attributes](https://govuk-components.netlify.app/components/footer/#footer-with-meta-links-that-have-custom-html-attributes) that allow you to add the href links to a meta_items 

#### Issues
In the original footnote the 'Build by' is not part of the link so not underlined.  
<img width="212" alt="Screenshot 2025-06-06 at 14 04 38" src="https://github.com/user-attachments/assets/9cf61a75-a114-453d-9323-448a23c37b76" />

However in the current updated version it is all underlined as a href link.  I couldn't find an option in the component to allow only parts of the text to be underlined. 

I tried removing the href link from the meta data table and having the link solely in transaction file but that caused an error. 

```service_owner_html: <span>Built by</span> <a href="https://mojdigital.blog.gov.uk/"><abbr title="Ministry of Justice">MOJ Digital Services</abbr></a>```

```- meta_items = [{ text: t('.cookies'), href: cookies_path, },
    { text: t('.contact'), href: contact_us_page_path, },
    { text: t('.accessibility'), href: accessibility_statement_path, },
    { text: t('.terms_and_conditions'), href: tandcs_page_path },
    { text: t('.feedback'), href:  new_feedback_path},
    { text: t('.research'), href: Settings.research_panel_url},
    { text: t('.service_owner_html'),  REMOVE LINK HERE},
    ]
```

```controller` can't be used during initialization```

So it expects to see this href link when the component is initialized. So I am not sure the best way to get around this. 

