### PR TITLE
Reinstate npm dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,26 +1,26 @@
 version: 2
 updates:
-# - package-ecosystem: npm
-#   directory: "/"
-#   schedule:
-#     interval: daily
-#     day: wednesday
-#     time: "03:00"
-#     timezone: Europe/London
-#   groups:
-#     babel:
-#       patterns:
-#         - "*babel*"
-#     datatables:
-#       patterns:
-#         - "*datatables*"
-#     postcss:
-#       patterns:
-#         - "postcss"
-#         - "postcss-*"
-#   open-pull-requests-limit: 10
-#   allow:
-#     - dependency-type: "all"
+- package-ecosystem: npm
+  directory: "/"
+  schedule:
+    interval: daily
+    day: wednesday
+    time: "03:00"
+    timezone: Europe/London
+  groups:
+    babel:
+      patterns:
+        - "*babel*"
+    datatables:
+      patterns:
+        - "*datatables*"
+    postcss:
+      patterns:
+        - "postcss"
+        - "postcss-*"
+  open-pull-requests-limit: 10
+  allow:
+    - dependency-type: "all"
 - package-ecosystem: bundler
   directory: "/"
   schedule:


### PR DESCRIPTION
#### What

Re-enables updates to npm packages in `github/dependabot.yml`.

#### Why

Dependabot updates to npm packages were disabled by https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/8931 in September 2025 due to the Shai Hulud security incident, which compromised many javascript libraries, and were kept disabled due to Shai Hulud 2.0 in November 2025. There have been no further such incidents since then and our javascript dependencies are now increasingly out of date.