### PR TITLE
(WIP) Modify navigation of claims for case workers

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -5,7 +5,7 @@ module CaseWorkers
     skip_load_and_authorize_resource
     authorize_resource class: Claim::BaseClaim
 
-    helper_method :sort_column, :sort_direction, :selection_type, :search_terms
+    helper_method :sort_column, :sort_direction, :selection_type, :tab, :search_terms
 
     respond_to :html
 
@@ -88,7 +88,7 @@ module CaseWorkers
 
     def set_claim_navigation
       @claim_navigation = Claims::CaseWorkerClaimsLocal.new(
-        current_user:, action: tab, sort_column:, sort_direction:, search: search_terms
+        current_user:, action: selection_type, sort_column:, sort_direction:, search: search_terms
       ).navigation(@claim)
     end
 
@@ -122,9 +122,7 @@ module CaseWorkers
     end
 
     def selection_type
-      return @selection_type ||= 'allocated' if params[:action] == 'index'
-
-      @selection_type ||= params[:action]
+      @selection_type ||= params[:selection_type].presence || 'current'
     end
 
     def search_terms

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -5,7 +5,7 @@ module CaseWorkers
     skip_load_and_authorize_resource
     authorize_resource class: Claim::BaseClaim
 
-    helper_method :sort_column, :sort_direction, :search_terms
+    helper_method :sort_column, :sort_direction, :selection_type, :search_terms
 
     respond_to :html
 
@@ -16,6 +16,7 @@ module CaseWorkers
     before_action :filter_archived_claims,  only: [:archived]
     before_action :sort_claims,             only: %i[index archived]
     before_action :set_claim, only: %i[show messages download_zip]
+    before_action :set_claim_navigation, only: :show
 
     include ReadMessages
     include MessageControlsDisplay
@@ -85,6 +86,12 @@ module CaseWorkers
       @claims = Claims::CaseWorkerClaims.new(current_user:, action: tab, criteria: criteria_params).claims
     end
 
+    def set_claim_navigation
+      @claim_navigation = Claims::CaseWorkerClaimsLocal.new(
+        current_user:, action: tab, sort_column:, sort_direction:
+      ).navigation(@claim)
+    end
+
     def set_presenters
       @defendant_presenter = CaseWorkers::DefendantPresenter
     end
@@ -112,6 +119,12 @@ module CaseWorkers
 
     def sort_direction
       %w[asc desc].include?(params[:direction]) ? params[:direction] : 'asc'
+    end
+
+    def selection_type
+      return @selection_type ||= 'allocated' if params[:action] == 'index'
+
+      @selection_type ||= params[:action]
     end
 
     def search_terms

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -88,7 +88,7 @@ module CaseWorkers
 
     def set_claim_navigation
       @claim_navigation = Claims::CaseWorkerClaimsLocal.new(
-        current_user:, action: tab, sort_column:, sort_direction:
+        current_user:, action: tab, sort_column:, sort_direction:, search: search_terms
       ).navigation(@claim)
     end
 

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -5,7 +5,7 @@ module CaseWorkers
     skip_load_and_authorize_resource
     authorize_resource class: Claim::BaseClaim
 
-    helper_method :sort_column, :sort_direction, :selection_type, :tab, :search_terms
+    helper_method :sort_column, :sort_direction, :selection_type, :tab, :navigation, :search_terms
 
     respond_to :html
 
@@ -16,7 +16,7 @@ module CaseWorkers
     before_action :filter_archived_claims,  only: [:archived]
     before_action :sort_claims,             only: %i[index archived]
     before_action :set_claim, only: %i[show messages download_zip]
-    before_action :set_claim_navigation, only: :show
+    before_action :set_navigation, only: :show
 
     include ReadMessages
     include MessageControlsDisplay
@@ -86,8 +86,8 @@ module CaseWorkers
       @claims = Claims::CaseWorkerClaims.new(current_user:, action: tab, criteria: criteria_params).claims
     end
 
-    def set_claim_navigation
-      @claim_navigation = Claims::CaseWorkerClaimsLocal.new(
+    def set_navigation
+      @navigation = Claims::CaseWorkerClaimsLocal.new(
         current_user:, action: selection_type, sort_column:, sort_direction:, search: search_terms
       ).navigation(@claim)
     end

--- a/app/helpers/case_workers/claims_helper.rb
+++ b/app/helpers/case_workers/claims_helper.rb
@@ -19,53 +19,6 @@ module CaseWorkers::ClaimsHelper
     Claim::BaseClaim.active.submitted_or_redetermination_or_awaiting_written_reasons.count
   end
 
-  def claim_position_and_count
-    "#{claim_ids.index(@claim.id) + 1} of #{claim_count}"
-  end
-
-  def not_first_claim?
-    (claim_ids.index(@claim.id) + 1) != 1
-  end
-
-  def not_last_claim?
-    (claim_ids.index(@claim.id) + 1) != claim_count.to_i
-  end
-
-  def last_claim?
-    (claim_ids.index(@claim.id) + 1) == claim_count.to_i
-  end
-
-  def next_claim_link
-    case_workers_claim_path(claim_ids[claim_ids.index(@claim.id) + 1], sort: sort_column, direction: sort_direction)
-  end
-
-  def previous_claim_link
-    case_workers_claim_path(claim_ids[claim_ids.index(@claim.id) - 1], sort: sort_column, direction: sort_direction)
-  end
-
-  def claim_ids
-    @claim_ids ||= current_user.claims.allocated.order(sql_sort_column => sql_sort_direction).pluck(:id)
-  end
-
-  def claim_count
-    @claim_count ||= claim_ids.count
-  end
-
-  def sql_sort_column
-    {
-      # 'type' => '???',
-      'case_number' => 'case_number',
-      # 'advocate' => '???',
-      # 'total_inc_vat' => '???',
-      # 'case_type' => '???',
-      'last_submitted_at' => 'last_submitted_at'
-    }[sort_column] || 'last_submitted_at'
-  end
-
-  def sql_sort_direction
-    %w[asc desc].include?(sort_direction) ? sort_direction : 'desc'
-  end
-
   def format_miscellaneous_fee_names(claim)
     claim.eligible_misc_fee_types.map do |fees|
       fees.description.split('(')[0].strip

--- a/app/helpers/case_workers/claims_helper.rb
+++ b/app/helpers/case_workers/claims_helper.rb
@@ -23,20 +23,47 @@ module CaseWorkers::ClaimsHelper
     "#{claim_ids.index(@claim.id) + 1} of #{claim_count}"
   end
 
+  def not_first_claim?
+    (claim_ids.index(@claim.id) + 1) != 1
+  end
+
+  def not_last_claim?
+    (claim_ids.index(@claim.id) + 1) != claim_count.to_i
+  end
+
   def last_claim?
     (claim_ids.index(@claim.id) + 1) == claim_count.to_i
   end
 
-  def next_claim_link(text, options = {})
-    govuk_link_to text, case_workers_claim_path(claim_ids[claim_ids.index(@claim.id) + 1]), options
+  def next_claim_link
+    case_workers_claim_path(claim_ids[claim_ids.index(@claim.id) + 1], sort: sort_column, direction: sort_direction)
+  end
+
+  def previous_claim_link
+    case_workers_claim_path(claim_ids[claim_ids.index(@claim.id) - 1], sort: sort_column, direction: sort_direction)
   end
 
   def claim_ids
-    session[:claim_ids]
+    @claim_ids ||= current_user.claims.allocated.order(sql_sort_column => sql_sort_direction).pluck(:id)
   end
 
   def claim_count
-    session[:claim_count]
+    @claim_count ||= claim_ids.count
+  end
+
+  def sql_sort_column
+    {
+      # 'type' => '???',
+      'case_number' => 'case_number',
+      # 'advocate' => '???',
+      # 'total_inc_vat' => '???',
+      # 'case_type' => '???',
+      'last_submitted_at' => 'last_submitted_at'
+    }[sort_column] || 'last_submitted_at'
+  end
+
+  def sql_sort_direction
+    %w[asc desc].include?(sort_direction) ? sort_direction : 'desc'
   end
 
   def format_miscellaneous_fee_names(claim)

--- a/app/services/claims/case_worker_claims.rb
+++ b/app/services/claims/case_worker_claims.rb
@@ -3,6 +3,7 @@ module Claims
     attr_accessor :current_user, :action, :criteria
 
     def initialize(current_user:, action:, criteria:)
+      # binding.pry
       self.current_user = current_user
       self.action = action
       self.criteria = criteria
@@ -21,6 +22,10 @@ module Claims
       else
         raise ArgumentError, format('Unknown action: %{s}', s: action)
       end
+    end
+
+    def next_after(claim)
+      claims.index(claim) + 1
     end
 
     private

--- a/app/services/claims/case_worker_claims.rb
+++ b/app/services/claims/case_worker_claims.rb
@@ -3,7 +3,6 @@ module Claims
     attr_accessor :current_user, :action, :criteria
 
     def initialize(current_user:, action:, criteria:)
-      # binding.pry
       self.current_user = current_user
       self.action = action
       self.criteria = criteria

--- a/app/services/claims/case_worker_claims_local.rb
+++ b/app/services/claims/case_worker_claims_local.rb
@@ -2,7 +2,7 @@ module Claims
   class CaseWorkerClaimsLocal
     PERMITTED = {
       actions: %w[current archived],
-      columns: %w[type case_number advocate total_inc_vat case_type last_submitted_at],
+      columns: %w[type case_number advocate total_inc_vat state case_type last_submitted_at],
       directions: %w[asc desc]
     }.freeze
 

--- a/app/services/claims/case_worker_claims_local.rb
+++ b/app/services/claims/case_worker_claims_local.rb
@@ -1,0 +1,77 @@
+module Claims
+  class CaseWorkerClaimsLocal
+    PERMITTED = {
+      actions: %w[current archived],
+      columns: %w[case_number last_submitted_at],
+      directions: %w[asc desc]
+    }.freeze
+
+    def initialize(current_user:, action:, sort_column: nil, sort_direction: nil)
+      @current_user = current_user
+      @action = fetch_permitted(:actions, action, default: 'current')
+      @sort_column = fetch_permitted(:columns, sort_column)
+      @sort_direction = fetch_permitted(:directions, sort_direction, default: 'asc')
+    end
+
+    def claims
+      @claims ||= case @action
+                  when 'current'
+                    sorted(current_claims)
+                  when 'archived'
+                    sorted(archived_claims)
+                  end
+    end
+
+    def navigation(claim)
+      {
+        previous: previous_claim_id(claim),
+        next: next_claim_id(claim),
+        position: claim_ids.index(claim.id) + 1,
+        count: claim_ids.count,
+        items: items(claim)
+      }
+    end
+
+    private
+
+    def claim_ids = @claim_ids ||= claims.pluck(:id)
+
+    def previous_claim_id(claim)
+      return if claim_ids.first == claim.id
+
+      claim_ids[claim_ids.index(claim.id) - 1]
+    end
+
+    def next_claim_id(claim)
+      return if claim_ids.last == claim.id
+
+      claim_ids[claim_ids.index(claim.id) + 1]
+    end
+
+    def items(claim)
+      [
+        ({ number: 1 } if claim_ids.first != claim.id),
+        ({ ellipsis: true } if claim_ids[0, 2].exclude?(claim.id)),
+        { number: claim_ids.index(claim.id) + 1, current: true },
+        ({ ellipsis: true } if claim_ids[-2, 2].exclude?(claim.id)),
+        ({ number: claim_ids.count } if claim_ids.last != claim.id)
+      ].compact
+    end
+
+    def fetch_permitted(key, value, default: nil) = PERMITTED[key].include?(value) ? value : default
+
+    def sorted(claims)
+      return claims if @sort_column.nil?
+
+      claims.sort_using(@sort_column, @sort_direction)
+    end
+
+    def current_claims
+      @current_user.claims.where(id: Claim::BaseClaim.search('', Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES))
+    end
+
+    def archived_claims
+      Claim::BaseClaim.active.search('', Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES)
+    end
+  end
+end

--- a/app/services/claims/case_worker_claims_local.rb
+++ b/app/services/claims/case_worker_claims_local.rb
@@ -2,15 +2,16 @@ module Claims
   class CaseWorkerClaimsLocal
     PERMITTED = {
       actions: %w[current archived],
-      columns: %w[case_number last_submitted_at],
+      columns: %w[type case_number advocate total_inc_vat case_type last_submitted_at],
       directions: %w[asc desc]
     }.freeze
 
-    def initialize(current_user:, action:, sort_column: nil, sort_direction: nil)
+    def initialize(current_user:, action:, sort_column: nil, sort_direction: nil, search: '')
       @current_user = current_user
       @action = fetch_permitted(:actions, action, default: 'current')
       @sort_column = fetch_permitted(:columns, sort_column)
       @sort_direction = fetch_permitted(:directions, sort_direction, default: 'asc')
+      @search = search
     end
 
     def claims
@@ -26,7 +27,7 @@ module Claims
       {
         previous: previous_claim_id(claim),
         next: next_claim_id(claim),
-        position: claim_ids.index(claim.id) + 1,
+        position: position(claim),
         count: claim_ids.count,
         items: items(claim)
       }
@@ -34,26 +35,35 @@ module Claims
 
     private
 
-    def claim_ids = @claim_ids ||= claims.pluck(:id)
+    # pluck would be more efficient than map but it causes problems with some of the sorting options
+    def claim_ids = @claim_ids ||= claims.map(&:id)
 
     def previous_claim_id(claim)
       return if claim_ids.first == claim.id
+      return unless claim_ids.include?(claim.id)
 
       claim_ids[claim_ids.index(claim.id) - 1]
     end
 
     def next_claim_id(claim)
       return if claim_ids.last == claim.id
+      return unless claim_ids.include?(claim.id)
 
       claim_ids[claim_ids.index(claim.id) + 1]
+    end
+
+    def position(claim)
+      return unless claim_ids.include?(claim.id)
+
+      claim_ids.index(claim.id) + 1
     end
 
     def items(claim)
       [
         ({ number: 1 } if claim_ids.first != claim.id),
-        ({ ellipsis: true } if claim_ids[0, 2].exclude?(claim.id)),
-        { number: claim_ids.index(claim.id) + 1, current: true },
-        ({ ellipsis: true } if claim_ids[-2, 2].exclude?(claim.id)),
+        ({ ellipsis: true } if claim_ids[0, 2]&.exclude?(claim.id)),
+        ({ number: position(claim), current: true } if claim_ids.include?(claim.id)),
+        ({ ellipsis: true } if claim_ids[-2, 2]&.exclude?(claim.id) && claim_ids.include?(claim.id)),
         ({ number: claim_ids.count } if claim_ids.last != claim.id)
       ].compact
     end
@@ -67,11 +77,23 @@ module Claims
     end
 
     def current_claims
-      @current_user.claims.where(id: Claim::BaseClaim.search('', Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES))
+      @current_user.claims.where(
+        id: Claim::BaseClaim.search(
+          @search, Claims::StateMachine::CASEWORKER_DASHBOARD_UNDER_ASSESSMENT_STATES, *search_options
+        )
+      )
     end
 
     def archived_claims
-      Claim::BaseClaim.active.search('', Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES)
+      Claim::BaseClaim.active.search(
+        @search, Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES, *search_options
+      )
+    end
+
+    def search_options
+      options = %i[case_number maat_reference defendant_name]
+      options << :case_worker_name_or_email if @current_user.persona.admin?
+      options
     end
   end
 end

--- a/app/services/claims/case_worker_claims_local.rb
+++ b/app/services/claims/case_worker_claims_local.rb
@@ -28,8 +28,7 @@ module Claims
         previous: previous_claim_id(claim),
         next: next_claim_id(claim),
         position: position(claim),
-        count: claim_ids.count,
-        items: items(claim)
+        count: claim_ids.count
       }
     end
 
@@ -56,16 +55,6 @@ module Claims
       return unless claim_ids.include?(claim.id)
 
       claim_ids.index(claim.id) + 1
-    end
-
-    def items(claim)
-      [
-        ({ number: 1 } if claim_ids.first != claim.id),
-        ({ ellipsis: true } if claim_ids[0, 2]&.exclude?(claim.id)),
-        ({ number: position(claim), current: true } if claim_ids.include?(claim.id)),
-        ({ ellipsis: true } if claim_ids[-2, 2]&.exclude?(claim.id) && claim_ids.include?(claim.id)),
-        ({ number: claim_ids.count } if claim_ids.last != claim.id)
-      ].compact
     end
 
     def fetch_permitted(key, value, default: nil) = PERMITTED[key].include?(value) ? value : default

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -46,7 +46,7 @@
             = row.with_cell(html_attributes: { 'data-label': t('.type') }, text: claim.pretty_type)
             = row.with_cell(html_attributes: { 'data-label': t('.case_number') }) do
               = govuk_link_to claim.case_number,
-                        case_workers_claim_path(claim),
+                        case_workers_claim_path(claim, sort: sort_column, direction: sort_direction),
                         class: 'js-test-case-number-link',
                         'aria-label': "View #{claim.state.humanize} Claim, Case number: #{claim.case_number}"
               = render partial: 'case_workers/injection_errors', locals: { claim: claim }

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -46,7 +46,7 @@
             = row.with_cell(html_attributes: { 'data-label': t('.type') }, text: claim.pretty_type)
             = row.with_cell(html_attributes: { 'data-label': t('.case_number') }) do
               = govuk_link_to claim.case_number,
-                        case_workers_claim_path(claim, sort: sort_column, direction: sort_direction, selection_type:, search: search_terms),
+                        case_workers_claim_path(claim, sort: sort_column, direction: sort_direction, selection_type: tab, search: search_terms),
                         class: 'js-test-case-number-link',
                         'aria-label': "View #{claim.state.humanize} Claim, Case number: #{claim.case_number}"
               = render partial: 'case_workers/injection_errors', locals: { claim: claim }

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -46,7 +46,7 @@
             = row.with_cell(html_attributes: { 'data-label': t('.type') }, text: claim.pretty_type)
             = row.with_cell(html_attributes: { 'data-label': t('.case_number') }) do
               = govuk_link_to claim.case_number,
-                        case_workers_claim_path(claim, sort: sort_column, direction: sort_direction),
+                        case_workers_claim_path(claim, sort: sort_column, direction: sort_direction, selection_type:),
                         class: 'js-test-case-number-link',
                         'aria-label': "View #{claim.state.humanize} Claim, Case number: #{claim.case_number}"
               = render partial: 'case_workers/injection_errors', locals: { claim: claim }

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -46,7 +46,7 @@
             = row.with_cell(html_attributes: { 'data-label': t('.type') }, text: claim.pretty_type)
             = row.with_cell(html_attributes: { 'data-label': t('.case_number') }) do
               = govuk_link_to claim.case_number,
-                        case_workers_claim_path(claim, sort: sort_column, direction: sort_direction, selection_type:),
+                        case_workers_claim_path(claim, sort: sort_column, direction: sort_direction, selection_type:, search: search_terms),
                         class: 'js-test-case-number-link',
                         'aria-label': "View #{claim.state.humanize} Claim, Case number: #{claim.case_number}"
               = render partial: 'case_workers/injection_errors', locals: { claim: claim }

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -10,8 +10,9 @@
           - if claim_ids.present? && claim_ids.include?(@claim.id)
             = t('shared.position_and_count', position: claim_position_and_count)
 
-            - unless last_claim?
-              = next_claim_link 'Next claim'.html_safe, class: 'next-claim'
+            = govuk_pagination(block_mode: true) do |p|
+              - p.with_previous_page(href: previous_claim_link, text: 'Previous') if not_first_claim?
+              - p.with_next_page(href: next_claim_link, text: 'Next') if not_last_claim?
 
   = render partial: 'shared/claim_history', locals: { claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -5,14 +5,7 @@
         = t('.h2_messages')
 
     .govuk-grid-column-one-half
-      - if current_user.persona.is_a?(CaseWorker)
-        .other-claims
-          - if claim_ids.present? && claim_ids.include?(@claim.id)
-            = t('shared.position_and_count', position: claim_position_and_count)
-
-            = govuk_pagination(block_mode: true) do |p|
-              - p.with_previous_page(href: previous_claim_link, text: 'Previous') if not_first_claim?
-              - p.with_next_page(href: next_claim_link, text: 'Next') if not_last_claim?
+      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @claim_navigation, current_user: }
 
   = render partial: 'shared/claim_history', locals: { claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }

--- a/app/views/shared/_claim_accordion.html.haml
+++ b/app/views/shared/_claim_accordion.html.haml
@@ -5,7 +5,7 @@
         = t('.h2_messages')
 
     .govuk-grid-column-one-half
-      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @claim_navigation, current_user: }
+      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @navigation, current_user: }
 
   = render partial: 'shared/claim_history', locals: { claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }

--- a/app/views/shared/_claim_header_beta.html.haml
+++ b/app/views/shared/_claim_header_beta.html.haml
@@ -11,9 +11,9 @@
             %p{ class: 'govuk-!-margin-bottom-0' }
               = t('shared.position_and_count', position: claim_position_and_count)
 
-            - unless last_claim?
-              %p
-                = next_claim_link 'Next claim', class: 'next-claim'
+            = govuk_pagination(block_mode: true) do |p|
+              - p.with_previous_page(href: previous_claim_link, text: 'Previous') if not_first_claim?
+              - p.with_next_page(href: next_claim_link, text: 'Next') if not_last_claim?
 
   %h1.govuk-heading-xl
     = claim.defendant_name_and_initial + claim.other_defendant_summary

--- a/app/views/shared/_claim_header_beta.html.haml
+++ b/app/views/shared/_claim_header_beta.html.haml
@@ -5,15 +5,7 @@
         = govuk_tag claim.state.humanize, class: "app-tag--#{claim.state}"
 
     .govuk-grid-column-one-half
-      - if current_user.persona.is_a?(CaseWorker)
-        .other-claims
-          - if claim_ids.present? && claim_ids.include?(@claim.id)
-            %p{ class: 'govuk-!-margin-bottom-0' }
-              = t('shared.position_and_count', position: claim_position_and_count)
-
-            = govuk_pagination(block_mode: true) do |p|
-              - p.with_previous_page(href: previous_claim_link, text: 'Previous') if not_first_claim?
-              - p.with_next_page(href: next_claim_link, text: 'Next') if not_last_claim?
+      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @claim_navigation, current_user: }
 
   %h1.govuk-heading-xl
     = claim.defendant_name_and_initial + claim.other_defendant_summary

--- a/app/views/shared/_claim_header_beta.html.haml
+++ b/app/views/shared/_claim_header_beta.html.haml
@@ -5,7 +5,7 @@
         = govuk_tag claim.state.humanize, class: "app-tag--#{claim.state}"
 
     .govuk-grid-column-one-half
-      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @claim_navigation, current_user: }
+      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @navigation, current_user: }
 
   %h1.govuk-heading-xl
     = claim.defendant_name_and_initial + claim.other_defendant_summary

--- a/app/views/shared/_new_claim_accordion.html.haml
+++ b/app/views/shared/_new_claim_accordion.html.haml
@@ -10,8 +10,9 @@
           - if claim_ids.present? && claim_ids.include?(@claim.id)
             = t('shared.position_and_count', position: claim_position_and_count)
 
-            - unless last_claim?
-              = next_claim_link 'Next claim'.html_safe, class: 'next-claim'
+            = govuk_pagination(block_mode: true) do |p|
+              - p.with_previous_page(href: previous_claim_link, text: 'Previous') if not_first_claim?
+              - p.with_next_page(href: next_claim_link, text: 'Next') if not_last_claim?
 
   = render partial: 'shared/claim_history', locals: { claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }

--- a/app/views/shared/_new_claim_accordion.html.haml
+++ b/app/views/shared/_new_claim_accordion.html.haml
@@ -5,14 +5,7 @@
         = t('.messages')
 
     .govuk-grid-column-one-half
-      - if current_user.persona.is_a?(CaseWorker)
-        .other-claims
-          - if claim_ids.present? && claim_ids.include?(@claim.id)
-            = t('shared.position_and_count', position: claim_position_and_count)
-
-            = govuk_pagination(block_mode: true) do |p|
-              - p.with_previous_page(href: previous_claim_link, text: 'Previous') if not_first_claim?
-              - p.with_next_page(href: next_claim_link, text: 'Next') if not_last_claim?
+      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @claim_navigation, current_user: }
 
   = render partial: 'shared/claim_history', locals: { claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }

--- a/app/views/shared/_new_claim_accordion.html.haml
+++ b/app/views/shared/_new_claim_accordion.html.haml
@@ -5,7 +5,7 @@
         = t('.messages')
 
     .govuk-grid-column-one-half
-      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @claim_navigation, current_user: }
+      = render partial: 'shared/other_claims_links', locals: {claim: claim, navigation: @navigation, current_user: }
 
   = render partial: 'shared/claim_history', locals: { claim: claim }
   = render partial: 'shared/claim_status', locals: { claim: claim, disabled: status_disabled }

--- a/app/views/shared/_other_claims_links.html.haml
+++ b/app/views/shared/_other_claims_links.html.haml
@@ -1,0 +1,7 @@
+- if current_user.persona.is_a?(CaseWorker)
+  .other-claims
+    - if navigation.present? && !navigation[:position].nil?
+      = govuk_pagination do |p|
+        - p.with_previous_page(href: case_workers_claim_path(navigation[:previous]), text: 'Previous') unless navigation[:previous].nil?
+        - p.with_items(navigation[:items])
+        - p.with_next_page(href: case_workers_claim_path(navigation[:next]), text: 'Next') unless navigation[:next].nil?

--- a/app/views/shared/_other_claims_links.html.haml
+++ b/app/views/shared/_other_claims_links.html.haml
@@ -2,6 +2,6 @@
   .other-claims
     - if navigation.present? && !navigation[:position].nil?
       = govuk_pagination do |p|
-        - p.with_previous_page(href: case_workers_claim_path(navigation[:previous]), text: 'Previous') unless navigation[:previous].nil?
+        - p.with_previous_page(href: case_workers_claim_path(navigation[:previous], **request.query_parameters), text: 'Previous') unless navigation[:previous].nil?
         - p.with_items(navigation[:items])
-        - p.with_next_page(href: case_workers_claim_path(navigation[:next]), text: 'Next') unless navigation[:next].nil?
+        - p.with_next_page(href: case_workers_claim_path(navigation[:next], **request.query_parameters), text: 'Next') unless navigation[:next].nil?

--- a/app/views/shared/_other_claims_links.html.haml
+++ b/app/views/shared/_other_claims_links.html.haml
@@ -1,7 +1,10 @@
 - if current_user.persona.is_a?(CaseWorker)
   .other-claims
-    - if navigation.present? && !navigation[:position].nil?
-      = govuk_pagination do |p|
-        - p.with_previous_page(href: case_workers_claim_path(navigation[:previous], **request.query_parameters), text: 'Previous') unless navigation[:previous].nil?
-        - p.with_items(navigation[:items])
-        - p.with_next_page(href: case_workers_claim_path(navigation[:next], **request.query_parameters), text: 'Next') unless navigation[:next].nil?
+    - if navigation.present? && navigation[:count] > 1
+      = t('shared.position_and_count', position: navigation[:position], count: navigation[:count])
+
+      %p
+        -if navigation[:previous].present?
+          = govuk_link_to 'Previous claim', case_workers_claim_path(navigation[:previous], **request.query_parameters)
+        -if navigation[:next].present?
+          = govuk_link_to 'Next claim', case_workers_claim_path(navigation[:next], **request.query_parameters)

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2671,6 +2671,7 @@ en:
     no_message_found: 'No messages found'
     summary_totals: 'Summary totals'
     vat: 'VAT'
+    position_and_count: 'Showing %{position} of %{count} claims'
     password_updated: 'Password successfully updated'
   case_workers:
     table_headings:

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2671,7 +2671,6 @@ en:
     no_message_found: 'No messages found'
     summary_totals: 'Summary totals'
     vat: 'VAT'
-    position_and_count: 'Showing %{position} claims'
     password_updated: 'Password successfully updated'
   case_workers:
     table_headings:

--- a/spec/helpers/case_workers/claims_helper_spec.rb
+++ b/spec/helpers/case_workers/claims_helper_spec.rb
@@ -72,47 +72,6 @@ describe CaseWorkers::ClaimsHelper do
     end
   end
 
-  context 'carousel helper methods' do
-    let(:claim_ids) { [1244, 36364, 3774, 2773, 73773] }
-
-    before do
-      allow(helper).to receive_messages(claim_ids:, claim_count: claim_ids.size)
-    end
-
-    describe '#claim_position_and_count' do
-      it 'returns the position and count of the claim in the list' do
-        assign(:claim, double(Claim::BaseClaim, id: 2773))
-        expect(helper.claim_position_and_count).to eq '4 of 5'
-      end
-    end
-
-    describe '#last_claim?' do
-      it 'returns true when it is the last claim' do
-        assign(:claim, double(Claim::BaseClaim, id: 73773))
-        expect(helper.last_claim?).to be true
-      end
-
-      it 'returns false when not the last claim' do
-        assign(:claim, double(Claim::BaseClaim, id: 3774))
-        expect(helper.last_claim?).to be false
-      end
-    end
-
-    describe '#next_claim_link' do
-      it 'returns a link for the next claim id in the series' do
-        assign(:claim, double(Claim::BaseClaim, id: 3774))
-        expect(helper.next_claim_link('my_text')).to eq(link_to('my_text', case_workers_claim_path(2773), class: 'govuk-link'))
-      end
-    end
-  end
-
-  describe 'claim_count' do
-    it 'returns the claim count from the session' do
-      session[:claim_count] = 3
-      expect(helper.claim_count).to eq 3
-    end
-  end
-
   describe '#format_miscellaneous_fee_names' do
     subject { format_miscellaneous_fee_names(claim) }
 

--- a/spec/services/claims/case_worker_claims_local_spec.rb
+++ b/spec/services/claims/case_worker_claims_local_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Claims::CaseWorkerClaimsLocal do
     let(:claim) { instance_double(Claim::BaseClaim, id: 25) }
 
     before do
-      selected_claims = instance_double(ActiveRecord::AssociationRelation, pluck: claim_ids)
+      selected_claims = instance_double(ActiveRecord::AssociationRelation, map: claim_ids)
       claims = instance_double(ActiveRecord::AssociationRelation, where: selected_claims)
       allow(case_worker).to receive(:claims).and_return(claims)
     end
@@ -158,6 +158,26 @@ RSpec.describe Claims::CaseWorkerClaimsLocal do
         expect(navigation[:items])
           .to eq([{ number: 1 }, { ellipsis: true }, { number: 4, current: true }])
       end
+    end
+
+    context 'when there is only one claim in the list' do
+      let(:claim_ids) { [claim.id] }
+
+      it { expect(navigation[:previous]).to be_nil }
+      it { expect(navigation[:next]).to be_nil }
+      it { expect(navigation[:position]).to eq(1) }
+      it { expect(navigation[:count]).to eq(1) }
+      it { expect(navigation[:items]).to eq([{ number: 1, current: true }]) }
+    end
+
+    context 'when the claim is not in the list' do
+      let(:claim_ids) { [57, 19, 98] }
+
+      it { expect(navigation[:previous]).to be_nil }
+      it { expect(navigation[:next]).to be_nil }
+      it { expect(navigation[:position]).to be_nil }
+      it { expect(navigation[:count]).to eq(3) }
+      it { expect(navigation[:items]).to eq([{ number: 1 }, { ellipsis: true }, { number: 3 }]) }
     end
   end
 end

--- a/spec/services/claims/case_worker_claims_local_spec.rb
+++ b/spec/services/claims/case_worker_claims_local_spec.rb
@@ -111,11 +111,6 @@ RSpec.describe Claims::CaseWorkerClaimsLocal do
       it { expect(navigation[:next]).to eq(57) }
       it { expect(navigation[:position]).to eq(1) }
       it { expect(navigation[:count]).to eq(4) }
-
-      it do
-        expect(navigation[:items])
-          .to eq([{ number: 1, current: true }, { ellipsis: true }, { number: 4 }])
-      end
     end
 
     context 'when the claim is the second in the list' do
@@ -125,11 +120,6 @@ RSpec.describe Claims::CaseWorkerClaimsLocal do
       it { expect(navigation[:next]).to eq(19) }
       it { expect(navigation[:position]).to eq(2) }
       it { expect(navigation[:count]).to eq(4) }
-
-      it do
-        expect(navigation[:items])
-          .to eq([{ number: 1 }, { number: 2, current: true }, { ellipsis: true }, { number: 4 }])
-      end
     end
 
     context 'when the claim is the third in the list' do
@@ -139,11 +129,6 @@ RSpec.describe Claims::CaseWorkerClaimsLocal do
       it { expect(navigation[:next]).to eq(98) }
       it { expect(navigation[:position]).to eq(3) }
       it { expect(navigation[:count]).to eq(4) }
-
-      it do
-        expect(navigation[:items])
-          .to eq([{ number: 1 }, { ellipsis: true }, { number: 3, current: true }, { number: 4 }])
-      end
     end
 
     context 'when the claim is the fourth in the list' do
@@ -153,11 +138,6 @@ RSpec.describe Claims::CaseWorkerClaimsLocal do
       it { expect(navigation[:next]).to be_nil }
       it { expect(navigation[:position]).to eq(4) }
       it { expect(navigation[:count]).to eq(4) }
-
-      it do
-        expect(navigation[:items])
-          .to eq([{ number: 1 }, { ellipsis: true }, { number: 4, current: true }])
-      end
     end
 
     context 'when there is only one claim in the list' do
@@ -167,7 +147,6 @@ RSpec.describe Claims::CaseWorkerClaimsLocal do
       it { expect(navigation[:next]).to be_nil }
       it { expect(navigation[:position]).to eq(1) }
       it { expect(navigation[:count]).to eq(1) }
-      it { expect(navigation[:items]).to eq([{ number: 1, current: true }]) }
     end
 
     context 'when the claim is not in the list' do
@@ -177,7 +156,6 @@ RSpec.describe Claims::CaseWorkerClaimsLocal do
       it { expect(navigation[:next]).to be_nil }
       it { expect(navigation[:position]).to be_nil }
       it { expect(navigation[:count]).to eq(3) }
-      it { expect(navigation[:items]).to eq([{ number: 1 }, { ellipsis: true }, { number: 3 }]) }
     end
   end
 end

--- a/spec/services/claims/case_worker_claims_local_spec.rb
+++ b/spec/services/claims/case_worker_claims_local_spec.rb
@@ -1,0 +1,163 @@
+require 'rails_helper'
+
+RSpec.describe Claims::CaseWorkerClaimsLocal do
+  let(:case_worker) { create(:case_worker) }
+
+  describe '#claims' do
+    subject(:claims) do
+      described_class.new(
+        current_user: case_worker.user, action:, sort_column:, sort_direction:
+      ).claims
+    end
+
+    before do
+      admin = create(:case_worker, :admin)
+      allocator_options = {
+        current_user: admin.user,
+        case_worker_id: case_worker.id,
+        deallocate: false,
+        allocating: true
+      }
+      [
+        create(:claim, case_number: 'C123'),
+        create(:claim, case_number: 'C124'),
+        create(:claim, case_number: 'C122')
+      ].each do |claim|
+        claim.submit!
+        allocator_options[:claim_ids] = [claim.id]
+        allocator = Allocation.new(allocator_options)
+        allocator.save
+        claim.reload
+      end
+      [
+        create(:claim, :archived_pending_delete, case_number: 'C126'),
+        create(:claim, :archived_pending_delete, case_number: 'C127'),
+        create(:claim, :archived_pending_delete, case_number: 'C125')
+      ].each { |claim| claim.case_workers = [case_worker] }
+    end
+
+    context 'with current action' do
+      let(:action) { 'current' }
+
+      let(:sort_column) { nil }
+      let(:sort_direction) { nil }
+
+      it { expect(claims.count).to eq(3) }
+
+      context 'when sorting by case number ascending' do
+        let(:sort_column) { 'case_number' }
+        let(:sort_direction) { 'asc' }
+
+        it { expect(claims[0].case_number).to eq('C122') }
+        it { expect(claims[1].case_number).to eq('C123') }
+        it { expect(claims[2].case_number).to eq('C124') }
+      end
+
+      context 'when sorting by case number descending' do
+        let(:sort_column) { 'case_number' }
+        let(:sort_direction) { 'desc' }
+
+        it { expect(claims[0].case_number).to eq('C124') }
+        it { expect(claims[1].case_number).to eq('C123') }
+        it { expect(claims[2].case_number).to eq('C122') }
+      end
+    end
+
+    context 'with archived action' do
+      let(:action) { 'archived' }
+
+      let(:sort_column) { nil }
+      let(:sort_direction) { nil }
+
+      it { expect(claims.count).to eq(3) }
+
+      context 'when sorting by case number ascending' do
+        let(:sort_column) { 'case_number' }
+        let(:sort_direction) { 'asc' }
+
+        it { expect(claims[0].case_number).to eq('C125') }
+        it { expect(claims[1].case_number).to eq('C126') }
+        it { expect(claims[2].case_number).to eq('C127') }
+      end
+
+      context 'when sorting by case number descending' do
+        let(:sort_column) { 'case_number' }
+        let(:sort_direction) { 'desc' }
+
+        it { expect(claims[0].case_number).to eq('C127') }
+        it { expect(claims[1].case_number).to eq('C126') }
+        it { expect(claims[2].case_number).to eq('C125') }
+      end
+    end
+  end
+
+  describe '#navigation' do
+    subject(:navigation) do
+      described_class.new(current_user: case_worker.user, action: 'current').navigation(claim)
+    end
+
+    let(:claim) { instance_double(Claim::BaseClaim, id: 25) }
+
+    before do
+      selected_claims = instance_double(ActiveRecord::AssociationRelation, pluck: claim_ids)
+      claims = instance_double(ActiveRecord::AssociationRelation, where: selected_claims)
+      allow(case_worker).to receive(:claims).and_return(claims)
+    end
+
+    context 'when the claim is the first in the list' do
+      let(:claim_ids) { [claim.id, 57, 19, 98] }
+
+      it { expect(navigation[:previous]).to be_nil }
+      it { expect(navigation[:next]).to eq(57) }
+      it { expect(navigation[:position]).to eq(1) }
+      it { expect(navigation[:count]).to eq(4) }
+
+      it do
+        expect(navigation[:items])
+          .to eq([{ number: 1, current: true }, { ellipsis: true }, { number: 4 }])
+      end
+    end
+
+    context 'when the claim is the second in the list' do
+      let(:claim_ids) { [57, claim.id, 19, 98] }
+
+      it { expect(navigation[:previous]).to eq(57) }
+      it { expect(navigation[:next]).to eq(19) }
+      it { expect(navigation[:position]).to eq(2) }
+      it { expect(navigation[:count]).to eq(4) }
+
+      it do
+        expect(navigation[:items])
+          .to eq([{ number: 1 }, { number: 2, current: true }, { ellipsis: true }, { number: 4 }])
+      end
+    end
+
+    context 'when the claim is the third in the list' do
+      let(:claim_ids) { [57, 19, claim.id, 98] }
+
+      it { expect(navigation[:previous]).to eq(19) }
+      it { expect(navigation[:next]).to eq(98) }
+      it { expect(navigation[:position]).to eq(3) }
+      it { expect(navigation[:count]).to eq(4) }
+
+      it do
+        expect(navigation[:items])
+          .to eq([{ number: 1 }, { ellipsis: true }, { number: 3, current: true }, { number: 4 }])
+      end
+    end
+
+    context 'when the claim is the fourth in the list' do
+      let(:claim_ids) { [57, 19, 98, claim.id] }
+
+      it { expect(navigation[:previous]).to eq(98) }
+      it { expect(navigation[:next]).to be_nil }
+      it { expect(navigation[:position]).to eq(4) }
+      it { expect(navigation[:count]).to eq(4) }
+
+      it do
+        expect(navigation[:items])
+          .to eq([{ number: 1 }, { ellipsis: true }, { number: 4, current: true }])
+      end
+    end
+  end
+end


### PR DESCRIPTION
#### What

There is a bug with the navigation for when case workers are going through claims, they cannot navigate backwards in the UI.

#### Ticket

[CTSKF-1553](https://dsdmoj.atlassian.net/browse/CTSKF-1553)

#### Why

#### How

--------

#### TODO (wip)

 - [ ] The navigation information disappears when an authorisation has ben approved or declined.


[CTSKF-1553]: https://dsdmoj.atlassian.net/browse/CTSKF-1553?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ