### PR TITLE
Add a guard clause to prevent filtered_state_transitions.second retur…

### DIFF
--- a/app/models/message.rb
+++ b/app/models/message.rb
@@ -102,6 +102,9 @@ class Message < ApplicationRecord
   def process_written_reasons
     return unless claim.written_reasons_outstanding?
     return unless written_reasons_submitted == '1'
+    return unless claim.filtered_state_transitions.second
+    # A claim with written reason by necessity has already more than 2 state transitions (it comes after a claim has been authorised - submitted, allocated, authorised, Awaiting written reasons),
+    # so calling second event will not raise an error. This guard clause is added for extra caution, but in practice it should never be hit.
     claim.send(:"#{claim.filtered_state_transitions.second.event}!", author_id: sender_id)
   end
 


### PR DESCRIPTION
…ning nil if there are fewer than 2 transitions.

#### What

 Issue: filtered_state_transitions.second returns nil if there are fewer than 2 transitions. Calling .event on nil raises NoMethodError. 

  
#### Ticket

[CCCD: Nil Reference in Message Callback](CTSKF-1544)

#### Why
To prevent the message creation silently failing and claim state transitions not happen.

#### How
A guard clause has been added along side a comment explaining why it probably isn't necessary. 

I investigated the code and tried to reproduce a situation when `request_written_reasons` are generated in the local browser. I was only able to do this the once but I found other examples in the code base that showed that this only happens after a claim has been authorised- therefore making it unlikely that `claim.filtered_state_transitions.second.event` would ever be Nil.  

<img width="1215" height="270" alt="Screenshot 2026-03-11 at 13 05 58" src="https://github.com/user-attachments/assets/b6136b75-9b3e-426a-8b8e-4e402e4eb27b" />


<img width="1008" height="889" alt="Screenshot 2026-03-11 at 13 06 24" src="https://github.com/user-attachments/assets/f64013b8-083a-4209-8d4d-941c3b85e4d5" />
