### PR TITLE
[CTSKF-1599] Format additional info text for caseworker view

### DIFF
--- a/app/views/external_users/claims/additional_information/_summary.html.haml
+++ b/app/views/external_users/claims/additional_information/_summary.html.haml
@@ -6,7 +6,7 @@
     = govuk_link_to t('common.change_html', context: t('external_users.claims.additional_information.summary.header')), edit_polymorphic_path(claim, step: :supporting_evidence, anchor: 'additional_info', referrer: :summary), class: 'link-change'
 
   - if claim.additional_information.present?
-    = simple_format(claim.additional_information)
+    = format_multiline(claim.additional_information)
   - else
     - if local_assigns.has_key?(:editable) && !local_assigns[:editable]
       = render partial: 'external_users/claims/summary/section_status', locals: { claim: claim, section: section, step: :supporting_evidence }

--- a/app/views/shared/_new_additional_information.html.haml
+++ b/app/views/shared/_new_additional_information.html.haml
@@ -1,2 +1,2 @@
 = govuk_summary_card(title: t('shared.new_claim_accordion.additional_information')) do |card|
-  = claim.additional_information
+  = format_multiline(claim.additional_information)

--- a/app/views/shared/summary/_new_expenses.html.haml
+++ b/app/views/shared/summary/_new_expenses.html.haml
@@ -14,4 +14,4 @@
 
   - if claim.travel_expense_additional_information.present?
     = govuk_summary_card(title: t('shared.summary.expenses.travel_expense_additional_information')) do
-      = claim.travel_expense_additional_information
+      = format_multiline(claim.travel_expense_additional_information)


### PR DESCRIPTION
#### What
Wraps additional information added by a Provider in `format_multiline` which is defined in `application_helper` so that it retains line breaks and other formatting, making it easier for Caseworker to read the text.

#### Ticket
[CTSKF-1599](https://dsdmoj.atlassian.net/browse/CTSKF-1599)

#### Why
As a Caseworker, when viewing notes on the claim summary screen, the text appears as a single block - any line breaks or other layout that has been entered by the Provider is lost. This makes the notes harder to understand.

## Before change
<img width="983" height="164" alt="Screenshot 2026-04-07 at 13 19 55" src="https://github.com/user-attachments/assets/939a8ef8-e643-4a33-9096-173afcdfec34" />
<img width="973" height="161" alt="Screenshot 2026-04-07 at 13 20 06" src="https://github.com/user-attachments/assets/328b0360-6c8a-4353-84e1-bd0257afd026" />

## After change
<img width="987" height="239" alt="Screenshot 2026-04-07 at 13 17 30" src="https://github.com/user-attachments/assets/faa37efd-e0c0-43bb-8126-8ff65b5b3056" />
<img width="979" height="239" alt="Screenshot 2026-04-07 at 13 17 43" src="https://github.com/user-attachments/assets/df173c97-872d-45e4-a11b-397c24485a98" />