### PR TITLE
[CTSKF-1373] Restrict access to office hours

### DIFF
--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -15,6 +15,15 @@ metadata:
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
+      SecRule REMOTE_ADDR "@ipMatch 51.149.249.0,194.33.249.0,51.149.249.32,194.33.248.0,20.49.214.199,20.49.214.228,20.26.11.71,20.26.11.108,128.77.75.64,18.169.147.172,35.176.93.186,18.130.148.126,35.176.148.126" \
+          "phase:1,chain,id:997,deny,status:503"
+        SecRule TIME_HOUR "@within 21 22 23 00 01 02 03 04 05" "t:none"
+      SecRule REMOTE_ADDR "!@ipMatch 51.149.249.0,194.33.249.0,51.149.249.32,194.33.248.0,20.49.214.199,20.49.214.228,20.26.11.71,20.26.11.108,128.77.75.64,18.169.147.172,35.176.93.186,18.130.148.126,35.176.148.126" \
+          "phase:1,chain,id:998,deny,status:503"
+        SecRule TIME_WDAY "@within 0 6" "t:none"
+      SecRule REMOTE_ADDR "!@ipMatch 51.149.249.0,194.33.249.0,51.149.249.32,194.33.248.0,20.49.214.199,20.49.214.228,20.26.11.71,20.26.11.108,128.77.75.64,18.169.147.172,35.176.93.186,18.130.148.126,35.176.148.126" \
+          "phase:1,chain,id:999,deny,status:503"
+        SecRule TIME_HOUR "@within 18 19 20 21 22 23 00 01 02 03 04 05" "t:none"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -15,6 +15,15 @@ metadata:
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
+      SecRule REMOTE_ADDR "@ipMatch 51.149.249.0,194.33.249.0,51.149.249.32,194.33.248.0,20.49.214.199,20.49.214.228,20.26.11.71,20.26.11.108,128.77.75.64,18.169.147.172,35.176.93.186,18.130.148.126,35.176.148.126" \
+          "phase:1,chain,id:997,deny,status:503"
+        SecRule TIME_HOUR "@within 21 22 23 00 01 02 03 04 05" "t:none"
+      SecRule REMOTE_ADDR "!@ipMatch 51.149.249.0,194.33.249.0,51.149.249.32,194.33.248.0,20.49.214.199,20.49.214.228,20.26.11.71,20.26.11.108,128.77.75.64,18.169.147.172,35.176.93.186,18.130.148.126,35.176.148.126" \
+          "phase:1,chain,id:998,deny,status:503"
+        SecRule TIME_WDAY "@within 0 6" "t:none"
+      SecRule REMOTE_ADDR "!@ipMatch 51.149.249.0,194.33.249.0,51.149.249.32,194.33.248.0,20.49.214.199,20.49.214.228,20.26.11.71,20.26.11.108,128.77.75.64,18.169.147.172,35.176.93.186,18.130.148.126,35.176.148.126" \
+          "phase:1,chain,id:999,deny,status:503"
+        SecRule TIME_HOUR "@within 18 19 20 21 22 23 00 01 02 03 04 05" "t:none"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;


### PR DESCRIPTION
#### What

Restricts access to the service based on IP address and day/time, by adding modsecurity rules to implement the following:

* Internal users can access the service 7am-10pm, seven days a week 
* External users can access the service 7am-7pm, Monday to Friday

This is implemented in production, and also staging to ensure we have a production-like environment where testing can take place.

#### Ticket

[CTSKF-1373](https://dsdmoj.atlassian.net/browse/CTSKF-1373)


[CTSKF-1373]: https://dsdmoj.atlassian.net/browse/CTSKF-1373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ