### PR TITLE
[CTSKF-1478] Allow up to 10 PTPH fees

### DIFF
--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -82,7 +82,7 @@ module Fee
 
     def validate_pcm_quantity
       if @record.claim.supplementary? || @record.claim.case_type.try(:allow_pcmh_fee_type?)
-        add_error(:quantity, :pcm_numericality) if @record.quantity > 3
+        add_error(:quantity, :pcm_numericality) if @record.quantity > 10
       else
         add_error(:quantity, :pcm_not_applicable) unless @record.quantity.zero? || @record.quantity.blank?
       end

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -81,6 +81,7 @@ module Fee
     end
 
     def validate_pcm_quantity
+      # Note that plea and case management hearings (PCM) have been renamed to pre and trial preparation hearings (PTPH)
       if @record.claim.supplementary? || @record.claim.case_type.try(:allow_pcmh_fee_type?)
         add_error(:quantity, :pcm_numericality) if @record.quantity > 10
       else

--- a/config/locales/en/error_messages/claim.yml
+++ b/config/locales/en/error_messages/claim.yml
@@ -820,9 +820,9 @@ basic_fee:
       short: _
       api: Plea and case management hearing fee not applicable to case type
     enter_a_valid_quantity_1_to_3_for_plea_and_case_management_hearing_fees:
-      long: Enter a valid quantity (1 to 3) for plea and case management hearing fees
+      long: Enter a valid quantity (1 to 10) for plea and case management hearing fees
       short: _
-      api: Enter a valid quantity (1 to 3) for plea and case management hearing fees
+      api: Enter a valid quantity (1 to 10) for plea and case management hearing fees
 
     # standard quantity validations (when a rate exists but quantity not specified)
     enter_a_valid_quantity_for_the_basic_fee:
@@ -1047,9 +1047,9 @@ misc_fee:
       short: _
       api: Enter a valid quantity for plea and trial preparation hearing
     enter_a_valid_quantity_1_to_3_for_plea_and_case_management_hearing_fees:
-      long: Enter a valid quantity (1 to 3) for plea and case management hearing fees
+      long: Enter a valid quantity (1 to 10) for plea and case management hearing fees
       short: _
-      api: Enter a valid quantity (1 to 3) for plea and case management hearing fees
+      api: Enter a valid quantity (1 to 10) for plea and case management hearing fees
     enter_a_valid_quantity_(1)_for_unused_material_(up_to_3_hours):
       long: 'Enter a valid quantity (1) for unused material (up to 3 hours)'
       short: _

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -235,7 +235,7 @@ en:
               npw_invalid: Enter a valid quantity for number of prosecution witnesses fees
               pcm_invalid: Enter a valid quantity for plea and trial preparation hearing
               pcm_not_applicable: Plea and case management hearing fee not applicable to case type
-              pcm_numericality: Enter a valid quantity (1 to 3) for plea and case management hearing fees
+              pcm_numericality: Enter a valid quantity (1 to 10) for plea and case management hearing fees
               ppe_invalid: Enter a valid quantity for pages of prosecution evidence fees
               saf_invalid: Enter a valid quantity for standard appearance fees
             rate:
@@ -364,7 +364,7 @@ en:
               miste_numericality: Enter a valid quantity (1) for section 28 hearing
               miumu_numericality: Enter a valid quantity (1) for unused material (up to 3 hours)
               pcm_invalid: Enter a valid quantity for plea and trial preparation hearing
-              pcm_numericality: Enter a valid quantity (1 to 3) for plea and case management hearing fees
+              pcm_numericality: Enter a valid quantity (1 to 10) for plea and case management hearing fees
             rate:
               invalid: Enter a valid rate for the miscellaneous fee
               pcm_invalid: Enter a valid rate for the Plea and trial preparation hearing

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -364,7 +364,7 @@ en:
               miste_numericality: Enter a valid quantity (1) for section 28 hearing
               miumu_numericality: Enter a valid quantity (1) for unused material (up to 3 hours)
               pcm_invalid: Enter a valid quantity for plea and trial preparation hearing
-              pcm_numericality: Enter a valid quantity (1 to 10) for plea and case management hearing fees
+              pcm_numericality: Enter a valid quantity (1 to 10) for plea and trial preparation hearing fees
             rate:
               invalid: Enter a valid rate for the miscellaneous fee
               pcm_invalid: Enter a valid rate for the Plea and trial preparation hearing

--- a/config/locales/en/models/claim.yml
+++ b/config/locales/en/models/claim.yml
@@ -235,7 +235,7 @@ en:
               npw_invalid: Enter a valid quantity for number of prosecution witnesses fees
               pcm_invalid: Enter a valid quantity for plea and trial preparation hearing
               pcm_not_applicable: Plea and case management hearing fee not applicable to case type
-              pcm_numericality: Enter a valid quantity (1 to 10) for plea and case management hearing fees
+              pcm_numericality: Enter a valid quantity (1 to 10) for plea and trial preparation hearing fees
               ppe_invalid: Enter a valid quantity for pages of prosecution evidence fees
               saf_invalid: Enter a valid quantity for standard appearance fees
             rate:

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
         'The number of daily attendance fees \(2\+ days\) does not fit the actual \(re\)trial length'
       end
       let(:fee_quantity_error_message) do
-        'Enter a valid quantity \(1 to 3\) for plea and case management hearing fees'
+        'Enter a valid quantity \(1 to 10\) for plea and case management hearing fees'
       end
 
       context 'basic fee (BAF)' do
@@ -537,14 +537,14 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
             claim.case_type = build :case_type, :allow_pcmh_fee_type
           end
 
-          it {
+          it do
             should_error_if_equal_to_value(pcm_fee, :quantity, 0,
                                            'Enter a valid quantity for plea and trial preparation hearing')
-          }
+          end
 
-          it {
+          it do
             should_error_if_equal_to_value(pcm_fee, :quantity, 11, fee_quantity_error_message)
-          }
+          end
 
           it { should_be_valid_if_equal_to_value(pcm_fee, :quantity, 10) }
           it { should_be_valid_if_equal_to_value(pcm_fee, :quantity, 1) }
@@ -555,15 +555,15 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
             claim.case_type = build :case_type
           end
 
-          it {
+          it do
             should_error_if_equal_to_value(pcm_fee, :quantity, 1,
                                            'Plea and case management hearing fee not applicable to case type')
-          }
+          end
 
-          it {
+          it do
             should_error_if_equal_to_value(pcm_fee, :quantity, -1,
                                            'Plea and case management hearing fee not applicable to case type')
-          }
+          end
         end
       end
 

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -531,8 +531,8 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
         end
       end
 
-      context 'plea and case management hearing (PCM)' do
-        context 'permitted case type' do
+      context 'with PTPH (plea and trial preparation hearing, formerly PCM)' do
+        context 'with a permitted case type' do
           before do
             claim.case_type = build :case_type, :allow_pcmh_fee_type
           end
@@ -550,7 +550,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
           it { should_be_valid_if_equal_to_value(pcm_fee, :quantity, 1) }
         end
 
-        context 'unpermitted case type' do
+        context 'with an unpermitted case type' do
           before do
             claim.case_type = build :case_type
           end
@@ -567,7 +567,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
         end
       end
 
-      context 'plea and case management hearing (PCM) for supplementary claims' do
+      context 'with PTPH (plea and trial preparation hearing, formerly PCM) for supplementary claims' do
         before do
           supplementary_claim.force_validation = true
         end

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -338,7 +338,7 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
         'The number of daily attendance fees \(2\+ days\) does not fit the actual \(re\)trial length'
       end
       let(:fee_quantity_error_message) do
-        'Enter a valid quantity \(1 to 10\) for plea and case management hearing fees'
+        'Enter a valid quantity \(1 to 10\) for plea and trial preparation hearing fees'
       end
 
       context 'basic fee (BAF)' do

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -543,10 +543,10 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
           }
 
           it {
-            should_error_if_equal_to_value(pcm_fee, :quantity, 4, fee_quantity_error_message)
+            should_error_if_equal_to_value(pcm_fee, :quantity, 11, fee_quantity_error_message)
           }
 
-          it { should_be_valid_if_equal_to_value(pcm_fee, :quantity, 3) }
+          it { should_be_valid_if_equal_to_value(pcm_fee, :quantity, 10) }
           it { should_be_valid_if_equal_to_value(pcm_fee, :quantity, 1) }
         end
 
@@ -578,10 +578,10 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
         }
 
         it {
-          should_error_if_equal_to_value(supplementary_pcm_fee, :quantity, 4, fee_quantity_error_message)
+          should_error_if_equal_to_value(supplementary_pcm_fee, :quantity, 11, fee_quantity_error_message)
         }
 
-        it { should_be_valid_if_equal_to_value(supplementary_pcm_fee, :quantity, 3) }
+        it { should_be_valid_if_equal_to_value(supplementary_pcm_fee, :quantity, 10) }
         it { should_be_valid_if_equal_to_value(supplementary_pcm_fee, :quantity, 1) }
       end
 


### PR DESCRIPTION
There was previous a limit of 3 PCPH fees allows. This has been increased, although there is still a limit for the moment.

#### What

Permit advocates to add up to 10 plea and trial preparation hearings on a claim.

#### Ticket

[Increase the number of PTPH fees that are claimable in CCCD](https://dsdmoj.atlassian.net/browse/CTSKF-1487)

#### Why

Providers have requested that the limit of 3 plea and trial preparation hearings on a claim should be lifted and there is no reason why this limit is in place.

#### How

Update the validator to allow up to 10 instead of 3.

Note that plea and trial preparation hearings (PTPH) were originally called plea and case management hearings (PCM) and this is still used in various places in the code.