### PR TITLE
[CTSKF-1144] Set `active_record.default_column_serializer` to `nil`

### DIFF
--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -196,7 +196,7 @@ Rails.application.config.active_record.before_committed_on_all_records = true
 # recommended to explicitly define the serialization method for each column
 # rather than to rely on a global default.
 #++
-# Rails.application.config.active_record.default_column_serializer = nil
+Rails.application.config.active_record.default_column_serializer = nil
 
 ###
 # Enable a performance optimization that serializes Active Record models


### PR DESCRIPTION
#### What

Set `active_record.default_column_serializer` to `nil`

#### Ticket

[CTSKF-1144](https://dsdmoj.atlassian.net/browse/CTSKF-1144)

#### Why

As part of the upgrade to rails 7.1

#### How

Enable the setting in `config/initializers/new_framework_defaults_7_1.rb`


[CTSKF-1144]: https://dsdmoj.atlassian.net/browse/CTSKF-1144?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ