### PR TITLE
Set use_big_decimal_serializer

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -93,7 +93,7 @@ Rails.application.config.active_record.allow_deprecated_singular_associations_na
 # serializer. Therefore, this setting should only be enabled after all replicas
 # have been successfully upgraded to Rails 7.1.
 #++
-# Rails.application.config.active_job.use_big_decimal_serializer = true
+Rails.application.config.active_job.use_big_decimal_serializer = true
 
 ###
 # Specify if an `ArgumentError` should be raised if `Rails.cache` `fetch` or


### PR DESCRIPTION
#### What
Set the Rails.application.config.active_job.use_big_decimal_serializer setting as the default value for Rails 7.1.

#### Ticket

[CCCD - Set use_big_decimal_serializer](https://dsdmoj.atlassian.net/browse/CTSKF-1135)

#### Why

To continue to upgrade to v7.1 of rails

#### How

Rails.application.config.active_job.use_big_decimal_serializer = true
