### PR TITLE
Fix display of interim claim details

### DIFF
--- a/app/views/shared/_new_claim_interim_details.html.haml
+++ b/app/views/shared/_new_claim_interim_details.html.haml
@@ -1,52 +1,49 @@
 - fee = present(claim.interim_fee)
 
-= govuk_summary_card(title: t('shared.summary.fee')) do |card|
-  - card.with_summary_list do |summary_list|
+- summary_list.with_row do |row|
+  - row.with_key(text: t('shared.summary.fee_type'))
+  - row.with_value(text: fee.fee_type.description)
 
-    - summary_list.with_row do |row|
-      - row.with_key(text: t('shared.summary.fee_type'))
-      - row.with_value(text: fee.fee_type.description )
+- if fee.is_interim_warrant?
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.warrant_fee.date_issued'))
+    - row.with_value(text: fee.warrant_issued_date)
 
-    - if fee.is_interim_warrant?
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.warrant_fee.date_issued'))
-        - row.with_value(text: fee.warrant_issued_date )
+- if fee.warrant_executed_date.present?
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.warrant_fee.date_executed'))
+    - row.with_value(text: fee.warrant_executed_date)
 
-    - if fee.warrant_executed_date.present?
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.warrant_fee.date_executed'))
-        - row.with_value(text: fee.warrant_executed_date )
+- unless fee.is_disbursement?
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.ppe_total'))
+    - row.with_value(text: fee.quantity)
 
-    - unless fee.is_disbursement?
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.ppe_total'))
-        - row.with_value(text: fee.quantity )
+- if fee.is_effective_pcmh?
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.effective_pcmh_date'))
+    - row.with_value(text: fee.effective_pcmh_date)
 
-    - if fee.is_effective_pcmh?
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.effective_pcmh_date'))
-        - row.with_value(text: fee.effective_pcmh_date )
+- if fee.is_trial_start?
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.trial_start'))
+    - row.with_value(text: fee.first_day_of_trial )
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.estimated_trial_length'))
+    - row.with_value(text: fee.estimated_trial_length )
 
-    - if fee.is_trial_start?
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.trial_start'))
-        - row.with_value(text: fee.first_day_of_trial )
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.estimated_trial_length'))
-        - row.with_value(text: fee.estimated_trial_length )
+- if fee.is_retrial_start?
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.retrial_start'))
+    - row.with_value(text: fee.retrial_started_at)
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.estimated_retrial_length'))
+    - row.with_value(text: fee.retrial_estimated_length)
 
-    - if fee.is_retrial_start?
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.retrial_start'))
-        - row.with_value(text: fee.retrial_started_at )
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.estimated_retrial_length'))
-        - row.with_value(text: fee.retrial_estimated_length )
-
-    - if fee.is_retrial_new_solicitor?
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.legal_aid_transfer_date'))
-        - row.with_value(text: fee.legal_aid_transfer_date )
-      - summary_list.with_row do |row|
-        - row.with_key(text: t('shared.summary.trial_concluded_at'))
-        - row.with_value(text: fee.trial_concluded_at )
+- if fee.is_retrial_new_solicitor?
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.legal_aid_transfer_date'))
+    - row.with_value(text: fee.legal_aid_transfer_date)
+  - summary_list.with_row do |row|
+    - row.with_key(text: t('shared.summary.trial_concluded_at'))
+    - row.with_value(text: fee.trial_concluded_at)


### PR DESCRIPTION
#### What

Changes to the way summary lists are created has led to an error where details about LGFS interim claims are not being displayed on the claim summary screen.

This occurs because the `_new_claim_interim_details` partial defines its own summary card and list. This is being nested within the summary card defined by the `_new_claim` partial. This nesting is invalid and causes the data to not be displayed.

#### Why

So that caseworkers have access to all the data they need to assess claims.

#### How

Removes the creation of a new summary card and list from `_new_claim_interim_details` partial so that the summary list  passed in from the `_new_claim` partial is used instead.

#### Screenshots

**Original:**

<img width="975" height="590" alt="image" src="https://github.com/user-attachments/assets/57a911c7-aad4-41ba-ae8b-3cd058a6b30e" />

**Post component change:**

<img width="974" height="403" alt="image" src="https://github.com/user-attachments/assets/e5e50651-e573-4d2e-b1c8-7ebd09933b02" />

**Fixed:**

<img width="975" height="590" alt="image" src="https://github.com/user-attachments/assets/9794ac0e-0bcf-489e-9b31-f94c8d72f8d9" />
