### PR TITLE
Update dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,8 @@ updates:
     day: wednesday
     time: "03:00"
     timezone: Europe/London
+  cooldown:
+    default-days: 7
   groups:
     babel:
       patterns:
@@ -28,6 +30,8 @@ updates:
     day: wednesday
     time: "03:00"
     timezone: Europe/London
+  cooldown:
+    default-days: 7
   groups:
     aws:
       patterns:
@@ -53,13 +57,13 @@ updates:
   ignore:
     - dependency-name: "rails"
       versions:
-        - ">= 7.1"
+        - ">= 7.2"
     - dependency-name: "active*"
       versions:
-        - ">= 7.1"
+        - ">= 7.2"
     - dependency-name: "action*"
       versions:
-        - ">= 7.1"
+        - ">= 7.2"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:
@@ -67,6 +71,8 @@ updates:
     day: tuesday
     time: "03:00"
     timezone: Europe/London
+  cooldown:
+    default-days: 7
   open-pull-requests-limit: 5
   rebase-strategy: "disabled"
   allow:


### PR DESCRIPTION
#### What

Update dependabot configuration

#### Ticket

N/A

#### Why

* Recent security recommendations suggest using a cooldown period before using newly released versions. Note that this does not apply to security updates. See https://docs.github.com/en/code-security/reference/supply-chain-security/dependabot-options-reference#cooldown-
* Fix configuration to allow updates to Rails 7.2. It had previous been set to prevent anything more recent than 7.1.* to prevent accidental updates of a major version of the framework.

#### How

* Add the `cooldown` configuration
* Update the `ignore` configuration