### PR TITLE
Check npm packages

### DIFF
--- a/.github/workflows/npm_check.yml
+++ b/.github/workflows/npm_check.yml
@@ -1,0 +1,22 @@
+name: Check NPM updates
+on:
+  push:
+    paths:
+      - 'yarn.lock'
+
+jobs:
+  check-npm-packages:
+    runs-on: ubuntu-latest
+    name: Check npm packages
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v5
+
+    - name: Fetch test script
+      run: curl -s https://gist.githubusercontent.com/andrewrlee/5edfd25e9fdcbcf49e3a0eeddd3fe130/raw/check-yarn.mjs > /tmp/check-yarn.mjs
+
+    - name: Run script
+      run: node /tmp/check-yarn.mjs | tee /tmp/check_output.txt
+
+    - name: Check output
+      run: "! grep -E 'WARNING|CAUTION' /tmp/check_output.txt"


### PR DESCRIPTION
#### What

Check updated NPM packages against the list of possibly compromised packages.

#### Ticket

N/A

#### Why

Following the [S1ngularity/nx(https://www.aikido.dev/blog/s1ngularity-nx-attackers-strike-again) hack we need to be careful updating npm packages.

#### How

Github action that uses @andrewrlee's script for checking `yarn.lock` against the list of suspicious packages.

The workflow is only triggered if there has been a change to `yarn.lock`.