### PR TITLE
Update the laa-cda gem

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/ministryofjustice/laa-cda
-  revision: 0eac32d79feb474cb99f12769e0a46abca3ceeef
+  revision: ef5912030863dd354ac4f207b7e5dd8a815184de
   specs:
     laa-cda (0.0.1)
       faraday (~> 2.0)
@@ -444,13 +444,14 @@ GEM
       racc (~> 1.4)
     notifications-ruby-client (6.2.0)
       jwt (>= 1.5, < 3)
-    oauth2 (2.0.9)
-      faraday (>= 0.17.3, < 3.0)
-      jwt (>= 1.0, < 3.0)
+    oauth2 (2.0.12)
+      faraday (>= 0.17.3, < 4.0)
+      jwt (>= 1.0, < 4.0)
+      logger (~> 1.2)
       multi_xml (~> 0.5)
       rack (>= 1.2, < 4)
-      snaky_hash (~> 2.0)
-      version_gem (~> 1.1)
+      snaky_hash (~> 2.0, >= 2.0.3)
+      version_gem (>= 1.1.8, < 3)
     orm_adapter (0.5.0)
     ostruct (0.6.1)
     pagy (9.3.4)
@@ -666,9 +667,9 @@ GEM
       capybara (~> 3.34)
       site_prism-all_there (> 3, < 5)
     site_prism-all_there (3.0.6)
-    snaky_hash (2.0.1)
-      hashie
-      version_gem (~> 1.1, >= 1.1.1)
+    snaky_hash (2.0.3)
+      hashie (>= 0.1.0, < 6)
+      version_gem (>= 1.1.8, < 3)
     sprockets (4.2.2)
       concurrent-ruby (~> 1.0)
       logger
@@ -712,7 +713,7 @@ GEM
       activesupport
     vcr (6.3.1)
       base64
-    version_gem (1.1.7)
+    version_gem (1.1.8)
     view_component (3.23.2)
       activesupport (>= 5.2.0, < 8.1)
       concurrent-ruby (~> 1)


### PR DESCRIPTION
#### What

Update the laa-cda gem.

#### Ticket

N/A

#### Why

Requests are sent to CDA to search Common Platform using GET requests with URL parameters and these appear in the CDA logs. A POST endpoint has now been added so that search parameters can be added to the message body, which will prevent possibly PII data being stored in logs.

#### How

See https://github.com/ministryofjustice/laa-cda/pull/1