### PR TITLE
Ctskf 1545 cccd nil dereference validation bypass in unarchive

### DIFF
--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -160,12 +160,11 @@ module ExternalUsers
     def unarchive
       claim_url = external_users_claim_url(@claim)
       return redirect_to claim_url, alert: t('.not_archived') unless unarchive_allowed?
-      @claim = @claim.paper_trail.previous_version
+      revert_to_version_before_archived
+      return redirect_to claim_url, alert: t('.unarchivable') if @claim.nil?
       @claim.zeroise_nil_totals!
       @claim.save!(validate: false)
       redirect_to external_users_claims_url, notice: t('.unarchived')
-    rescue StandardError
-      redirect_to claim_url, alert: t('.unarchivable')
     end
 
     class << self
@@ -185,6 +184,12 @@ module ExternalUsers
     end
 
     private
+
+    def revert_to_version_before_archived
+      @claim = @claim.versions.select do |v|
+        v.object_changes['archived_pending_review'] || v.object_changes['archived_pending_delete']
+      end.compact.last.reify
+    end
 
     def log(message, error: nil, level: :info)
       log_data = {

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -186,9 +186,12 @@ module ExternalUsers
     private
 
     def revert_to_version_before_archived
-      @claim = @claim.versions.select do |v|
-        v.object_changes['archived_pending_review'] || v.object_changes['archived_pending_delete']
-      end.compact.last.reify
+      version = @claim.versions.reverse.detect do |v|
+        obj = v.reify
+        obj && !obj.state.to_s.start_with?('archived_')
+      end
+
+      @claim = version&.reify
     end
 
     def log(message, error: nil, level: :info)

--- a/app/controllers/external_users/claims_controller.rb
+++ b/app/controllers/external_users/claims_controller.rb
@@ -161,7 +161,7 @@ module ExternalUsers
       claim_url = external_users_claim_url(@claim)
       return redirect_to claim_url, alert: t('.not_archived') unless unarchive_allowed?
       revert_to_version_before_archived
-      return redirect_to claim_url, alert: t('.unarchivable') if @claim.nil?
+      return redirect_to claim_url, alert: t('.cannot_unarchive_no_version') if @claim.nil?
       @claim.zeroise_nil_totals!
       @claim.save!(validate: false)
       redirect_to external_users_claims_url, notice: t('.unarchived')

--- a/app/services/claims/external_user_claim_updater.rb
+++ b/app/services/claims/external_user_claim_updater.rb
@@ -17,6 +17,8 @@ module Claims
       else
         claim.archive_pending_delete!(audit_attributes)
       end
+      # Force a PT version even if validations were skipped or callbacks differ
+      claim.paper_trail.save_with_version(validate: false)
     end
 
     def clone_rejected

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -896,6 +896,7 @@ en:
       unarchive:
         not_archived: 'This claim is not in the archive'
         unarchivable: 'This claim cannot be unarchived'
+        cannot_unarchive_no_version: 'This claim cannot be unarchived as there is no previous version to restore'
         unarchived: 'Claim unarchived'
       hints:
         fees_header_prompt_text_html: &fees_vat_prompt All fees should be entered exclusive of VAT.

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -895,7 +895,6 @@ en:
         not_editable: 'Can only edit "draft" claims'
       unarchive:
         not_archived: 'This claim is not in the archive'
-        unarchivable: 'This claim cannot be unarchived'
         cannot_unarchive_no_version: 'This claim cannot be unarchived as there is no previous version to restore'
         unarchived: 'Claim unarchived'
       hints:

--- a/spec/controllers/external_users/claims_controller_spec.rb
+++ b/spec/controllers/external_users/claims_controller_spec.rb
@@ -773,6 +773,13 @@ RSpec.describe ExternalUsers::ClaimsController do
         context 'when the current version of paper trail is used' do
           before { patch :unarchive, params: { id: claim } }
 
+          it 'has previous versions' do
+            expect(claim.versions.map do |v|
+              YAML.safe_load(v.object_changes)['state']
+            end.flatten).to include('draft', 'submitted', 'allocated', 'rejected',
+                                    'archived_pending_review')
+          end
+
           it 'unarchives the claim and restores to state prior to archiving' do
             expect(claim.reload).to be_rejected
           end
@@ -823,6 +830,10 @@ RSpec.describe ExternalUsers::ClaimsController do
 
       it 'redirects to external users root url' do
         expect(response).to redirect_to(external_users_claim_url(claim))
+      end
+
+      it 'displays a success message' do
+        expect(flash[:alert]).to eq('This claim is not in the archive')
       end
     end
 


### PR DESCRIPTION
#### What

Improved the unarchive flow to avoid crashes and stop masking real errors.
I did not remove `(validate: false) ` as 

"it looks like there were some changes to the validation rules which meant that a claim could end up in a situation where:
- it was originally valid
- it was archived
- the validation rules changed
- if someone tried to unarchive the claim it would now be invalid and the the unarchiving would fail.

#### Ticket

[CCCD: Nil Dereference + Validation Bypass in Unarchive](https://dsdmoj.atlassian.net/browse/CTSKF-1545)

#### Why

Some archived claims had no version to reify, which caused crashes and was previously hidden by a broad rescue.
These updates make unarchiving safer, more predictable, and easier to debug.

#### How

Added guard for missing PaperTrail versions before reifying.
Ensured archiving always creates a version using save_with_version.