### PR TITLE
Fix deprecation warning

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -12,7 +12,7 @@ module Claim
 
     auto_strip_attributes :case_number, :cms_number, :supplier_number, squish: true, nullify: true
 
-    serialize :evidence_checklist_ids, Array
+    serialize :evidence_checklist_ids, type: Array
 
     attr_reader :form_step
     alias current_step form_step

--- a/app/models/claim_state_transition.rb
+++ b/app/models/claim_state_transition.rb
@@ -20,7 +20,7 @@ class ClaimStateTransition < ApplicationRecord
   belongs_to :author, class_name: 'User'
   belongs_to :subject, class_name: 'User'
 
-  serialize :reason_code, Array
+  serialize :reason_code, type: Array
   alias_attribute :reason_codes, :reason_code
 
   def reason

--- a/app/models/concerns/roles.rb
+++ b/app/models/concerns/roles.rb
@@ -3,7 +3,7 @@ module Roles
 
   included do |klass|
     klass.extend(ClassMethods)
-    klass.serialize :roles, Array
+    klass.serialize :roles, type: Array
     klass.before_validation :strip_empty_role
     klass.validate :roles_valid
 


### PR DESCRIPTION
#### What

Remove some deprecation warnings after upgrading to Rails 7.1.

#### Ticket

N/A

#### Why

After upgrading to Rails 7.1 `ActiveRecord::Base#serialize` takes a keyword argument for the type (or coder) instead of a positional arguments. A positional argument results in a deprecation warning and from Rails 7.2 onwards this will not work.

#### How

Change the second positional argument with keyward arguments on `serialize` calls in three places.