### PR TITLE
[CTSKF-1136] Set raise_on_invalid_cache_expiration_time

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -101,7 +101,7 @@ Rails.application.config.active_job.use_big_decimal_serializer = true
 # Options are `true`, and `false`. If `false`, the exception will be reported
 # as `handled` and logged instead.
 #++
-# Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
+Rails.application.config.active_support.raise_on_invalid_cache_expiration_time = true
 
 ###
 # Specify whether Query Logs will format tags using the SQLCommenter format


### PR DESCRIPTION
#### What

Set `raise_on_invalid_cache_expiration_time` for Rails 7.1 default

#### Ticket

[CCCD - Set raise_on_invalid_cache_expiration_time](https://dsdmoj.atlassian.net/browse/CTSKF-1136)

#### Why

Continue clean up after Rails 7.1 upgrade.

#### How

Set in `config/initializers/new_framework_defaults_7_1.rb`