### PR TITLE
[CTSKF-1627] Test the new ingress in the dev environment.

### DIFF
--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -39,6 +39,16 @@ spec:
                 name: cccd-app-service
                 port:
                   number: 80
+    - host: dev.claim-crown-court-defence.service.justice.gov.uk
+      http:
+        paths:
+          - path: /
+            pathType: ImplementationSpecific
+            backend:
+              service:
+                name: cccd-app-service
+                port:
+                  number: 80
   tls:
     - hosts:
       - dev.claim-crown-court-defence.service.justice.gov.uk

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -27,9 +27,9 @@ metadata:
   name: cccd-app-ingress-v1
   namespace: cccd-dev
 spec:
-  ingressClassName: modsec-non-prod
+  ingressClassName: beta
   rules:
-    - host: dev.claim-crown-court-defence.service.justice.gov.uk
+    - host: dev-claim-crown-court-defence.beta.cloud-platform.service.justice.gov.uk
       http:
         paths:
           - path: /


### PR DESCRIPTION
#### What

Use the testing ingress controller in a non-production environment.

#### Ticket

[Beta Ingress Testing for Ingress-NGINX Transition](https://dsdmoj.atlassian.net/browse/CTSKF-1627)

#### Why

Cloud Platform will require us to move to a new Ingress controller. The first step is to test in a non-production environment.

#### How

Update the `ingress.yaml` file for the dev environment.
