### PR TITLE
Refactor error

### DIFF
--- a/app/presenters/error_message/detail.rb
+++ b/app/presenters/error_message/detail.rb
@@ -31,11 +31,5 @@ module ErrorMessage
     def to_summary_error
       [attribute, long_message]
     end
-
-    # rubocop:disable Rails/OutputSafety
-    def long_message_link
-      %(<a href="##{@attribute}">#{@long_message}</a>).html_safe
-    end
-    # rubocop:enable Rails/OutputSafety
   end
 end

--- a/app/views/external_users/claims/_error_summary.html.haml
+++ b/app/views/external_users/claims/_error_summary.html.haml
@@ -15,4 +15,4 @@
         %ul.govuk-list.govuk-error-summary__list
           - ep.summary_errors.each do |error_detail|
             %li
-              = error_detail.long_message_link
+              = govuk_link_to(error_detail.long_message, anchor: error_detail.attribute)


### PR DESCRIPTION
#### What

Issue: @long_message is interpolated directly into HTML and marked html_safe without escaping. 

#### Ticket

[CCCD: XSS Vulnerability in Error Presenter](https://dsdmoj.atlassian.net/browse/CTSKF-1546)

#### Why
If validation error messages contain user input (e.g., "Name 'SCRIPT' is invalid"), this creates an XSS injection vector.

#### How

Remove `long_message_link` from the error_message detail class and use `govuk_link_to` directly on the page instead.

Replaces:
```
= error_detail.long_message_link
```
with:

```
= govuk_link_to(error_detail.long_message, anchor: error_detail.attribute)
```

Drops html_safe usage and relies on framework escaping to remove the XSS vulnerability. 

