### PR TITLE
Fix error caused by migration to component gem

### DIFF
--- a/app/views/provider_management/providers/show.html.haml
+++ b/app/views/provider_management/providers/show.html.haml
@@ -13,7 +13,7 @@
 
       - summary_list.with_row do |row|
         - row.with_key(text: t('.fee_schemes'))
-        - row.with_value( @provider.roles.map(&:upcase).join(', ') )
+        - row.with_value(text: @provider.roles.map(&:upcase).join(', ') )
 
       - if @provider.lgfs_supplier_numbers.any?
         - summary_list.with_row do |row|


### PR DESCRIPTION
#### What

Fix error caused by migration to component gem

#### Why

This is preventing caseworkers viewing and amending provider details

#### How

Add `text` keyword to call to `with_key` method in the `app/views/provider_management/providers/show.html.haml` partial.