### PR TITLE
[CTSKF-1572] Implement dev-sec-ops pipeline

### DIFF
--- a/.github/workflows/devsecops_sca_scan.yml
+++ b/.github/workflows/devsecops_sca_scan.yml
@@ -1,0 +1,29 @@
+name: DevSecOps SCA
+run-name: Software Composition Analysis
+
+on:
+  schedule:
+    - cron: "0 0 * * *" # Daily at midnight UTC
+  pull_request:
+    branches: ["main"]
+
+permissions: {}
+
+jobs:
+  sca:
+    name: Software Composition Analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+      security-events: read
+
+    steps:
+      - name: Run SCA
+        uses: ministryofjustice/devsecops-actions/sca@234ac1dca7bb965417bae451d3ea284a1286d68c
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          renovate: "false"

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,0 +1,3 @@
+config/settings/test.yml:generic-api-key:10
+config/settings/development.yml:generic-api-key:1
+config/initializers/devise.rb:generic-api-key:7

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -1,3 +1,8 @@
 config/settings/test.yml:generic-api-key:10
 config/settings/development.yml:generic-api-key:1
 config/initializers/devise.rb:generic-api-key:7
+vcr/cassettes/features/case_workers/admin/allocation.yml:generic-api-key:5
+vcr/cassettes/features/case_workers/admin/allocation.yml:generic-api-key:97
+vcr/cassettes/features/case_workers/admin/reallocation.yml:generic-api-key:5
+vcr/cassettes/features/case_workers/admin/reallocation.yml:generic-api-key:89
+vcr/cassettes/features/case_workers/admin/reallocation.yml:generic-api-key:174

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,3 +3,5 @@ repos:
     rev: v1.3.0
     hooks:
       - id: baseline
+        exclude: |
+          ^vcr/cassettes/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,5 @@
 repos:
   - repo: https://github.com/ministryofjustice/devsecops-hooks
-    rev: v1.3.0
+    rev: v1.5.0
     hooks:
       - id: baseline
-        exclude: |
-          ^vcr/cassettes/

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "stylelint-config-gds": "^2.0.0",
     "stylelint-order": "^6.0.4"
   },
+  "resolutions": {
+    "minimatch": "^10.2.1"
+  },
   "standard": {
     "env": [
       "jasmine",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1563,15 +1563,15 @@ babel-plugin-polyfill-regenerator@^0.6.5:
   dependencies:
     "@babel/helper-define-polyfill-provider" "^0.6.5"
 
-balanced-match@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
-  integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
 balanced-match@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-2.0.0.tgz#dc70f920d78db8b858535795867bf48f820633d9"
   integrity sha512-1ugUSr8BHXRnK23KfuYS+gVMC3LB8QGH9W1iGtDPsNWoQbgtXSExkBu2aDR4epiGWZOjZsj6lDl/N/AqqTC3UA==
+
+balanced-match@^4.0.2:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-4.0.4.tgz#bfb10662feed8196a2c62e7c68e17720c274179a"
+  integrity sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==
 
 baseline-browser-mapping@^2.9.0:
   version "2.9.19"
@@ -1598,20 +1598,12 @@ body-parser@^2.2.1:
     raw-body "^3.0.1"
     type-is "^2.0.1"
 
-brace-expansion@^1.1.7:
-  version "1.1.12"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-1.1.12.tgz#ab9b454466e5a8cc3a187beaad580412a9c5b843"
-  integrity sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==
+brace-expansion@^5.0.2:
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-5.0.3.tgz#6a9c6c268f85b53959ec527aeafe0f7300258eef"
+  integrity sha512-fy6KJm2RawA5RcHkLa1z/ScpBeA762UF9KmZQxwIbDtRJrgLzM10depAiEQ+CXYcoiqW1/m96OAAoke2nE9EeA==
   dependencies:
-    balanced-match "^1.0.0"
-    concat-map "0.0.1"
-
-brace-expansion@^2.0.1:
-  version "2.0.2"
-  resolved "https://registry.yarnpkg.com/brace-expansion/-/brace-expansion-2.0.2.tgz#54fc53237a613d854c7bd37463aad17df87214e7"
-  integrity sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ==
-  dependencies:
-    balanced-match "^1.0.0"
+    balanced-match "^4.0.2"
 
 braces@^3.0.3:
   version "3.0.3"
@@ -1776,11 +1768,6 @@ commander@^2.20.0:
   version "2.20.3"
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
-
-concat-map@0.0.1:
-  version "0.0.1"
-  resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
-  integrity sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==
 
 content-disposition@^1.0.0:
   version "1.0.0"
@@ -3716,26 +3703,12 @@ mini-css-extract-plugin@^2.9.4:
     schema-utils "^4.0.0"
     tapable "^2.2.1"
 
-minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.1.2.tgz#19cd194bfd3e428f049a70817c038d89ab4be35b"
-  integrity sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==
+minimatch@^10.2.1, minimatch@^3.0.5, minimatch@^3.1.1, minimatch@^3.1.2, minimatch@^5.0.1, minimatch@^9.0.4:
+  version "10.2.3"
+  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-10.2.3.tgz#c0ef582f21071b0123a5bbf275252ebda921fbf6"
+  integrity sha512-Rwi3pnapEqirPSbWbrZaa6N3nmqq4Xer/2XooiOKyV3q12ML06f7MOuc5DVH8ONZIFhwIYQ3yzPH4nt7iWHaTg==
   dependencies:
-    brace-expansion "^1.1.7"
-
-minimatch@^5.0.1:
-  version "5.1.6"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-5.1.6.tgz#1cfcb8cf5522ea69952cd2af95ae09477f122a96"
-  integrity sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==
-  dependencies:
-    brace-expansion "^2.0.1"
-
-minimatch@^9.0.4:
-  version "9.0.4"
-  resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-9.0.4.tgz#8e49c731d1749cbec05050ee5145147b32496a51"
-  integrity sha512-KqWh+VchfxcMNRAJjj2tnsSJdNbHsVgnkBhTNrW7AjVo6OvLtxw8zfT9oLw1JSohlFzJ8jCoTgaoXvJ+kHt6fw==
-  dependencies:
-    brace-expansion "^2.0.1"
+    brace-expansion "^5.0.2"
 
 minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.8"


### PR DESCRIPTION
#### What
Implement [DevSecOps SCA](https://github.com/ministryofjustice/devsecops-actions/blob/main/sca/README.md) workflow.

#### Ticket
[CTSKF-1572](https://dsdmoj.atlassian.net/browse/CTSKF-1572?atlOrigin=eyJpIjoiMDIwZTMwZDUxN2MyNDcwN2FlODNiYTg1YWI0MmIzYmUiLCJwIjoiaiJ9)

#### Why
To provide complete visibility into application's dependencies, vulnerabilities, and supply chain risks.

#### How
- Added `devsecops_sca_scan.yml` file
- Added false positive api keys to `.gitleaksignore` file

#### Notes
In order to address [minimatch cve](https://github.com/advisories/GHSA-f8q6-p94x-37v3), I've added a [yarn resolution](https://classic.yarnpkg.com/lang/en/docs/selective-version-resolutions/#toc-why-would-you-want-to-do-this) so dependencies that rely on `minimatch` specifically use the version `10.2.1` which fixes the CVE. For a long term solution, we'll need to migrate the `standard` library to `neostandard`.