### PR TITLE
[CTSKF-1396] Add WebP Support to Active Storage

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -40,7 +40,7 @@
 # This is possible due to broad browser support for WebP, but older browsers and email clients may still not support
 # WebP. Requires imagemagick/libvips built with WebP support.
 #++
-# Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
+Rails.application.config.active_storage.web_image_content_types = %w[image/png image/jpeg image/gif image/webp]
 
 ###
 # Enable validation of migration timestamps. When set, an ActiveRecord::InvalidMigrationTimestampError


### PR DESCRIPTION
#### What
Add support for webp image format
#### Ticket

[CCCD: Upgrade to rails 7.2 - Add WebP Support to Active Storage](https://dsdmoj.atlassian.net/browse/CTSKF-1396?atlOrigin=eyJpIjoiM2UxNTgwZmYzMGFlNDJkOWE4MmExMzhhYzdiYjY5ODAiLCJwIjoiaiJ9)

#### Why
To upgrade to rails version 7.2
#### How
By adding image/webp to the list of content types Active Storage considers as an image

#### Screenshot
<img width="953" height="607" alt="Screenshot 2025-10-21 at 11 59 02" src="https://github.com/user-attachments/assets/4dd1e782-9957-419b-b9ab-b4f1fd1daccd" />
Can confirm it's not a breaking change by deploying to dev and checking we're still able to upload images.