### PR TITLE
Ignore brakeman warning about Rails 7.1.5.1

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,6 +24,25 @@
       "note": ""
     },
     {
+      "warning_type": "Unmaintained Dependency",
+      "warning_code": 122,
+      "fingerprint": "21ab0fe00fdd5899ffc405cff75aadb91b805ee996a614f7e27b08a287e9062d",
+      "check_name": "EOLRails",
+      "message": "Support for Rails 7.1.5.1 ends on 2025-10-01",
+      "file": "Gemfile.lock",
+      "line": 507,
+      "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
+      "code": null,
+      "render_path": null,
+      "location": null,
+      "user_input": null,
+      "confidence": "Weak",
+      "cwe_id": [
+        1104
+      ],
+      "note": ""
+    },
+    {
       "warning_type": "Dangerous Eval",
       "warning_code": 13,
       "fingerprint": "2a4d5faf318702c8de64c418639d03c968e5523a3defd514bed34442b326ed7c",


### PR DESCRIPTION
#### What

Ignore brakeman warning about Rails 7.1.5.1

#### Why

Brakeman is failing due to a new warning about the end of Rails 7.1.5.1 support on 2025-10-01. We have plans to upgrade to 7.2 before then, so all this warning is achieving is blocking our deployment pipeline.

#### How

Adds the warning to the `brakeman.ignore` file 