### PR TITLE
Allow update PRs for Rails 7.2.*

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -57,13 +57,13 @@ updates:
   ignore:
     - dependency-name: "rails"
       versions:
-        - ">= 7.2"
+        - ">= 8.0"
     - dependency-name: "active*"
       versions:
-        - ">= 7.2"
+        - ">= 8.0"
     - dependency-name: "action*"
       versions:
-        - ">= 7.2"
+        - ">= 8.0"
 - package-ecosystem: github-actions
   directory: "/"
   schedule:


### PR DESCRIPTION
#### What

Allow dependabot to create PRs for Rails 7.2.* and related gems.

#### Ticket

N/A

#### Why

Ensure that security patches for Rails are applied while preventing unexpected updates of the major version.

#### How

Update the ignore configuration.