### PR TITLE
Fix error caused by migration to component gem

### DIFF
--- a/app/views/shared/_claim_transfer_details.html.haml
+++ b/app/views/shared/_claim_transfer_details.html.haml
@@ -3,5 +3,5 @@
   - row.with_value(text: claim.transfer_detail_summary )
 
 - summary_list.with_row do |row|
-  - row.with_key( t('common.transfer_date') )
+  - row.with_key(text: t('common.transfer_date') )
   - row.with_value(text: claim.transfer_date )


### PR DESCRIPTION
#### What

External users are seeing errors when trying to view a submitted transfer claim.

#### How

Add `text` keyword to call to `with_key` method in `app/views/shared/_claim_transfer_details.html.haml`.