### PR TITLE
Use blank password used for smoke tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -76,7 +76,7 @@ executors:
           SECRET_KEY_BASE: just-be-present
           SUPERADMIN_USERNAME: superadmin@circleci.com
           SUPERADMIN_PASSWORD: just-be-present
-          DATABASE_URL: postgres://postgres:circleci@127.0.0.1:5432/cccd_smoke_test
+          DATABASE_URL: postgres://postgres@127.0.0.1:5432/cccd_smoke_test
           TZ: Europe/London
           GITHUB_TEAM_NAME_SLUG: laa-get-paid
           REPO_NAME: cccd
@@ -84,7 +84,7 @@ executors:
       - image: cimg/postgres:13.3
         environment:
           POSTGRES_USER: postgres
-          POSTGRES_PASSWORD: "circleci"
+          POSTGRES_PASSWORD: ""
           POSTGRES_DB: cccd_smoke_test
 
   test-executor:


### PR DESCRIPTION
#### What

Reduce failing checks in SonarQube.

#### Ticket

N/A

#### Why

The database for the smoke tests is only temporary and does not hold any sensitive data so the hardwired password is not a problem. However, it is flagged by SonarQube and causes it to fail, which could be masking other issues.

See https://sonarcloud.io/project/issues?issues=AZc2ZhD-gc9-qdI65_nQ&open=AZc2ZhD-gc9-qdI65_nQ&id=ministryofjustice_Claim-for-Crown-Court-Defence

#### How

Use a blank password for the test database in the smoke tests.