### PR TITLE
CTSKF-1597 - CCCD: Remove case id from caseworker and provider claim summary

### DIFF
--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -134,10 +134,6 @@ class Claim::BaseClaimPresenter < BasePresenter
     claim.case_number.blank? ? 'N/A' : claim.case_number.scan(/.{1,3}/).join(' ')
   end
 
-  def unique_id
-    "##{claim.id}"
-  end
-
   def vat_date(format = nil)
     if format == :db
       claim.vat_date.to_fs(:db)

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -63,8 +63,6 @@
                   = row.with_cell(html_attributes: { 'data-label': t('.case_number') }) do
                     %span.js-test-case-number
                       = govuk_link_to claim.case_number, case_workers_claim_path(claim), 'aria-label': t('.case_number_label', case_number: claim.case_number)
-                      %span.unique-id-small
-                        = claim.unique_id
                       = render partial: 'case_workers/injection_errors', locals: { claim: claim }
 
                   = row.with_cell(html_attributes: { 'data-label': t('.court') }, text: claim.court.name)

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -33,8 +33,6 @@
         - row.with_key(text: t('case_number', scope: claim_fields))
         - row.with_value do
           = claim.case_number
-          .unique-id-small
-            = claim.unique_id
 
       - if claim.transfer_court.present?
         - summary_list.with_row do |row|

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -47,7 +47,6 @@
     - row.with_key(text: t('.case_num'))
     - row.with_value do
       = claim.case_number
-      %span.unique-id-small= claim.unique_id
 
   - if claim.transfer_court.present?
     - summary_list.with_row do |row|

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -5,7 +5,6 @@
         %span.govuk-caption-l
           = t('.case_number')
         = claim.formatted_case_number
-        %span.unique-id-small= claim.unique_id
 
     .govuk-grid-column-one-third
       %p.govuk-heading-l

--- a/app/views/shared/_claim_header_beta.html.haml
+++ b/app/views/shared/_claim_header_beta.html.haml
@@ -18,7 +18,7 @@
   %h1.govuk-heading-xl
     = claim.defendant_name_and_initial + claim.other_defendant_summary
 
-  %h2.govuk-heading-l Case Number: #{claim.case_number} (#{claim.unique_id})
+  %h2.govuk-heading-l Case Number: #{claim.case_number}
 
   .div{ class: 'govuk-!-margin-bottom-8' }
     %p.govuk-body-l{ class: 'govuk-!-margin-bottom-0' }

--- a/app/views/shared/_new_claim_and_case_type_details.html.haml
+++ b/app/views/shared/_new_claim_and_case_type_details.html.haml
@@ -39,7 +39,6 @@
   - row.with_key(text: t('shared.new_claim_and_case_type_details.case_num'))
   - row.with_value do
     = claim.case_number
-    %span.unique-id-small= claim.unique_id
 
 - if claim.transfer_court.present?
   - summary_list.with_row do |row|

--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -3,12 +3,6 @@ p {
   @extend %govuk-body-m;
 }
 
-.unique-id-small {
-  @include govuk-font(14);
-  display: block;
-  color: govuk-colour("black");
-}
-
 .sub-header {
   margin-bottom: $gutter-half;
 }

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -92,10 +92,6 @@ tr {
       text-transform: uppercase;
     }
 
-    .unique-id-small {
-      display: none;
-    }
-
     .state {
       display: inline;
     }

--- a/spec/presenters/claim/base_claim_presenter_spec.rb
+++ b/spec/presenters/claim/base_claim_presenter_spec.rb
@@ -111,10 +111,6 @@ RSpec.describe Claim::BaseClaimPresenter do
     it { expect { presenter.authorised_at(rubbish: false) }.to raise_error(ArgumentError) }
   end
 
-  describe '#unique_id' do
-    it { expect(presenter.unique_id).to eql("##{presenter.id}") }
-  end
-
   describe '#case_number' do
     it { expect(presenter.case_number).to eql(claim.case_number) }
 


### PR DESCRIPTION
### What

Remove unique id in:
Both versions of caseworker claim summary pages
Provider claim summary page
Claim reallocation page

Remove custom styling (unique-id-small)

### Ticket

[CTSKF-1597](https://dsdmoj.atlassian.net/browse/CTSKF-1597)

### Testing

<img width="502" height="288" alt="Screenshot 2026-03-06 at 1 29 21 pm" src="https://github.com/user-attachments/assets/afbb4610-827d-430c-a8f6-0966ce44e537" />
<img width="769" height="320" alt="Screenshot 2026-03-06 at 1 29 06 pm" src="https://github.com/user-attachments/assets/ab50fd5d-86fd-476b-9371-4de38d16ada1" />
<img width="584" height="390" alt="Screenshot 2026-03-06 at 1 28 58 pm" src="https://github.com/user-attachments/assets/d68b06f2-8b6a-4c09-b5b6-f87434ac8418" />
<img width="515" height="298" alt="Screenshot 2026-03-06 at 1 28 39 pm" src="https://github.com/user-attachments/assets/e2cd8942-cbd2-465b-924c-f706f3f9e4c7" />

