### PR TITLE
Fix tag styling

### DIFF
--- a/app/webpack/stylesheets/components/_tag.scss
+++ b/app/webpack/stylesheets/components/_tag.scss
@@ -1,40 +1,38 @@
-// stylelint-disable declaration-no-important
-
 .app-tag--authorised,
 .app-tag--accepted {
-  color: govuk-shade(govuk-colour("green"), 20%) !important;
-  background: govuk-tint(govuk-colour("green"), 80%) !important;
+  color: govuk-colour("green", $variant: "shade-50");
+  background-color: govuk-colour("green", $variant: "tint-80");
 }
 
 .app-tag--allocated {
-  color: govuk-shade(govuk-colour("purple"), 20%) !important;
-  background: govuk-tint(govuk-colour("purple"), 80%) !important;
+  color: govuk-colour("purple", $variant: "shade-50");
+  background-color: govuk-colour("purple", $variant: "tint-80");
 }
 
 .app-tag--draft {
-  color: govuk-shade(govuk-colour("blue"), 30%) !important;
-  background: govuk-tint(govuk-colour("blue"), 80%) !important;
+  color: govuk-colour("blue", $variant: "shade-50");
+  background-color: govuk-colour("blue", $variant: "tint-80");
 }
 
 .app-tag--rejected,
 .app-tag--refused,
 .app-tag--unverified {
-  color: govuk-shade(govuk-colour("red"), 30%) !important;
-  background: govuk-tint(govuk-colour("red"), 80%) !important;
+  color: govuk-colour("red", $variant: "shade-50");
+  background-color: govuk-colour("red", $variant: "tint-80");
 }
 
 .app-tag--archived-pending-delete,
 .app-tag--submitted {
-  color: govuk-shade(govuk-colour("black", $variant: "tint-25"), 30%) !important;
-  background: govuk-tint(govuk-colour("black", $variant: "tint-25"), 90%) !important;
+  color: govuk-colour("black");
+  background-color: govuk-colour("black", $variant: "tint-80");
 }
 
 .app-tag--redetermination {
-  color: govuk-shade(govuk-colour("black"), 30%) !important;
-  background: govuk-tint(govuk-colour("black"), 80%) !important;
+  color: govuk-colour("black");
+  background-color: govuk-colour("black", $variant: "tint-80");
 }
 
 .app-tag--part-authorised {
-  color: govuk-shade(govuk-colour("blue"), 30%) !important;
-  background: govuk-tint(govuk-colour("blue"), 80%) !important;
+  color: govuk-colour("blue", $variant: "shade-50");
+  background-color: govuk-colour("blue", $variant: "tint-80");
 }

--- a/app/webpack/stylesheets/components/_tag.scss
+++ b/app/webpack/stylesheets/components/_tag.scss
@@ -29,7 +29,7 @@
   background: govuk-tint(govuk-colour("black", $variant: "tint-25"), 90%) !important;
 }
 
-.app-tag--redermination {
+.app-tag--redetermination {
   color: govuk-shade(govuk-colour("black"), 30%) !important;
   background: govuk-tint(govuk-colour("black"), 80%) !important;
 }

--- a/app/webpack/stylesheets/statuses.scss
+++ b/app/webpack/stylesheets/statuses.scss
@@ -11,7 +11,7 @@
 
   &.submitted,
   &.allocated,
-  &.redermination,
+  &.redetermination,
   &.draft {
     border-color: $turquoise;
     color: $turquoise;


### PR DESCRIPTION
#### What

Updating the govuk-frontend dependency to 6.1.0 has caused our custom tag styles to break. The custom tag style used invalid methods to set colours (`govuk-shade()`/`govuk-tint()`) which resulted in all tags appearing
as the default blue.

There has been a long-standing typo in the class name for the redetermination tag. This corrects it to `app-tag--redetermination` so that styling is correctly applied. This adjusts our custom tag classes to ensure they use the correct
approach to set colours, eg `govuk-colour("green", $variant: "tint-80")`

#### Why

So that tags for claim statuses appear correctly.

#### Evidence

Before:

<img width="445" height="199" alt="image" src="https://github.com/user-attachments/assets/1ef48df1-b8ab-46e2-8359-5f5966ae1d9d" />


After:

<img width="495" height="202" alt="image" src="https://github.com/user-attachments/assets/f1d2d574-feb0-47ff-91c7-bbd4c04dc728" />


