### PR TITLE
[CTSKF-1542] Unauthorised access to message attachments

### DIFF
--- a/app/controllers/messages_controller.rb
+++ b/app/controllers/messages_controller.rb
@@ -19,6 +19,8 @@ class MessagesController < ApplicationController
 
   respond_to :html
 
+  before_action :authorize_message_access!, only: [:download_attachment]
+
   def create
     @message = Message.new(message_params.merge(sender_id: current_user.id))
     attach_documents(@message)
@@ -40,6 +42,11 @@ class MessagesController < ApplicationController
 
   def message
     @message ||= Message.find(params[:id])
+  end
+
+  def authorize_message_access!
+    claim = message.claim
+    authorize! :show, claim
   end
 
   def redirect_to_url

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -19,6 +19,8 @@ require 'rails_helper'
 RSpec.describe MessagesController do
   context 'standard sign in' do
     let(:sender) { create(:external_user) }
+    let(:claim) { create(:claim, external_user: sender, creator: sender) }
+    let(:message) { create(:message, claim: claim, sender: sender.user) }
 
     before do
       sign_in sender.user
@@ -33,7 +35,6 @@ RSpec.describe MessagesController do
       end
 
       context 'when message has attachment' do
-        let(:message) { create(:message) }
         let(:test_url) { 'https://document.storage/attachment.doc#123abc' }
 
         before do
@@ -46,9 +47,7 @@ RSpec.describe MessagesController do
       end
 
       context 'when message does not have attachment' do
-        let(:message) { create(:message) }
-
-        it 'redirects to 500 page' do
+        it 'raises an exception' do
           expect { download_attachment }.to raise_exception('No attachment present on this message')
         end
       end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -1,19 +1,3 @@
-# == Schema Information
-#
-# Table name: messages
-#
-#  id                      :integer          not null, primary key
-#  body                    :text
-#  claim_id                :integer
-#  sender_id               :integer
-#  created_at              :datetime
-#  updated_at              :datetime
-#  attachment_file_name    :string
-#  attachment_content_type :string
-#  attachment_file_size    :integer
-#  attachment_updated_at   :datetime
-#
-
 require 'rails_helper'
 
 RSpec.describe MessagesController do
@@ -49,6 +33,18 @@ RSpec.describe MessagesController do
       context 'when message does not have attachment' do
         it 'raises an exception' do
           expect { download_attachment }.to raise_exception('No attachment present on this message')
+        end
+      end
+
+      context 'when user attempts to download another provider\'s message attachment' do
+        let(:other_user) { create(:external_user) }
+
+        before { sign_in other_user.user }
+
+        it 'denies access and redirects to root' do
+          download_attachment
+          expect(response).to redirect_to(external_users_root_url)
+          expect(flash[:alert]).to eq(I18n.t('common.unauthorised'))
         end
       end
     end

--- a/spec/controllers/messages_controller_spec.rb
+++ b/spec/controllers/messages_controller_spec.rb
@@ -1,3 +1,19 @@
+# == Schema Information
+#
+# Table name: messages
+#
+#  id                      :integer          not null, primary key
+#  body                    :text
+#  claim_id                :integer
+#  sender_id               :integer
+#  created_at              :datetime
+#  updated_at              :datetime
+#  attachment_file_name    :string
+#  attachment_content_type :string
+#  attachment_file_size    :integer
+#  attachment_updated_at   :datetime
+#
+
 require 'rails_helper'
 
 RSpec.describe MessagesController do


### PR DESCRIPTION
#### What
Fix [IDOR](https://owasp.org/www-project-web-security-testing-guide/latest/4-Web_Application_Security_Testing/05-Authorization_Testing/04-Testing_for_Insecure_Direct_Object_References) vulnerability where any authenticated user could download message attachments by knowing the message and attachment ID.

#### Ticket
[CTSKF-1542](https://dsdmoj.atlassian.net/browse/CTSKF-1542?atlOrigin=eyJpIjoiODVjOTA4M2IyOTk0NDhjMGEyMWIxYWI3OTViYzQwMjEiLCJwIjoiaiJ9)

#### Why
Make the application more secure.

#### How
I added a `before_action` callback that runs a security check before downloads. This check gets the claim associated with the message and uses CanCan's [authorize!](https://www.rubydoc.info/github/CanCanCommunity/cancancan/CanCan%2FControllerAdditions:authorize!) method to verify the user has permission to view that specific claim. If the logged in user isn't the claim's owner, CanCan raises an AccessDenied error and shows `Unauthorized`

#### Test
##### Before changes
1. `git pull` from main branch
2. start the server and login as `advocate@example.com`
3. visit `/external_users/claims/3` and within the chat box you'll find an attachment called `test_attachment_file.jpeg (6.55 KB)` copy it's download link http://localhost:3000/messages/74/download_attachment?attachment_id=143
4. logout and login as `litigator@example.com`
5. paste the link in the url and you'll see it downloads the file, proving IDOR vulnerability

##### After changes
1. `git pull` from `ctskf-1542-Unauthorised-access-to-message-attachments`
2. paste the link in the url again
3. you should be redirected to `/external_users` with an alert `Unauthorized`, proving the fix is in place

[CTSKF-1542]: https://dsdmoj.atlassian.net/browse/CTSKF-1542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ