### PR TITLE
Fix CircleCI test splitting

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -191,13 +191,12 @@ commands:
           name: Run rspec tests
           command: |
             tmp/cc-test-reporter before-build
-            TESTFILES=$(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings --timings-type=filename)
-
-            bundle exec rspec --format progress \
-            --format RspecJunitFormatter \
-            -o /tmp/test-results/rspec/rspec.xml \
-            -- ${TESTFILES}
-
+            circleci tests glob "spec/**/*_spec.rb" | circleci tests run --command="xargs bundle exec rspec \
+                                                                                            --format progress \
+                                                                                            --format RspecJunitFormatter \
+                                                                                            --out /tmp/test-results/rspec/rspec.xml" \
+                                                                         --split-by=timings \
+                                                                         --timings-type=file
             tmp/cc-test-reporter format-coverage -t simplecov -o "tmp/coverage/codeclimate.$CIRCLE_NODE_INDEX.json"
       - persist_to_workspace:
           root: tmp
@@ -222,7 +221,7 @@ commands:
                                                       --format junit,fileattribute=true \
                                                       --out /tmp/test-results/cucumber" \
                                    --split-by=timings \
-                                   --timings-type=filename
+                                   --timings-type=file
       - store_artifacts:
           path: tmp/capybara
       - store_test_results:


### PR DESCRIPTION
#### What

Cucumber tests have started to fail on CircleCI with the error

<img width="745" alt="image" src="https://github.com/user-attachments/assets/538dcef1-b30d-4a53-904d-ff4486ef0173" />

It appears that `filename` is no longer a valid timing type when executing `circleci tests run`. This commit replaces it with the valid `file`.

Additionally, rspec tests were still being run using `circleci tests split` which has now been superseded by `circleci tests run`. This change updates the command so it is consistent with the Cucumber test suite, and replaces
`filename` with `file`.