### PR TITLE
Enable  Active Job's #perform_later

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -32,7 +32,7 @@
 # backends that use the same database as Active Record as a queue, hence they
 # don't need this feature.
 #++
-# Rails.application.config.active_job.enqueue_after_transaction_commit = :default
+Rails.application.config.active_job.enqueue_after_transaction_commit = :default
 
 ###
 # Adds image/webp to the list of content types Active Storage considers as an image

--- a/features/support/hooks.rb
+++ b/features/support/hooks.rb
@@ -72,6 +72,11 @@ Before('not @no-seed') do
   end
 end
 
+# after the defaults have been changed to 7.2 in config/application.rb it might be possible to remove this.
+Before('@javascript') do
+  Rails.application.config.active_job.enqueue_after_transaction_commit = true
+end
+
 # minimum seeding necessary for case worker functionality
 # to avoid long start up time for basic case worker features
 #


### PR DESCRIPTION
#### What
 Set active_job.enqueue_after_transaction_commit

#### Ticket

[Upgrade to rails 7.2 - Set active_job.enqueue_after_transaction_commit](https://dsdmoj.atlassian.net/browse/CTSKF-1394)

#### Why
In earlier versions of Rails, jobs could be queued before a transaction was committed, potentially causing failures if the transaction rolled back. This new default defers job queuing until after the transaction commits, reducing the risk of invalid data being processed by background jobs.

#### How

Uncomment the following:
Rails.application.config.active_job.enqueue_after_transaction_commit = :default

And then I checked things around where we are using jobs: I create some claims and submit them,  sent messages and  created attachments. 


