### PR TITLE
Change the test test password

### DIFF
--- a/features/step_definitions/caseworker_claim_allocation_steps.rb
+++ b/features/step_definitions/caseworker_claim_allocation_steps.rb
@@ -1,5 +1,5 @@
 Given(/^case worker "(.*?)" exists$/) do |name|
-  @password = "password1234"
+  @password = "PasswordForTest"
   first_name = name.split.first
   last_name = name.split.last
   @case_worker_user = create(:user, first_name: first_name, last_name: last_name,

--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -1,5 +1,5 @@
 def make_accounts(role, number = 1)
-  @password = 'password1234'
+  @password = 'PasswordForTest'
   case role
     when 'advocate'
       @advocates = create_list(:external_user, number)
@@ -43,7 +43,7 @@ Given(/^I am a signed in advocate$/) do
   @advocate = @current_user = create(:external_user, :advocate)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@advocate.user, 'password1234')
+  sign_in(@advocate.user, 'PasswordForTest')
 end
 
 Given('I am a signed in advocate with final claim {string}') do |case_number|
@@ -51,7 +51,7 @@ Given('I am a signed in advocate with final claim {string}') do |case_number|
   create(:advocate_claim, creator: @advocate, external_user: @advocate, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@advocate.user, 'password1234')
+  sign_in(@advocate.user, 'PasswordForTest')
 end
 
 Given('I am a signed in advocate with fixed fee claim {string}') do |case_number|
@@ -59,21 +59,21 @@ Given('I am a signed in advocate with fixed fee claim {string}') do |case_number
   create(:advocate_claim, :with_fixed_fee_case, creator: @advocate, external_user: @advocate, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@advocate.user, 'password1234')
+  sign_in(@advocate.user, 'PasswordForTest')
 end
 
 Given(/^I am a signed in advocate admin$/) do
   @advocate = @current_user = create(:external_user, :advocate_and_admin)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@advocate.user, 'password1234')
+  sign_in(@advocate.user, 'PasswordForTest')
 end
 
 Given(/^I am a signed in litigator$/) do
   @litigator = @current_user = create(:external_user, :litigator)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@litigator.user, 'password1234')
+  sign_in(@litigator.user, 'PasswordForTest')
 end
 
 Given('I am a signed in litigator with final claim {string}') do |case_number|
@@ -81,28 +81,28 @@ Given('I am a signed in litigator with final claim {string}') do |case_number|
   create(:litigator_claim, creator: @litigator, external_user: @litigator, case_number: case_number)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@litigator.user, 'password1234')
+  sign_in(@litigator.user, 'PasswordForTest')
 end
 
 Given(/^I am a signed in litigator admin$/) do
   @litigator = @current_user = create(:external_user, :litigator_and_admin)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@litigator.user, 'password1234')
+  sign_in(@litigator.user, 'PasswordForTest')
 end
 
 Given(/^I am a signed in admin for an AGFS and LGFS firm$/) do
   @admin = @current_user = create(:external_user, :agfs_lgfs_admin)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@admin.user, 'password1234')
+  sign_in(@admin.user, 'PasswordForTest')
 end
 
 Given(/^I am a signed in case worker$/) do
   @case_worker = @current_user = create(:case_worker)
   visit new_user_session_path
   switch_to_chrome_window
-  sign_in(@case_worker.user, 'password1234')
+  sign_in(@case_worker.user, 'PasswordForTest')
 end
 
 Given(/^I am signed in as the case worker$/) do
@@ -118,11 +118,11 @@ When(/^I sign in as the case worker$/) do
 end
 
 When(/^I attempt to sign in again as the deleted caseworker$/) do
-  sign_in(@case_worker.user, 'password1234')
+  sign_in(@case_worker.user, 'PasswordForTest')
 end
 
 When(/^I attempt to sign in again as the advocate$/) do
-  sign_in(@advocate.user, 'password1234')
+  sign_in(@advocate.user, 'PasswordForTest')
 end
 
 Given('a case worker admin user account exists') do
@@ -130,23 +130,23 @@ Given('a case worker admin user account exists') do
 end
 
 When('I sign in as the case worker admin') do
-  sign_in(@case_worker.user, 'password1234')
+  sign_in(@case_worker.user, 'PasswordForTest')
 end
 
 Given(/^I am a signed in case worker admin$/) do
   @case_worker = create(:case_worker, :admin)
-  sign_in(@case_worker.user, 'password1234')
+  sign_in(@case_worker.user, 'PasswordForTest')
 end
 
 Given(/^I am a signed in case worker provider manager$/) do
   @case_worker = create(:case_worker, :provider_manager)
-  sign_in(@case_worker.user, 'password1234')
+  sign_in(@case_worker.user, 'PasswordForTest')
 end
 
 Given(/^I am a signed in super admin$/) do
   make_accounts('super admin')
   visit new_user_session_path
-  sign_in(@super_admin.user, 'password1234')
+  sign_in(@super_admin.user, 'PasswordForTest')
 end
 
 Then(/^I should see an Manage advocates link and it should work$/) do

--- a/features/users/user_signup_on_api_sandbox.feature
+++ b/features/users/user_signup_on_api_sandbox.feature
@@ -23,8 +23,8 @@ Feature: User signup on api-sandbox
     Then I fill in 'First name' with 'Jim'
     And I fill in 'Last name' with 'Bob'
     And I fill in 'Email' with 'jim.bob@example.com'
-    And I fill in 'Password' with 'password1234'
-    And I fill in 'Password confirmation' with 'password1234'
+    And I fill in 'Password' with 'PasswordForTest'
+    And I fill in 'Password confirmation' with 'PasswordForTest'
     And I click the button 'Sign up'
 
     Then My new claim should be displayed

--- a/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
+++ b/spec/controllers/case_workers/admin/case_workers_controller_spec.rb
@@ -146,13 +146,13 @@ RSpec.describe CaseWorkers::Admin::CaseWorkersController do
 
   describe 'PUT #update_password' do
     before do
-      subject.user.update(password: 'password1234', password_confirmation: 'password1234')
+      subject.user.update(password: 'PasswordForTest', password_confirmation: 'PasswordForTest')
       sign_in subject.user # need to sign in again after password change
     end
 
     context 'when valid' do
       before do
-        put :update_password, params: { id: subject, case_worker: { user_attributes: { current_password: 'password1234', password: 'password5678', password_confirmation: 'password5678' } } }
+        put :update_password, params: { id: subject, case_worker: { user_attributes: { current_password: 'PasswordForTest', password: 'password5678', password_confirmation: 'password5678' } } }
       end
 
       it 'redirects to case_worker show action' do

--- a/spec/controllers/external_users/admin/external_users_controller_spec.rb
+++ b/spec/controllers/external_users/admin/external_users_controller_spec.rb
@@ -100,8 +100,8 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
             external_user: {
               user_attributes: {
                 email: 'foo@foobar.com',
-                password: 'password1234',
-                password_confirmation: 'password1234',
+                password: 'PasswordForTest',
+                password_confirmation: 'PasswordForTest',
                 first_name: 'John',
                 last_name: 'Smith',
                 email_notification_of_message: 'true'
@@ -124,7 +124,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
           params = {
             external_user: {
               user_attributes: {
-                email: 'foo@foobar.com', password: 'password1234', password_confirmation: 'password1234', first_name: 'John', last_name: 'Smith'
+                email: 'foo@foobar.com', password: 'PasswordForTest', password_confirmation: 'PasswordForTest', first_name: 'John', last_name: 'Smith'
               },
               roles: ['advocate'],
               supplier_number: 'XY123'
@@ -138,7 +138,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
           params = {
             external_user: {
               user_attributes: {
-                email: 'foo@foobar.com', password: 'password1234', password_confirmation: 'password1234', first_name: 'John', last_name: 'Smith'
+                email: 'foo@foobar.com', password: 'PasswordForTest', password_confirmation: 'PasswordForTest', first_name: 'John', last_name: 'Smith'
               },
               roles: ['advocate'],
               supplier_number: 'XY123'
@@ -154,7 +154,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
           expect {
             post :create,
                  params: { external_user: {
-                   user_attributes: { email: 'foo@foobar.com', password: 'password1234',
+                   user_attributes: { email: 'foo@foobar.com', password: 'PasswordForTest',
                                       password_confirmation: 'xxx' }, roles: ['advocate']
                  } }
           }.to_not change(User, :count)
@@ -163,7 +163,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
         it 'renders the new template' do
           post :create,
                params: { external_user: {
-                 user_attributes: { email: 'foo@foobar.com', password: 'password1234',
+                 user_attributes: { email: 'foo@foobar.com', password: 'PasswordForTest',
                                     password_confirmation: 'xxx' }, roles: ['advocate']
                } }
           expect(response).to render_template(:new)
@@ -200,7 +200,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
 
     describe 'PUT #update_password' do
       before do
-        subject.user.update(password: 'password1234', password_confirmation: 'password1234')
+        subject.user.update(password: 'PasswordForTest', password_confirmation: 'PasswordForTest')
         sign_in subject.user # need to sign in again after password change
       end
 
@@ -208,12 +208,12 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
         before do
           put :update_password,
               params: { id: subject,
-                        external_user: { user_attributes: { current_password: 'password1234', password: 'password5678',
+                        external_user: { user_attributes: { current_password: 'PasswordForTest', password: 'password5678',
                                                             password_confirmation: 'password5678' } } }
         end
 
         it 'redirects to external_user show action' do
-          # put :update_password, id: external_user, external_user: { user_attributes: { current_password: 'password1234', password: 'password5678', password_confirmation: 'password5678' } }
+          # put :update_password, id: external_user, external_user: { user_attributes: { current_password: 'PasswordForTest', password: 'password5678', password_confirmation: 'password5678' } }
           expect(response).to redirect_to(external_users_admin_external_user_path(subject))
         end
       end
@@ -302,7 +302,7 @@ RSpec.describe ExternalUsers::Admin::ExternalUsersController do
       it 'redirects to all claims page with Unauthorised in flash' do
         post :create,
              params: { external_user: {
-               user_attributes: { email: 'foo@foobar.com', password: 'password1234',
+               user_attributes: { email: 'foo@foobar.com', password: 'PasswordForTest',
                                   password_confirmation: 'xxx' }, roles: ['advocate']
              } }
         expect(response).to redirect_to(external_users_root_path)

--- a/spec/controllers/super_admins/admin/super_admins_controller_spec.rb
+++ b/spec/controllers/super_admins/admin/super_admins_controller_spec.rb
@@ -53,12 +53,12 @@ RSpec.describe SuperAdmins::Admin::SuperAdminsController do
 
   describe 'PUT #update_password' do
     before do
-      subject.user.update(password: 'password1234', password_confirmation: 'password1234')
+      subject.user.update(password: 'PasswordForTest', password_confirmation: 'PasswordForTest')
       sign_in subject.user # need to sign in again after password change
     end
 
     context 'when valid' do
-      before { put :update_password, params: { id: subject, super_admin: { user_attributes: { current_password: 'password1234', password: 'password5678', password_confirmation: 'password5678' } } } }
+      before { put :update_password, params: { id: subject, super_admin: { user_attributes: { current_password: 'PasswordForTest', password: 'password5678', password_confirmation: 'password5678' } } } }
 
       it 'redirects to super admin show action' do
         expect(response).to redirect_to(super_admins_admin_super_admin_path(subject))
@@ -83,7 +83,7 @@ RSpec.describe SuperAdmins::Admin::SuperAdminsController do
 
   describe 'PUT #update' do
     before do
-      put :update, params: { id: subject, super_admin: { user_attributes: { first_name: 'Joshua', last_name: 'Dude', password: 'password1234', email: 'superadmin@bigblackhhole.com' } } }
+      put :update, params: { id: subject, super_admin: { user_attributes: { first_name: 'Joshua', last_name: 'Dude', password: 'PasswordForTest', email: 'superadmin@bigblackhhole.com' } } }
     end
 
     context 'when valid' do

--- a/spec/factories/case_workers.rb
+++ b/spec/factories/case_workers.rb
@@ -19,7 +19,7 @@ FactoryBot.define do
 
     after(:build) do |case_worker, evaluator|
       if evaluator.build_user
-        case_worker.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, password: 'password1234', password_confirmation: 'password1234')
+        case_worker.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, password: 'PasswordForTest', password_confirmation: 'PasswordForTest')
         case_worker.user.email = "#{case_worker.first_name}.#{case_worker.last_name}@laa.gov.uk"
       end
     end

--- a/spec/factories/external_users.rb
+++ b/spec/factories/external_users.rb
@@ -21,7 +21,7 @@ FactoryBot.define do
 
     after(:build) do |eu, evaluator|
       if evaluator.build_user
-        eu.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'password1234', password_confirmation: 'password1234')
+        eu.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'PasswordForTest', password_confirmation: 'PasswordForTest')
       end
     end
 

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -20,7 +20,7 @@ FactoryBot.define do
     claim
 
     after(:build) do |message|
-      message.sender_id ||= (message.sender || create(:user, email: Faker::Internet.unique.email, password: 'password1234', password_confirmation: 'password1234')).id
+      message.sender_id ||= (message.sender || create(:user, email: Faker::Internet.unique.email, password: 'PasswordForTest', password_confirmation: 'PasswordForTest')).id
     end
   end
 

--- a/spec/factories/super_admins.rb
+++ b/spec/factories/super_admins.rb
@@ -10,7 +10,7 @@
 FactoryBot.define do
   factory :super_admin do
     after(:build) do |super_admin|
-      super_admin.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'password1234', password_confirmation: 'password1234')
+      super_admin.user ||= build(:user, first_name: Faker::Name.first_name, last_name: Faker::Name.last_name, email: Faker::Internet.unique.email, password: 'PasswordForTest', password_confirmation: 'PasswordForTest')
     end
   end
 end

--- a/spec/requests/devise/registrations/user_signup_spec.rb
+++ b/spec/requests/devise/registrations/user_signup_spec.rb
@@ -58,8 +58,8 @@ RSpec.describe 'User sign up' do
       { first_name: 'Bob',
         last_name: 'Smith',
         email: 'foo@bar.com',
-        password: 'password1234',
-        password_confirmation: 'password1234',
+        password: 'PasswordForTest',
+        password_confirmation: 'PasswordForTest',
         terms_and_conditions: '1' }
     end
 

--- a/spec/requests/provider_management/external_users_spec.rb
+++ b/spec/requests/provider_management/external_users_spec.rb
@@ -288,7 +288,7 @@ RSpec.describe 'providers external users management' do
     let(:user) { create(:case_worker, :provider_manager).user }
     let(:external_user) { create(:external_user) }
 
-    let(:password) { 'password1234' }
+    let(:password) { 'PasswordForTest' }
     let(:password_confirm) { password }
 
     before do


### PR DESCRIPTION
#### What

Update test password.

#### Ticket

N/A

#### Why

Some cucumber tests fails when run locally because the browser brings up an insecure password browser pop-up that needs to be cleared before proceeding.

#### How

Global search-and-replace `password1234` with `PasswordForTest`.