### PR TITLE
Add conditions to the casworker document ability to restrict access t…

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -64,7 +64,9 @@ class Ability
     end
     can_administer_any_provider if persona.roles.include?('provider_management')
     can %i[upload delete], Document
-    can %i[show download], Document
+    can %i[show download], Document do |document|
+      document.claim.case_workers.include?(persona)
+    end
     can %i[index feedback], CourtData
     can_manage_own_password(persona)
     can %i[dismiss], InjectionAttempt

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -435,9 +435,23 @@ RSpec.describe Ability do
       end
     end
 
-    context 'can view and download documents' do
+    context 'can view and download documents on allocated claims' do
+      let(:claim) { create(:advocate_claim) }
+      let(:document) { create(:document, claim:) }
+
+      before { case_worker.claims << claim }
+
       %i[show download].each do |action|
-        it { should be_able_to(action, Document.new) }
+        it { should be_able_to(action, document) }
+      end
+    end
+
+    context 'can not view and download documents on claims that are not allocated to them' do
+      let(:claim) { create(:advocate_claim) }
+      let(:document) { create(:document, claim:) }
+
+      %i[show download].each do |action|
+        it { should_not be_able_to(action, document) }
       end
     end
 


### PR DESCRIPTION
…o allocated caseworker.

#### What

Prevent unauthorised access to documents that are not associated with a claim that has been allocated to them. 


#### Ticket

[CCCD: Unauthorised access to documents](https://dsdmoj.atlassian.net/browse/CTSKF-1543)

#### Why
Ensured that caseworkers cannot access documents by claims assigned to other caseworkers, improving data security and privacy.

#### How

Update the Ability class so these conditions are added. 

