### PR TITLE
[CTSKF-1552] Pin `connection_pool` to v2 to prevent document conversion sidekiq failures

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,6 +11,7 @@ gem 'bootsnap', require: false
 gem 'cancancan',              '~> 3.6'
 gem 'chartkick',              '~> 5.2.1'
 gem 'cocoon',                 '~> 1.2.15'
+gem 'connection_pool',        '< 3.0.0'    # This can be removed after Rails is updated to 8.1
 gem 'csv'
 gem 'devise', '~> 4.9.4'
 gem 'dotenv-rails', '~> 3.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -184,7 +184,7 @@ GEM
     config (5.6.1)
       deep_merge (~> 1.2, >= 1.2.1)
       ostruct
-    connection_pool (3.0.2)
+    connection_pool (2.5.5)
     crack (1.0.1)
       bigdecimal
       rexml
@@ -784,6 +784,7 @@ DEPENDENCIES
   cocoon (~> 1.2.15)
   concurrent-ruby (< 1.3.6)
   config (~> 5.6)
+  connection_pool (< 3.0.0)
   csv
   cucumber-rails (~> 4.0.0)
   database_cleaner


### PR DESCRIPTION
#### What

When a provider uploads a file, a background job converts it to a PDF. Caseworkers can then view the PDF version of the file in their browser. Since 18/12/2025, these Sidekiq document conversion jobs are not running. Sidekiq is receiving the jobs but not enqueuing them. There is currently a backlog of over 55,000 jobs.

<img width="2376" height="160" alt="image" src="https://github.com/user-attachments/assets/104fbf20-4d87-405e-8454-f66ea8563f32" />

This appears to be caused by an patch update to rails: https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/9096. This change bumped the version of the `connection_pool` gem from 2.5.5 to 3.0.2, which introduced an issue with sidekiq, leading to failures: https://ministryofjustice.sentry.io/issues/7121515787/events/39cd6632f98f4756af4b55085671f870/

The issue is discussed here:

https://github.com/sidekiq/sidekiq/issues/6886
https://github.com/rails/rails/pull/56292

This has been fixed in Rails 8.1 but the fix is not being backported to earlier Rails versions. The recommended solution is to pin `connection_pool` to v2.

#### Ticket

[CTSKF-1552](https://dsdmoj.atlassian.net/browse/CTSKF-1552)

#### Why

These failures mean that PDF versions of evidence are unavailable. Caseworkers have to download the original files to their devices and view them there. This takes more time, adds cognitive load, and is potentially less secure.

#### How

Pin the `connection_pool` gem to `< 3.0.0`.

This is temporary fix until we update CCCD to Rails 8.1, at which point this line can be removed from the `gemfile`.


#### Testing

Tested on staging: 

1) Uploaded two documents.
2) Viewed the Sidekiq console as a Super Admin user. The two documents remained scheduled:

<img width="1190" height="194" alt="image" src="https://github.com/user-attachments/assets/4444ddb6-b591-483f-9138-8bd19d637951" />

3) Deployed this change to staging.
4) Viewed the Sidekiq console again. The two documents were no longer scheduled and had been successfully processed: 

<img width="1195" height="131" alt="image" src="https://github.com/user-attachments/assets/79f1124e-2622-4d88-8556-f92b25b815ca" />

5) Uploaded a new document and monitored the Sidekiq console. The document was immediately scheduled and successfully processed.

This demonstrates that this fix will both clear the backlog and allow all new jobs to run successfully.

[CTSKF-1552]: https://dsdmoj.atlassian.net/browse/CTSKF-1552?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ