### PR TITLE
 CCCD: Upgrade to rails 7.2  - Enable YJIT for Ruby 3.3

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -67,4 +67,4 @@
 # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are
 # deploying to a memory constrained environment you may want to set this to `false`.
 #++
-# Rails.application.config.yjit = true
+Rails.application.config.yjit = true


### PR DESCRIPTION
### Ticket
[ CCCD: Upgrade to rails 7.2  - Enable YJIT for Ruby 3.3](https://dsdmoj.atlassian.net/browse/CTSKF-1399)

### Why
YJIT improves runtime performance by optimizing frequently run code paths. It may reduce CPU usage and response times.

### How
Set `Rails.application.config.yjit = true`

A report is exported on the response time of last 14 days in CCCD production. 
The query `CCCD_performance_monitor` is saved in sentry.

Here is the report:
[CCCD_performance_monitor_251016](https://justiceuk-my.sharepoint.com/:x:/r/personal/vince_chiu_justice_gov_uk/Documents/CCCD_performance_monitor_251016.xlsx?d=waddac69c6f354235906e4bfeb2b29d1e&csf=1&web=1&e=yz5DK4)

We can compare the performance later.

