### PR TITLE
[CTSKF-1141] Set `belongs_to_required_validates_foreign_key` to `false`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -175,7 +175,7 @@ end
 # The previous behavior was to validate the presence of the parent record, which performed an extra query
 # to get the parent every time the child record was updated, even when parent has not changed.
 #++
-# Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
+Rails.application.config.active_record.belongs_to_required_validates_foreign_key = false
 
 ###
 # Enable precompilation of `config.filter_parameters`. Precompilation can


### PR DESCRIPTION
#### What

Set `belongs_to_required_validates_foreign_key` to `false`

#### Ticket

[CTSKF-1141](https://dsdmoj.atlassian.net/browse/CTSKF-1141)

#### Why

To continue to upgrade to v7.1 of rails

#### How

Enable the setting in `config/initializers/new_framework_defaults_7_1.rb`

[CTSKF-1141]: https://dsdmoj.atlassian.net/browse/CTSKF-1141?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ