### PR TITLE
Remove Determination#present?

### DIFF
--- a/app/models/determination.rb
+++ b/app/models/determination.rb
@@ -52,10 +52,6 @@ class Determination < ApplicationRecord
     blank?
   end
 
-  def present?
-    !blank?
-  end
-
   private
 
   def fees_valid


### PR DESCRIPTION
Determination#present? used to be used to find the last redetermination of a claim. This was removed in:

  https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/commit/7947c07c9b05d91f0eddbb161ac2aa6db23612a7

#### What

#### Ticket

[board ticket description](link)

#### Why

#### How

--------

#### TODO (wip)

 - [ ] item 1
 - [X] item 2
