### PR TITLE
 Restrict caseworkers to only access their assigned claims

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -25,6 +25,7 @@ module CaseWorkers
     def archived; end
 
     def show
+      authorize! :show, @claim
       prepare_show_action
     end
 

--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -16,6 +16,7 @@ module CaseWorkers
     before_action :filter_archived_claims,  only: [:archived]
     before_action :sort_claims,             only: %i[index archived]
     before_action :set_claim, only: %i[show messages download_zip]
+    before_action :authorize_claim, only: %i[show download_zip messages update]
 
     include ReadMessages
     include MessageControlsDisplay
@@ -25,7 +26,6 @@ module CaseWorkers
     def archived; end
 
     def show
-      authorize! :show, @claim
       prepare_show_action
     end
 
@@ -136,6 +136,10 @@ module CaseWorkers
 
     def criteria_params
       { sorting: sort_column, direction: sort_direction, page: current_page, limit: page_size, search: search_terms }
+    end
+
+    def authorize_claim
+      authorize! action_name.to_sym, @claim
     end
   end
 end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -58,7 +58,10 @@ class Ability
   end
 
   def case_worker(persona)
-    can %i[index show show_message_controls archived], Claim::BaseClaim
+    can [:index], Claim::BaseClaim
+    can %i[show show_message_controls archived], Claim::BaseClaim do |claim|
+      claim.case_workers.map(&:id).include?(persona.id)
+    end
     can [:update], Claim::BaseClaim do |claim|
       claim.case_workers.include?(persona)
     end

--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -58,12 +58,8 @@ class Ability
   end
 
   def case_worker(persona)
-    can [:index], Claim::BaseClaim
-    can %i[show show_message_controls archived], Claim::BaseClaim do |claim|
+    can %i[show show_message_controls update index archived], Claim::BaseClaim do |claim|
       claim.case_workers.map(&:id).include?(persona.id)
-    end
-    can [:update], Claim::BaseClaim do |claim|
-      claim.case_workers.include?(persona)
     end
     can_administer_any_provider if persona.roles.include?('provider_management')
     can %i[upload delete], Document
@@ -125,7 +121,7 @@ class Ability
 
   def can_manage_own_claims_of_class(persona, claim_klass)
     can [:create], ClaimIntention
-    can %i[index outstanding authorised archived new create], claim_klass
+    can %i[index outstanding authorised archived new create], claim_klass, external_user_id: persona.id
     can MANAGE_CLAIM_METHODS, claim_klass, external_user_id: persona.id
     can %i[show create update], Certification
     can_manage_own_documents(persona)

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -54,9 +54,12 @@ RSpec.describe CaseWorkers::ClaimsController do
   describe 'GET download_zip' do
     let(:claim) { create(:claim) }
 
-    before { get :download_zip, params: { id: claim } }
+    before do
+      claim.case_workers << @case_worker
+      get :download_zip, params: { id: claim }
+    end
 
-    it 'responds with an http success' do
+    it 'responds  with an http success' do
       expect(response).to be_successful
     end
 
@@ -72,7 +75,10 @@ RSpec.describe CaseWorkers::ClaimsController do
   describe 'GET show' do
     let(:claim) { create(:claim) }
 
-    before { get :show, params: { id: claim } }
+    before do
+      claim.case_workers << @case_worker
+      get :show, params: { id: claim }
+    end
 
     it 'responds with an http success' do
       expect(response).to be_successful
@@ -93,6 +99,7 @@ RSpec.describe CaseWorkers::ClaimsController do
     let(:claim) { create(:claim) }
 
     it 'renders the messages partial' do
+      claim.case_workers << @case_worker
       get :messages, params: { id: claim.id }
       expect(response).to render_template('messages/claim_messages')
     end
@@ -104,6 +111,7 @@ RSpec.describe CaseWorkers::ClaimsController do
     let(:params) { strong_params('additional_information' => 'foo bar', 'current_user' => @case_worker.user) }
 
     before do
+      claim.case_workers << @case_worker
       expect(updater).to receive(:update!).and_return(updater)
       expect(updater).to receive(:claim).and_return(claim)
       expect(Claims::CaseWorkerClaimUpdater).to receive(:new).with(claim.id.to_s, params).and_return(updater)

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -59,7 +59,7 @@ RSpec.describe CaseWorkers::ClaimsController do
       get :download_zip, params: { id: claim }
     end
 
-    it 'responds  with an http success' do
+    it 'responds with an http success' do
       expect(response).to be_successful
     end
 
@@ -82,6 +82,13 @@ RSpec.describe CaseWorkers::ClaimsController do
 
     it 'responds with an http success' do
       expect(response).to be_successful
+    end
+
+    it 'responds with a forbidden status if the claim is not assigned to the case worker' do
+      other_claim = create(:claim)
+      get :show, params: { id: other_claim }
+      expect(response).to redirect_to(case_workers_root_url)
+      expect(flash[:alert]).to eq(I18n.t('common.unauthorised'))
     end
 
     it 'populates instance variables' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -411,8 +411,26 @@ RSpec.describe Ability do
     it { should be_able_to(:update_settings, user) }
     it { should_not be_able_to(:update_settings, another_user) }
 
-    %i[index archived show show_message_controls].each do |action|
+    %i[index archived].each do |action|
       it { should be_able_to(action, Claim::AdvocateClaim.new) }
+    end
+
+    context 'can show and view message controls when assigned to claim' do
+      let(:claim) { create(:advocate_claim) }
+
+      before { case_worker.claims << claim }
+
+      %i[show show_message_controls archived].each do |action|
+        it { should be_able_to(action, claim) }
+      end
+    end
+
+    context 'cannot show or view message controls when not assigned to claim' do
+      let(:claim) { create(:advocate_claim) }
+
+      %i[show show_message_controls archived].each do |action|
+        it { should_not be_able_to(action, claim) }
+      end
     end
 
     context 'can update claim when assigned to claim' do

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -407,12 +407,15 @@ RSpec.describe Ability do
   context 'case worker' do
     let(:case_worker) { create(:case_worker) }
     let(:user) { case_worker.user }
+    let(:claim) { create(:advocate_claim) }
+
+    before { case_worker.claims << claim }
 
     it { should be_able_to(:update_settings, user) }
     it { should_not be_able_to(:update_settings, another_user) }
 
     %i[index archived].each do |action|
-      it { should be_able_to(action, Claim::AdvocateClaim.new) }
+      it { should be_able_to(action, claim) }
     end
 
     context 'can show and view message controls when assigned to claim' do
@@ -426,7 +429,7 @@ RSpec.describe Ability do
     end
 
     context 'cannot show or view message controls when not assigned to claim' do
-      let(:claim) { create(:advocate_claim) }
+      let(:claim) { create(:advocate_claim, id: 12_345) }
 
       %i[show show_message_controls archived].each do |action|
         it { should_not be_able_to(action, claim) }


### PR DESCRIPTION
#### What
Prevent unauthorised access to documents by limiting caseworkers to only being able to view claims specifically allocated to them. 

#### Ticket
[CCCD: Unauthorised access to documents](https://dsdmoj.atlassian.net/browse/CTSKF-1543)

#### Why
- Ensured that caseworkers cannot view or interact with claims assigned to other caseworkers, improving data security and privacy.

#### How
Update the Ability class CanCanCan from allowing caseworker persona to persona.id specific to the caseworker user. 
Add explicit authorisation in the Claims controller show action.  
- Updated CanCanCan ability for caseworkers to restrict access to view only those claims where the current caseworker is assigned (by ID).
- Added explicit  check in to enforce instance-level authorization and prevent bypassing restrictions via URL manipulation.

#### Tested manually
Manually tested in the browser by allocating claims to caseworkers Charles `charles.asare@legalaid.gsi.gov.uk` and Chloe `chloe.atkin@legalaid.gsi.gov.uk` when signed in as a Caseworkeradmin and then signed as these caseworkers. 
