### PR TITLE
Fix display of prosecution evidence on discontinuance claims

### DIFF
--- a/app/views/shared/_new_claim_and_case_type_details.html.haml
+++ b/app/views/shared/_new_claim_and_case_type_details.html.haml
@@ -62,4 +62,4 @@
 - if claim.discontinuance?
   - summary_list.with_row do |row|
     - row.with_key(text: t('common.prosecution_evidence'))
-    - row.with_value(text: claim.prosecution_evidence?.class )
+    - row.with_value(text: t(claim.prosecution_evidence?.class))


### PR DESCRIPTION
#### What

Moving to the govuk-component gem for summary cards and lists introduced a small bug when displaying the response to 'Was prosecution evidence served on this case?' to caseworkers.

This should appear as 'Yes' or 'No' but is showing as 'TrueClass' or 'FalseClass'.

This is occurring because `row.with_value(text: t(claim.prosecution_evidence?.class) )` has inadvertently been changed to row.with_value(text: claim.prosecution_evidence?.class).

Losing the call to the translate method is causing the wrong text to appear on screen.

This change restores the previous functionality.

#### Screenshots

Before

<img width="452" height="137" alt="image" src="https://github.com/user-attachments/assets/eacc3014-633d-435e-8cec-a435f90e3ca3" />


After

<img width="457" height="137" alt="image" src="https://github.com/user-attachments/assets/587b6614-c78c-434d-b337-078107d4602a" />

