### PR TITLE
Ctskf 1397 cccd upgrade to rails 7.2 enable migration timestamp validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@
 
 # Ignore all logfiles and tempfiles.
 /log/*.log
+/log/*.log.*
 /log/*.output
 /tmp
 
@@ -84,3 +85,4 @@ yarn-debug.log*
 
 # ignore Brewfile changes
 Brewfile.lock.json
+

--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -51,7 +51,7 @@
 # Applications with existing timestamped migrations that do not adhere to the
 # expected format can disable validation by setting this config to `false`.
 #++
-# Rails.application.config.active_record.validate_migration_timestamps = true
+Rails.application.config.active_record.validate_migration_timestamps = true
 
 ###
 # Controls whether the PostgresqlAdapter should decode dates automatically with manual queries.


### PR DESCRIPTION
#### What
Enable validation of migration timestamps to prevent forward-dated migration files:
#### Ticket

[CCCD: Upgrade to rails 7.2 Enable Migration Timestamp Validation](https://dsdmoj.atlassian.net/browse/CTSKF-1397)

#### Why
Forward-dated migrations can cause issues with migration ordering, generation, and deployment across teams. Validating timestamps ensures predictable migration sequences.

#### How

Tested a migration set in the future and got the expected error message. 

```
RAILS_ENV=test bin/rails db:migrate

bin/rails aborted!
ActiveRecord::InvalidMigrationTimestampError:  (ActiveRecord::InvalidMigrationTimestampError)

Invalid timestamp 20251019120000 for migration file: dummy_test_migration.
Timestamp must be in form YYYYMMDDHHMMSS, and less than 20251018095021.
```


