### PR TITLE
Revert "CTSKF-1597 - CCCD: Remove case id from caseworker and provider claim summary"

### DIFF
--- a/app/presenters/claim/base_claim_presenter.rb
+++ b/app/presenters/claim/base_claim_presenter.rb
@@ -134,6 +134,10 @@ class Claim::BaseClaimPresenter < BasePresenter
     claim.case_number.blank? ? 'N/A' : claim.case_number.scan(/.{1,3}/).join(' ')
   end
 
+  def unique_id
+    "##{claim.id}"
+  end
+
   def vat_date(format = nil)
     if format == :db
       claim.vat_date.to_fs(:db)

--- a/app/views/case_workers/admin/allocations/_re_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_re_allocation.html.haml
@@ -63,6 +63,8 @@
                   = row.with_cell(html_attributes: { 'data-label': t('.case_number') }) do
                     %span.js-test-case-number
                       = govuk_link_to claim.case_number, case_workers_claim_path(claim), 'aria-label': t('.case_number_label', case_number: claim.case_number)
+                      %span.unique-id-small
+                        = claim.unique_id
                       = render partial: 'case_workers/injection_errors', locals: { claim: claim }
 
                   = row.with_cell(html_attributes: { 'data-label': t('.court') }, text: claim.court.name)

--- a/app/views/external_users/claims/case_details/_summary.html.haml
+++ b/app/views/external_users/claims/case_details/_summary.html.haml
@@ -33,6 +33,8 @@
         - row.with_key(text: t('case_number', scope: claim_fields))
         - row.with_value do
           = claim.case_number
+          .unique-id-small
+            = claim.unique_id
 
       - if claim.transfer_court.present?
         - summary_list.with_row do |row|

--- a/app/views/shared/_claim.html.haml
+++ b/app/views/shared/_claim.html.haml
@@ -47,6 +47,7 @@
     - row.with_key(text: t('.case_num'))
     - row.with_value do
       = claim.case_number
+      %span.unique-id-small= claim.unique_id
 
   - if claim.transfer_court.present?
     - summary_list.with_row do |row|

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -5,6 +5,7 @@
         %span.govuk-caption-l
           = t('.case_number')
         = claim.formatted_case_number
+        %span.unique-id-small= claim.unique_id
 
     .govuk-grid-column-one-third
       %p.govuk-heading-l

--- a/app/views/shared/_claim_header_beta.html.haml
+++ b/app/views/shared/_claim_header_beta.html.haml
@@ -18,7 +18,7 @@
   %h1.govuk-heading-xl
     = claim.defendant_name_and_initial + claim.other_defendant_summary
 
-  %h2.govuk-heading-l Case Number: #{claim.case_number}
+  %h2.govuk-heading-l Case Number: #{claim.case_number} (#{claim.unique_id})
 
   .div{ class: 'govuk-!-margin-bottom-8' }
     %p.govuk-body-l{ class: 'govuk-!-margin-bottom-0' }

--- a/app/views/shared/_new_claim_and_case_type_details.html.haml
+++ b/app/views/shared/_new_claim_and_case_type_details.html.haml
@@ -39,6 +39,7 @@
   - row.with_key(text: t('shared.new_claim_and_case_type_details.case_num'))
   - row.with_value do
     = claim.case_number
+    %span.unique-id-small= claim.unique_id
 
 - if claim.transfer_court.present?
   - summary_list.with_row do |row|

--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -3,6 +3,12 @@ p {
   @extend %govuk-body-m;
 }
 
+.unique-id-small {
+  @include govuk-font(14);
+  display: block;
+  color: govuk-colour("black");
+}
+
 .sub-header {
   margin-bottom: $gutter-half;
 }

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -92,6 +92,10 @@ tr {
       text-transform: uppercase;
     }
 
+    .unique-id-small {
+      display: none;
+    }
+
     .state {
       display: inline;
     }

--- a/spec/presenters/claim/base_claim_presenter_spec.rb
+++ b/spec/presenters/claim/base_claim_presenter_spec.rb
@@ -111,6 +111,10 @@ RSpec.describe Claim::BaseClaimPresenter do
     it { expect { presenter.authorised_at(rubbish: false) }.to raise_error(ArgumentError) }
   end
 
+  describe '#unique_id' do
+    it { expect(presenter.unique_id).to eql("##{presenter.id}") }
+  end
+
   describe '#case_number' do
     it { expect(presenter.case_number).to eql(claim.case_number) }
 


### PR DESCRIPTION
Reverts ministryofjustice/Claim-for-Crown-Court-Defence#9252.

Providers have objected to this change. This rolls it back for both providers and caseworkers so we can reassess.