### PR TITLE
[CTSKF-889] Use GOVUK Components gem for pagination styling

### DIFF
--- a/app/views/shared/_pagination.html.haml
+++ b/app/views/shared/_pagination.html.haml
@@ -1,2 +1,2 @@
-%nav.pagination.app-pagintion--inline
-  = pagy_nav(@pagy).html_safe if @pagy.pages > 1
+%nav.pagination.app-pagination--inline
+  = govuk_pagination(pagy: @pagy)

--- a/app/webpack/stylesheets/_navigation.scss
+++ b/app/webpack/stylesheets/_navigation.scss
@@ -26,7 +26,6 @@ nav {
 
 .pagination {
   padding: $gutter-half 0;
-  float: right;
 
   a {
     padding: $gutter-one-sixth;
@@ -51,6 +50,7 @@ nav {
   }
 }
 
-.app-pagintion--inline li {
-  display: inline-block;
+.app-pagination--inline {
+  display: flex;
+  justify-content: right;
 }


### PR DESCRIPTION
#### What

Implements the `govuk-components` gem for styling pagination navigation.

#### Ticket

[CTSKF-889](https://dsdmoj.atlassian.net/browse/CTSKF-889)

#### Why

To ensure compliance with GDS designs, and improve accessibility and usability.


#### How

* Updates the `app/views/shared/_pagination.html.haml` partial to call the `govuk_pagination` method, removing some unnecessary logic now handled by the gem.

* Updates the `app/webpack/stylesheets/_navigation.scss` stylesheet to remove some unnecessary styling and ensure the navigation continues to be displayed in the same place:
  * Using `float: right;` causes an issue where the pagination component overlaps with the footer. This can be replaced with `display: flex; justify-content: right;`.

#### Testing

Advocate:

- [x] Your claims 
- [x] Your archive

Litigator:

- [x] Your claims 
- [x] Your archive

Caseworker:

- [x] Your claims
- [x] Your archive
- [x] Allocation (should remain unchanged as this pagination is controlled by the Datatables library)
- [x] Re-allocation

Super admin:

- [x] Users

#### Screenshots

**Before:**

<img width="979" height="794" alt="image" src="https://github.com/user-attachments/assets/c706d2a1-0d82-402e-8d51-2e8129dcadf2" />

**After:**

<img width="985" height="826" alt="image" src="https://github.com/user-attachments/assets/692e9b1e-6928-4da7-a293-0265caf9c7e9" />

[CTSKF-889]: https://dsdmoj.atlassian.net/browse/CTSKF-889?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ