### PR TITLE
Remove this line as the creator_id belongs to the User model not Exte…

### DIFF
--- a/app/controllers/documents_controller.rb
+++ b/app/controllers/documents_controller.rb
@@ -34,7 +34,7 @@ class DocumentsController < ApplicationController
   end
 
   def upload
-    @document = Document.new(document_params.merge(creator_id: current_user.id))
+    @document = Document.new(document_params.merge(creator: current_user))
     if @document.save_and_verify
       render_success_response
     else

--- a/app/models/document.rb
+++ b/app/models/document.rb
@@ -2,7 +2,7 @@ class Document < ApplicationRecord
   include Duplicable
 
   belongs_to :external_user
-  belongs_to :creator, class_name: 'ExternalUser'
+  belongs_to :creator, class_name: 'User'
   belongs_to :claim, class_name: 'Claim::BaseClaim'
 
   has_one_attached :converted_preview_document

--- a/spec/models/document_spec.rb
+++ b/spec/models/document_spec.rb
@@ -45,7 +45,7 @@ RSpec.describe Document do
   end
 
   it { is_expected.to belong_to(:external_user) }
-  it { is_expected.to belong_to(:creator).class_name('ExternalUser') }
+  it { is_expected.to belong_to(:creator).class_name('User') }
   it { is_expected.to belong_to(:claim) }
   it { is_expected.to delegate_method(:provider_id).to(:external_user) }
 


### PR DESCRIPTION
…rnalUsers

#### What
The Document model has a field creator_id that is set to current_user.id when a document is uploaded and this links the document to an instance of User. However, the model has a reference defined as belongs_to :creator, class_name: 'ExternalUser'.

#### Ticket

[CCCD - Confused definition of Document#creator_id](https://dsdmoj.atlassian.net/browse/CTSKF-1014)

#### Why

#### How
Replace this line 
`belongs_to :creator, class_name: 'ExternalUser'`

With 
`belongs_to :creator, class_name: 'User'`

So we no longer have to call creator_id inside the documents controller. creator now references the User model directly. 

