### PR TITLE
[CTSKF-1436] Restore time sensitive tests

### DIFF
--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -258,7 +258,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with a completed journey' do
         before do
-          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
+          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -276,7 +276,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with an uncompleted journey' do
         before do
-          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
+          # pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do


### PR DESCRIPTION
#### What

Re-enable tests that fail during BST.

#### Ticket

[3RD NOV - CCCD: Fix failing timezone tests (part 2)](https://dsdmoj.atlassian.net/browse/CTSKF-1436)

#### Why

Conflicts with database time and time in the app mean that some MI tests fail during BST.

#### How

Comment out `pending` for two tests so that they can be added back next March.