### PR TITLE
Fix MI daily report timezone errors during BST

### DIFF
--- a/app/services/stats/management_information/concerns/journey_queryable.rb
+++ b/app/services/stats/management_information/concerns/journey_queryable.rb
@@ -60,7 +60,7 @@ module Stats
                 where id = c.id
               ) c2 ON TRUE
               LEFT JOIN LATERAL (
-                select (transitions ->> 'created_at')::timestamptz at time zone 'Europe/London' as completed_at
+                select (transitions ->> 'created_at')::timestamp as completed_at
                   from jsonb_array_elements(j.journey) transitions
                 where transitions ->> 'to' in ('rejected', 'refused', 'authorised', 'part_authorised')
                 fetch first row only
@@ -161,7 +161,7 @@ module Stats
                       on t.subject_id = subjects.id
                     where t.claim_id = in_claim_id
                     and t.to not in (select * from unnest(filtered_states))
-                    and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= DATE_TRUNC('day', (current_date - '6 months'::interval) at time zone 'utc' at time zone 'Europe/London')
+                    and DATE_TRUNC('day', t.created_at at time zone 'utc' at time zone 'Europe/London') >= (current_date - '6 months'::interval)
                   )
                   select t.claim_id,
                         jsonb_agg(to_jsonb(t) order by t.created_at asc) as transitions

--- a/spec/services/stats/management_information/daily_report_query_spec.rb
+++ b/spec/services/stats/management_information/daily_report_query_spec.rb
@@ -258,7 +258,6 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
 
       context 'with a completed journey' do
         before do
-          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -270,13 +269,13 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
         end
 
         it 'returns the created_at timestamp for the claim transition to the completed state' do
-          expect(completed_ats).to eql([authorised_at, refused_at])
+          expect(completed_ats.map { |t| t.strftime('%F %T') })
+            .to eql([authorised_at, refused_at].map { |t| t.in_time_zone('Europe/London').strftime('%F %T') })
         end
       end
 
       context 'with an uncompleted journey' do
         before do
-          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           travel_to(authorised_at) { claim }
 
           travel_to(redetermine_at) do
@@ -286,7 +285,8 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
         end
 
         it 'returns nil for timestamp of claim transition to a completed state' do
-          expect(completed_ats).to eql([authorised_at, nil])
+          expect(completed_ats.map { |t| t&.strftime('%F %T') })
+            .to eql([authorised_at.in_time_zone('Europe/London').strftime('%F %T'), nil])
         end
       end
 
@@ -302,12 +302,12 @@ RSpec.describe Stats::ManagementInformation::DailyReportQuery do
       #
       context 'when handling timezones' do
         before do
-          pending 'Bug with timezones in BST' # TODO: reinstate this line when entering BST
           create(:advocate_final_claim, :authorised)
         end
 
         it 'returns date in same time zone as current time zone for rails' do
-          expect(completed_ats.first.utc).to be_within(5.seconds).of(Time.current.utc)
+          expected_time = Time.current.in_time_zone('Europe/London').strftime('%F %H:%M')
+          expect(completed_ats.first.strftime('%F %H:%M')).to eq(expected_time)
         end
       end
     end


### PR DESCRIPTION
#### What

The beta version of the Management Information daily report (and its LGFS/AGFS variants) produces incorrect timestamps during British Summer Time (BST), showing times offset by 1 hour. This is caused by two bugs in the SQL within `JourneyQueryable`:

**1. completed_at double timezone conversion (line 63)**

The `JSONB` journey data already contains `created_at` values converted to Europe/London local time (via `at time zone 'utc' at time zone 'Europe/London'` on line 152). Casting these back with `::timestamptz at time zone 'Europe/London'` reinterpreted the already-local time as UTC, then converted again — shifting by 1 hour during BST.

Fix: casts with `::timestamp` only, since the value is already in local time. This is consistent with how `last_submitted_at` and `originally_submitted_at` are handled.

**2. 6-month filter erroneous timezone conversion (line 164)**

`current_date - '6 months'::interval` produces a timezone-naive timestamp. Applying `at time zone 'utc' at time zone 'Europe/London'` incorrectly shifted the midnight boundary by 1 hour during BST.

Fix: uses `(current_date - '6 months'::interval)` directly, since the left-hand side is already in local time. This makes the use of `DATE_TRUNC` on the right-hand side of the comparison redundant.

**Test changes:** 

Removes three `pending 'Bug with timezones in BST'` markers and updates assertions to compare wall-clock times (via `strftime`) rather than timezone-aware objects, matching what the presenter actually displays.


#### Why

To provide accurate data to caseworkers on MI reports all year round and remove the need for developers to adjust tests every six months.


#### Testing

Tested locally. Created and authorised a claim at 12:47 on 14/04/2026. Produced copies of the 'Management Information' report, 'Management Information beta` report pre-fix, and 'Management Information' report post-fix for comparison.

**'Management Information'**: displays 'Completed at' as `14/04/2026  12:47:00` [correct]

**'Management Information beta' pre-fix**: displayed 'Completed at' as `14/04/2026  13:47:00` [incorrect]

**'Management Information beta' post-fix**: displays 'Completed at' as `14/04/2026  12:47:00` [correct]
