### PR TITLE
Fix sha on actions checkout

### DIFF
--- a/.github/workflows/docker_image_scan_test.yml
+++ b/.github/workflows/docker_image_scan_test.yml
@@ -38,7 +38,7 @@ jobs:
         args: --file=docker/Dockerfile
 
     - name: Upload result to GitHub Code Scanning
-      uses: github/codeql-action/upload-sarif@vc793b717bc78562f491db7b0e93a3a178b099162
+      uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13
       with:
         sarif_file: snyk.sarif
 


### PR DESCRIPTION
#### What

Fix the SHA on a Github action checkout.

#### Ticket

N/A

#### Why

A 'v' was left in the checkout reference when changing from the version number to a sha. This was preventing the action from being checked out.

#### How

In addition to fixing the sha the latest version is now being used. See https://github.com/github/codeql-action/releases/tag/v4.35.1