### PR TITLE
CCCD: Upgrade to rails 7.2 - Enable PostgreSQL Adapter Date Decoding

### DIFF
--- a/config/initializers/new_framework_defaults_7_2.rb
+++ b/config/initializers/new_framework_defaults_7_2.rb
@@ -61,7 +61,7 @@ Rails.application.config.active_record.validate_migration_timestamps = true
 #
 # This query used to return a `String`.
 #++
-# Rails.application.config.active_record.postgresql_adapter_decode_dates = true
+Rails.application.config.active_record.postgresql_adapter_decode_dates = true
 
 ###
 # Enables YJIT as of Ruby 3.3, to bring sizeable performance improvements. If you are

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -420,7 +420,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
         end
       end
 
-      it { is_expected.to contain_exactly(31.days.ago.strftime('%F')) }
+      it { is_expected.to contain_exactly(31.days.ago.to_date) }
     end
 
     # authors full name for the "previous decision" that was redetermined or nil if previous decision was not redetermined


### PR DESCRIPTION
### What
CCCD: Upgrade to rails 7.2 - Enable PostgreSQL Adapter Date Decoding

### Ticket
[CCCD: Upgrade to rails 7.2 - Enable PostgreSQL Adapter Date Decoding](https://dsdmoj.atlassian.net/browse/CTSKF-1398)

### Why
Previously, raw SQL queries returned date columns as strings, requiring manual type casting. Automatic decoding simplifies queries and reduces errors.

### How
Set `Rails.application.config.active_record.postgresql_adapter_decode_dates = true`

I have deployed the change to dev for testing. There was rspec test failing around daily report generation. I compared the management report (view by CaseworkerAdmin) downloaded from dev and staging, nothing suspicious. 

Seems most of date and time related object or field is formatted by `strftime()` function and `strftime()` function can work on both string or Date.
