### PR TITLE
Suppress Rails 7.1 EOL warning

### DIFF
--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -119,18 +119,18 @@
     },
     {
       "warning_type": "Unmaintained Dependency",
-      "warning_code": 122,
-      "fingerprint": "98b26f60d776fd41ee6f088c833725145be9aac2d7c5b33780241c273622db42",
+      "warning_code": 120,
+      "fingerprint": "d84924377155b41e094acae7404ec2e521629d86f97b0ff628e3d1b263f8101c",
       "check_name": "EOLRails",
-      "message": "Support for Rails 7.1.5.2 ends on 2025-10-01",
+      "message": "Support for Rails 7.1.5.2 ended on 2025-10-01",
       "file": "Gemfile.lock",
-      "line": 501,
+      "line": 502,
       "link": "https://brakemanscanner.org/docs/warning_types/unmaintained_dependency/",
       "code": null,
       "render_path": null,
       "location": null,
       "user_input": null,
-      "confidence": "Medium",
+      "confidence": "High",
       "cwe_id": [
         1104
       ],

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -209,3 +209,23 @@ feature again. It should no longer require the api endpoints.
 You should now commit the cassette to the repo to ensure it is not unneccessarily created by upstream test suite runs on the CI solution.
 
 ***When you change a feature test such that you need to re-record its cassette you should delete the existing cassette in the `vcr` folder and proceed as if creating a new cassette, above.***
+
+## Static analysis
+
+### brakeman
+
+`brakeman` is normally executed in the pipeline in the `other-tests`. To execute it from the command line use;
+
+```bash
+bundle exec brakeman
+```
+
+`brakeman` maintains an ignore list, `config/brakeman.ignore`,  of known issues that are to be suppressed. This file is
+automatically generated and it can be modified by running `brakeman` interactively;
+
+```bash
+bundle exec brakeman -I
+```
+
+This will allow warnings to be examined and added to the ignore list if necessary, and for suppressed warnings to be
+removed after they have been resolved.


### PR DESCRIPTION
#### What

Suppress warnings about Rails 7.1 EOL

#### Ticket

N/A

#### Why

Rails 7.1 has reached end of life. There is a PR ready to resolve this (#8944). It is in the final stages of testing and will be merged soon.

#### How

Update the `brakeman` ignore list.