### PR TITLE
Revert "[CTSKF-1627] Test the new ingress in the dev environment."

### DIFF
--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -27,18 +27,8 @@ metadata:
   name: cccd-app-ingress-v1
   namespace: cccd-dev
 spec:
-  ingressClassName: beta
+  ingressClassName: modsec-non-prod
   rules:
-    - host: dev-claim-crown-court-defence.beta.cloud-platform.service.justice.gov.uk
-      http:
-        paths:
-          - path: /
-            pathType: ImplementationSpecific
-            backend:
-              service:
-                name: cccd-app-service
-                port:
-                  number: 80
     - host: dev.claim-crown-court-defence.service.justice.gov.uk
       http:
         paths:


### PR DESCRIPTION
Reverts ministryofjustice/Claim-for-Crown-Court-Defence#9309

The new ingress controller has been put live for non-production environments so this change is no longer required for testing.