### PR TITLE
Hide warrant fee details if no fee claimed

### DIFF
--- a/app/views/external_users/claims/interim_claim_info/_summary.html.haml
+++ b/app/views/external_users/claims/interim_claim_info/_summary.html.haml
@@ -4,12 +4,12 @@
     %h3.govuk-heading-m
       = t('common.warrant_fees')
 
-  = govuk_summary_list do |summary_list|
-    - summary_list.with_row do |row|
-      - row.with_key { t('shared.claims.interim_claim_info.fields.date_issued') }
-      - row.with_value(text: info.warrant_issued_date )
+    = govuk_summary_list do |summary_list|
+      - summary_list.with_row do |row|
+        - row.with_key { t('shared.claims.interim_claim_info.fields.date_issued') }
+        - row.with_value(text: info.warrant_issued_date )
 
-    - summary_list.with_row do |row|
-      - row.with_key { t('shared.claims.interim_claim_info.fields.date_executed') }
-      - row.with_value(text: info.warrant_executed_date )
+      - summary_list.with_row do |row|
+        - row.with_key { t('shared.claims.interim_claim_info.fields.date_executed') }
+        - row.with_value(text: info.warrant_executed_date )
 


### PR DESCRIPTION
#### What

Migrating to the component gem for summary lists has led to a small bug on the provider summary page where a blank section for warrant fee details is displayed even if no warrant fee has been claimed.

This occurs because a component which was previously nested within a conditional is now not.

#### How

Fixes the indentation of the relevant summary list so that it is now nested within the appropriate conditional and only displayed if `info.warrant_fee_paid?` is true.

#### Screenshots

##### Before

<img width="1007" height="415" alt="image" src="https://github.com/user-attachments/assets/c26fe271-fb40-4269-bbaa-b22876f6b47f" />

##### After

<img width="995" height="315" alt="image" src="https://github.com/user-attachments/assets/d9d8eca0-dbf7-4260-96e4-85afa7f2f8e9" />
