### PR TITLE
[CTSKF-1133] Set run_commit_callbacks_on_first_saved_instances_in_transaction

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -65,7 +65,7 @@ Rails.application.config.action_controller.allow_deprecated_parameters_hash_equa
 # state which matches what was committed to the database, typically the last
 # instance to save.
 #++
-# Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
+Rails.application.config.active_record.run_commit_callbacks_on_first_saved_instances_in_transaction = false
 
 ###
 # Configures SQLite with a strict strings mode, which disables double-quoted string literals.


### PR DESCRIPTION
#### What

Set the `run_commit_callbacks_on_first_saved_instances_in_transaction` option to false.

#### Ticket

[CCCD - Set run_commit_callbacks_on_first_saved_instances_in_transaction](https://dsdmoj.atlassian.net/browse/CTSKF-1133)

#### Why

Continue to clean up after the Rails 7.1 upgrade.

#### How

Update in the `config/initializers/new_framework_defaults_7_1.rb` file.
