### PR TITLE
Temporarily disable npm updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,26 @@
 version: 2
 updates:
-- package-ecosystem: npm
-  directory: "/"
-  schedule:
-    interval: daily
-    day: wednesday
-    time: "03:00"
-    timezone: Europe/London
-  groups:
-    babel:
-      patterns:
-        - "*babel*"
-    datatables:
-      patterns:
-        - "*datatables*"
-    postcss:
-      patterns:
-        - "postcss"
-        - "postcss-*"
-  open-pull-requests-limit: 10
-  allow:
-    - dependency-type: "all"
+# - package-ecosystem: npm
+#   directory: "/"
+#   schedule:
+#     interval: daily
+#     day: wednesday
+#     time: "03:00"
+#     timezone: Europe/London
+#   groups:
+#     babel:
+#       patterns:
+#         - "*babel*"
+#     datatables:
+#       patterns:
+#         - "*datatables*"
+#     postcss:
+#       patterns:
+#         - "postcss"
+#         - "postcss-*"
+#   open-pull-requests-limit: 10
+#   allow:
+#     - dependency-type: "all"
 - package-ecosystem: bundler
   directory: "/"
   schedule:


### PR DESCRIPTION
#### What

Disable NPM updates in dependabot.

#### Ticket

N/A

#### Why

There is currently a security breach affecting multiple NPM packages. It is recommended to stop updating until this is resolved.

See https://www.koi.security/blog/shai-hulud-npm-supply-chain-attack-crowdstrike-tinycolor

#### How

Remove the `package-ecosystem: npm` section of the dependabot configuration.