### PR TITLE
Remove reviewers fields from dependabot.yml

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @ministryofjustice/laa-claim-for-payment @ministryofjustice/laa-clair-taskforce
+* @ministryofjustice/laa-clair-taskforce

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -21,8 +21,6 @@ updates:
   open-pull-requests-limit: 10
   allow:
     - dependency-type: "all"
-  reviewers:
-  - "ministryofjustice/laa-claim-for-payment"
 - package-ecosystem: bundler
   directory: "/"
   schedule:
@@ -62,10 +60,6 @@ updates:
     - dependency-name: "action*"
       versions:
         - ">= 7.1"
-  reviewers:
-  - "mpw5"
-  - "jrmhaig"
-  - "ministryofjustice/laa-claim-for-payment"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -77,5 +71,3 @@ updates:
   rebase-strategy: "disabled"
   allow:
     - dependency-type: "all"
-  reviewers:
-  - "ministryofjustice/laa-claim-for-payment"


### PR DESCRIPTION
#### What

Updates `.github/dependabot.yml` and `.github/CODEOWNERS`

#### Why

Dependabot PRs are being annotated with the following comment:

```
The reviewers field in the dependabot.yml file will be removed soon.
Please use the code owners file to specify reviewers for Dependabot PRs
```

#### How

* Deletes `reviewers` fields from `.github/dependabot.yml`
* Updates `.github/CODEOWNERS` to remove reference to the old `laa-claim-for-payment` github team.