### PR TITLE
[CTSKF-1139] Set use_message_serializer_for_metadata

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -151,7 +151,7 @@ Rails.application.config.active_record.query_log_tags_format = :sqlcommenter
 # leave this optimization off on the first deploy, then enable it on a
 # subsequent deploy.
 #++
-# Rails.application.config.active_support.use_message_serializer_for_metadata = true
+Rails.application.config.active_support.use_message_serializer_for_metadata = true
 
 ###
 # Set the maximum size for Rails log files.


### PR DESCRIPTION
#### What

Enable a performance optimization that serializes message data and metadata together.

#### Ticket

[CCCD - Set active_support.use_message_serializer_for_metadata](https://dsdmoj.atlassian.net/browse/CTSKF-1139)

#### Why

Continue the clean up following the Rails 7.1 update.

#### How

Set `Rails.application.config.active_support.use_message_serializer_for_metadata`