### PR TITLE
Use SHA pinning for Github actions

### DIFF
--- a/.github/workflows/docker_image_scan_test.yml
+++ b/.github/workflows/docker_image_scan_test.yml
@@ -1,0 +1,70 @@
+name: Scan docker image (test)
+on:
+  schedule:
+    - cron: '30 7 * * *'
+
+jobs:
+  scan-docker-image:
+    runs-on: ubuntu-latest
+    name: Scan docker image
+    steps:
+    - name: Checkout
+      uses: actions/checkout@vde0fac2e4500dabe0009e67214ff5f5447ce83dd
+
+    - name: Build docker image
+      run: |
+        docker build \
+          --tag cccd:scan \
+          --file docker/Dockerfile .
+
+    - name: Scan docker image using snyk
+      id: image-scan
+      continue-on-error: true
+      uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        image: cccd:scan
+        args: --file=docker/Dockerfile
+
+    - name: Monitor docker image using snyk
+      id: image-monitor
+      uses: snyk/actions/docker@9adf32b1121593767fc3c057af55b55db032dc04
+      env:
+        SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+      with:
+        command: monitor
+        image: cccd:scan
+        args: --file=docker/Dockerfile
+
+    - name: Upload result to GitHub Code Scanning
+      uses: github/codeql-action/upload-sarif@vc793b717bc78562f491db7b0e93a3a178b099162
+      with:
+        sarif_file: snyk.sarif
+
+    - name: Slack notify failure
+      if: ${{ steps.image-scan.outcome == 'failure' }}
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+      env:
+        SLACK_USERNAME: Snyk docker image scan
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: laa-cccd-alerts
+        SLACK_ICON_EMOJI: ':snyk:'
+        SLACK_COLOR: ${{ steps.image-scan.outcome }}
+        SLACK_TITLE: Scanned ${{ github.repository }}
+        SLACK_MESSAGE: docker scan detected vulnerabilites! @laa-claim-for-payment-devs
+        SLACK_LINK_NAMES: true
+        SLACK_FOOTER:
+
+    - name: Slack notify success
+      if: ${{ steps.image-scan.outcome == 'success' }}
+      uses: rtCamp/action-slack-notify@e31e87e03dd19038e411e38ae27cbad084a90661
+      env:
+        SLACK_USERNAME: Snyk docker image scan
+        SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+        SLACK_CHANNEL: laa-claim-for-payment-development
+        SLACK_ICON_EMOJI: ':snyk:'
+        SLACK_COLOR: ${{ steps.image-scan.outcome }}
+        SLACK_TITLE: Scanned ${{ github.repository }}
+        SLACK_MESSAGE: docker scan found no vulnerabilites!
+        SLACK_FOOTER:


### PR DESCRIPTION
#### What

Use SHA pinning for Github actions

#### Ticket

N/A

#### Why

Supply chain attacks can occur when upstream packages include malicious changes that are automatically picked up due to actions being pulled from Github based on the current master branch or the latest released version. These attacks can be avoided by fetching actions based on specific commits.

#### How

Replace all versions of Github actions in the pipelines with the corresponding commits.

As a first step a new pipeline is created so that it can be validated without breaking the existing pipeline.