### PR TITLE
[CTSKF-1134] Set `allow_deprecated_singular_associations_name` to `false`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -81,7 +81,7 @@ Rails.application.config.active_record.sqlite3_adapter_strict_strings_by_default
 ###
 # Disable deprecated singular associations names.
 #++
-# Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
+Rails.application.config.active_record.allow_deprecated_singular_associations_name = false
 
 ###
 # Enable the Active Job `BigDecimal` argument serializer, which guarantees


### PR DESCRIPTION
#### What

Set `allow_deprecated_singular_associations_name` to `false`

#### Ticket

[CTSKF-1134](https://dsdmoj.atlassian.net/browse/CTSKF-1134)

#### Why

To continue to upgrade to v7.1 of rails

#### How

Enable the setting in `config/initializers/new_framework_defaults_7_1.rb`


[CTSKF-1134]: https://dsdmoj.atlassian.net/browse/CTSKF-1134?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ