### PR TITLE
CTSKF-1145 Set `marshalling_format_version` to `7.1`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -207,7 +207,7 @@ Rails.application.config.active_record.before_committed_on_all_records = true
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-# Rails.application.config.active_record.marshalling_format_version = 7.1
+Rails.application.config.active_record.marshalling_format_version = 7.1
 
 ###
 # Run `after_commit` and `after_*_commit` callbacks in the order they are defined in a model.


### PR DESCRIPTION
#### What

Set `marshalling_format_version` to `7.1`

#### Ticket

[CTSKF-1145](https://dsdmoj.atlassian.net/browse/CTSKF-1145)

#### Why

To continue to upgrade to v7.1 of rails

#### How

Enable the setting in `config/initializers/new_framework_defaults_7_1.rb`

[CTSKF-1145]: https://dsdmoj.atlassian.net/browse/CTSKF-1145?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ