### PR TITLE
Ctskf 1545 cccd nil dereference + validation bypass in unarchive

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -160,7 +160,8 @@ module ExternalUsers
     def unarchive
       claim_url = external_users_claim_url(@claim)
       return redirect_to claim_url, alert: t('.not_archived') unless unarchive_allowed?
-      @claim = @claim.paper_trail.previous_version
+      version = @claim.versions.last
+      @claim = version.reify
       @claim.zeroise_nil_totals!
       @claim.save!(validate: false)
       redirect_to external_users_claims_url, notice: t('.unarchived')

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -160,13 +160,17 @@ module ExternalUsers
     def unarchive
       claim_url = external_users_claim_url(@claim)
       return redirect_to claim_url, alert: t('.not_archived') unless unarchive_allowed?
+
       version = @claim.versions.last
       return redirect_to claim_url, alert: t('.cannot_unarchive_no_version') unless version
+
       @claim = version.reify
       @claim.zeroise_nil_totals!
       @claim.save!(validate: false)
       redirect_to external_users_claims_url, notice: t('.unarchived')
-    rescue StandardError
+    rescue ActiveRecord::RecordNotSaved,
+      ActiveRecord::StatementInvalid => e
+      Rails.logger.error(e.full_message)
       redirect_to claim_url, alert: t('.unarchivable')
     end
 

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -160,12 +160,10 @@ module ExternalUsers
     def unarchive
       claim_url = external_users_claim_url(@claim)
       return redirect_to claim_url, alert: t('.not_archived') unless unarchive_allowed?
-      claim_previous_version
+      @claim = @claim.paper_trail.previous_version
+      return redirect_to claim_url, alert: t('.unarchivable') if @claim.nil?
       @claim.zeroise_nil_totals!
       @claim.save!(validate: false)
-    rescue ActiveRecord::RecordNotSaved, ActiveRecord::StatementInvalid => e
-      Rails.logger.error(e.full_message)
-      redirect_to claim_url, alert: t('.unarchivable')
     end
 
     class << self
@@ -185,15 +183,6 @@ module ExternalUsers
     end
 
     private
-
-    def claim_previous_version
-      version = @claim.versions.last
-      unless version
-        return redirect_to claim_url,
-                           alert: t('external_users.claims.unarchive.cannot_unarchive_no_version')
-      end
-      @claim = version.reify
-    end
 
     def log(message, error: nil, level: :info)
       log_data = {

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -160,18 +160,11 @@ module ExternalUsers
     def unarchive
       claim_url = external_users_claim_url(@claim)
       return redirect_to claim_url, alert: t('.not_archived') unless unarchive_allowed?
-
-      version = @claim.versions.last
-      return redirect_to claim_url, alert: t('.cannot_unarchive_no_version') unless version
-
-      @claim = version.reify
+      claim_previous_version
       @claim.zeroise_nil_totals!
       @claim.save!(validate: false)
       redirect_to external_users_claims_url, notice: t('.unarchived')
-    rescue ActiveRecord::RecordNotSaved,
-      ActiveRecord::StatementInvalid => e
-      Rails.logger.error(e.full_message)
-      redirect_to claim_url, alert: t('.unarchivable')
+      rescue_and_log_errors
     end
 
     class << self
@@ -191,6 +184,22 @@ module ExternalUsers
     end
 
     private
+
+    def rescue_and_log_errors
+    rescue ActiveRecord::RecordNotSaved,
+           ActiveRecord::StatementInvalid => e
+      Rails.logger.error(e.full_message)
+      redirect_to claim_url, alert: t('external_users.claims.unarchive.unarchivable')
+    end
+
+    def claim_previous_version
+      version = @claim.versions.last
+      unless version
+        return redirect_to claim_url,
+                           alert: t('external_users.claims.unarchive.cannot_unarchive_no_version')
+      end
+      @claim = version.reify
+    end
 
     def log(message, error: nil, level: :info)
       log_data = {

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -161,6 +161,7 @@ module ExternalUsers
       claim_url = external_users_claim_url(@claim)
       return redirect_to claim_url, alert: t('.not_archived') unless unarchive_allowed?
       version = @claim.versions.last
+      return redirect_to claim_url, alert: t('.cannot_unarchive_no_version') unless version
       @claim = version.reify
       @claim.zeroise_nil_totals!
       @claim.save!(validate: false)

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -163,8 +163,9 @@ module ExternalUsers
       claim_previous_version
       @claim.zeroise_nil_totals!
       @claim.save!(validate: false)
-      redirect_to external_users_claims_url, notice: t('.unarchived')
-      rescue_and_log_errors
+    rescue ActiveRecord::RecordNotSaved, ActiveRecord::StatementInvalid => e
+      Rails.logger.error(e.full_message)
+      redirect_to claim_url, alert: t('.unarchivable')
     end
 
     class << self
@@ -184,13 +185,6 @@ module ExternalUsers
     end
 
     private
-
-    def rescue_and_log_errors
-    rescue ActiveRecord::RecordNotSaved,
-           ActiveRecord::StatementInvalid => e
-      Rails.logger.error(e.full_message)
-      redirect_to claim_url, alert: t('external_users.claims.unarchive.unarchivable')
-    end
 
     def claim_previous_version
       version = @claim.versions.last

--- a/app/services/claims/external_user_claim_updater.rb
+++ b/app/services/claims/external_user_claim_updater.rb
@@ -17,6 +17,8 @@ module Claims
       else
         claim.archive_pending_delete!(audit_attributes)
       end
+      # Force a PT version even if validations were skipped or callbacks differ
+      claim.paper_trail.save_with_version(validate: false)
     end
 
     def clone_rejected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -896,6 +896,7 @@ en:
       unarchive:
         not_archived: 'This claim is not in the archive'
         unarchivable: 'This claim cannot be unarchived'
+        cannot_unarchive_no_version: 'This claim cannot be unarchived as there is no previous version to restore'
         unarchived: 'Claim unarchived'
       hints:
         fees_header_prompt_text_html: &fees_vat_prompt All fees should be entered exclusive of VAT.

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -827,12 +827,19 @@ RSpec.describe ExternalUsers::ClaimsController do
     end
 
     context 'when the claim is archived with assessed values' do
+      # It looks like there were some changes to the validation rules which meant that a claim could end up in a situation where:
+      # Validation is set to false so that this test is testing that behaviour.
+      # - it was originally valid
+      # - it was archived
+      # - the validation rules changed
+      # - if someone tried to unarchive the claim it would now be invalid and the the unarchiving would fail.
       subject(:claim) { create(:advocate_claim, external_user: advocate) }
 
       before do
         claim.submit!
         claim.allocate!
-        claim.assessment.update(fees: 123.00, expenses: 23.45)
+        claim.assessment.update(fees: 123.00, expenses: 23.45) # cant be zero for part auth but must be zero for refused state
+        # the line above was relying on @claim.save! to have been called with validate:false.
         claim.authorise_part!
         claim.redetermine!
         claim.allocate!

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -824,6 +824,10 @@ RSpec.describe ExternalUsers::ClaimsController do
       it 'redirects to external users root url' do
         expect(response).to redirect_to(external_users_claim_url(claim))
       end
+
+      it 'displays a success message' do
+        expect(flash[:alert]).to eq('This claim is not in the archive')
+      end
     end
 
     context 'when the claim is archived with assessed values' do


### PR DESCRIPTION
#### What
Improved the unarchive flow to avoid crashes and stop masking real errors.
I did not remove `(validate: false) ` as 

"it looks like there were some changes to the validation rules which meant that a claim could end up in a situation where:
- it was originally valid
- it was archived
- the validation rules changed
- if someone tried to unarchive the claim it would now be invalid and the the unarchiving would fail." (Mark)

#### Ticket

[CCCD: Nil Dereference + Validation Bypass in Unarchive](https://dsdmoj.atlassian.net/browse/CTSKF-1545)

#### Why

Some archived claims had no version to reify, which caused crashes and was previously hidden by a broad rescue.
These updates make unarchiving safer, more predictable, and easier to debug.

#### How

Added guard for missing PaperTrail versions before reifying.
Ensured archiving always creates a version using save_with_version.
Replaced broad rescue StandardError with targeted DB‑level rescue (RecordNotSaved, StatementInvalid).
Added error logging for easier debugging.


