### PR TITLE
[CTSKF-1148] Set active_record.generate_secure_token_on

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -224,7 +224,7 @@ Rails.application.config.active_record.commit_transaction_on_non_local_return = 
 ###
 # Controls when to generate a value for <tt>has_secure_token</tt> declarations.
 #++
-# Rails.application.config.active_record.generate_secure_token_on = :initialize
+Rails.application.config.active_record.generate_secure_token_on = :initialize
 
 ###
 # ** Please read carefully, this must be configured in config/application.rb **


### PR DESCRIPTION
#### What
Set generate secure token on initialize
#### Ticket

[CTSKF-1148](https://dsdmoj.atlassian.net/browse/CTSKF-1148?atlOrigin=eyJpIjoiMDZjYTFkZDk0NDRhNGJkMWExOTk1ODljYmNkODZkMTkiLCJwIjoiaiJ9)

#### Why
To continue to upgrade to v7.1 of rails


#### How
Enable the setting in `config/initializers/new_framework_defaults_7_1.rb`



[CTSKF-1148]: https://dsdmoj.atlassian.net/browse/CTSKF-1148?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ