### PR TITLE
explicitly disable SHA1 support

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -56,7 +56,7 @@ Rails.application.config.action_controller.allow_deprecated_parameters_hash_equa
 # 3. If you don't currently have data encrypted with Active Record encryption, you can disable this setting to
 # configure the default behavior starting 7.1+:
 #++
-# Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = false
+Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = false
 
 ###
 # No longer run after_commit callbacks on the first of multiple Active Record


### PR DESCRIPTION
 #### What
explicitly disable SHA1 support as there is no existing encrypted columns with legacy data

#### Ticket
[CCCD - Set active_record.encryption.hash_digest_class](https://dsdmoj.atlassian.net/browse/CTSKF-1132)

#### Why
The only encrypted column with data is the encrypted_password on the User model is used by Devise, not Active Record Encryption, therefore you don't need to configure hash_digest_class for it. Devise handles its own hashing separately.

#### How

Therefore the ` Rails.application.config.active_record.encryption.support_sha1_for_non_deterministic_encryption = false` has been explicitly set. 
