### PR TITLE
Set the Rails.application.config.active_record.raise_on_assign_to_att…

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -168,7 +168,7 @@ end
 # behavior would allow assignment but silently not persist changes to the
 # database.
 #++
-# Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
+Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true
 
 ###
 # Enable validating only parent-related columns for presence when the parent is mandatory.


### PR DESCRIPTION
#### What

Set the Rails.application.config.active_record.raise_on_assign_to_attr_readonly setting as the default value for Rails 7.1.

#### Ticket

[[board ticket description](https://dsdmoj.atlassian.net/browse/CTSKF-1140)](https://dsdmoj.atlassian.net/browse/CTSKF-1140)

#### Why

To continue to upgrade to v7.1 of rails

#### How

Rails.application.config.active_record.raise_on_assign_to_attr_readonly = true

