### PR TITLE
[CTSKF-1466] Update ModSecurity rules

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -13,6 +13,10 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
+      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
+                                                                            ctl:ruleRemoveById=933210, \
+                                                                            ctl:ruleRemoveById=932370, \
+                                                                            ctl:ruleRemoveById=932380"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -14,7 +14,10 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
-      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
+      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
+                                                                            ctl:ruleRemoveById=933210, \
+                                                                            ctl:ruleRemoveById=932370, \
+                                                                            ctl:ruleRemoveById=932380"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -14,7 +14,10 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
-      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
+      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
+                                                                            ctl:ruleRemoveById=933210, \
+                                                                            ctl:ruleRemoveById=932370, \
+                                                                            ctl:ruleRemoveById=932380"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -14,7 +14,10 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
-      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
+      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
+                                                                            ctl:ruleRemoveById=933210, \
+                                                                            ctl:ruleRemoveById=932370, \
+                                                                            ctl:ruleRemoveById=932380"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -14,7 +14,10 @@ metadata:
       SecAction "id:900200,phase:1,nolog,pass,t:none,setvar:tx.allowed_methods=GET HEAD POST OPTIONS PUT PATCH DELETE"
       SecRuleRemoveById 200002
       SecRuleRemoveById 200003
-      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110,ctl:ruleRemoveById=933210"
+      SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
+                                                                            ctl:ruleRemoveById=933210, \
+                                                                            ctl:ruleRemoveById=932370, \
+                                                                            ctl:ruleRemoveById=932380"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;


### PR DESCRIPTION
#### What

In CCCD, users are experiencing occasional failures when trying to send messages. There is no error but the message fails to send.

This is a result of false positives identified by ModSecurity rules 932370 and 932380. These rules identify two instances of Remote Command Execution: Windows Command Injection and are matching messages that contain punctuation such as colons, slashes, semicolons; command-like words (eg 'start', 'statement', and 'response'); and dates and monetary values.

This change adds 932370 and 932380 to the list of disabled ModSecurity rules on the /messages page.

This will prevent valid messages being blocked as false positives while other parts of the application will continue to be protected by those rules.

#### Ticket

[CTSKF-1482](https://dsdmoj.atlassian.net/browse/CTSKF-1482)

#### Testing

Tested on `dev` using text extracted from the ModSecurity logs of the requests that triggered the failure and prompted the user to report the problem. This text is stored securely in 1Password. 

1. Before removing the rules: the message was not sent.
2. After removing the rules: the message was sent.




[CTSKF-1482]: https://dsdmoj.atlassian.net/browse/CTSKF-1482?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ