### PR TITLE
[CTSKF-1149] Set cache_format_version

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -28,6 +28,19 @@ module AdvocateDefencePayments
     # To set this configuration, add the following line to `config/application.rb` (NOT this file):
     config.add_autoload_paths_to_load_path = false
 
+    ### New default configuration for Rails 7.1. To be removed when load_defaults is updated.
+    # Change the format of the cache entry.
+    #
+    # Changing this default means that all new cache entries added to the cache
+    # will have a different format that is not supported by Rails 7.0
+    # applications.
+    #
+    # Only change this value after your application is fully deployed to Rails 7.1
+    # and you have no plans to rollback.
+    # When you're ready to change format, add this to `config/application.rb` (NOT
+    # this file):
+    config.active_support.cache_format_version = 7.1
+
     config.middleware.use Rack::Deflater
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.

--- a/config/initializers/new_framework_defaults_7_1.rb
+++ b/config/initializers/new_framework_defaults_7_1.rb
@@ -226,7 +226,7 @@ Rails.application.config.active_record.commit_transaction_on_non_local_return = 
 #++
 Rails.application.config.active_record.generate_secure_token_on = :initialize
 
-###
+### Updated in config/application.rb
 # ** Please read carefully, this must be configured in config/application.rb **
 #
 # Change the format of the cache entry.


### PR DESCRIPTION
#### What

Change the cache format.

#### Ticket

[CCCD - Set active_support.cache_format_version (rails 7.1)](https://dsdmoj.atlassian.net/browse/CTSKF-1149)

#### Why

Continue the clean-up after upgrading to Rails 7.1.

#### How

Set the cache format version to 7.1, in line with the version of Rails.
