### PR TITLE
[CTSKF-1484] Allocating claims to null caseworker

### DIFF
--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -337,22 +337,21 @@ moj.Modules.AllocationDataTable = {
 
     // EVENT: Allocate claims
     $('.allocation-submit').on('click', function (e) {
-      self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--error govuk-notification-banner--success')
-      self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html('Allocating.. please wait a moment..')
-
       e.preventDefault()
-      self.ui.$submit.prop('disabled', true)
 
       const quantityToAllocate = $('#quantity-to-allocate-field').val() || false
-
       const allocationCaseWorkerId = $('#allocation-case-worker-id-field-select').val()
 
       if (!allocationCaseWorkerId) {
-        $.publish('/allocation/error/', {
-          msg: 'Select a case worker.'
-        })
+        self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--success')
+        self.ui.$notificationMsg.addClass('govuk-notification-banner--error')
+        self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html('Select a case worker.')
         return
       }
+
+      self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--error govuk-notification-banner--success')
+      self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html('Allocating.. please wait a moment..')
+      self.ui.$submit.prop('disabled', true)
 
       const filters = {
         order: 'current',

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -335,17 +335,25 @@ moj.Modules.AllocationDataTable = {
       self.clearFilter()
     })
 
+    // EVENT: No case worker allocation error
+    $.subscribe('/allocation/error/', function (e, data) {
+      self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--success')
+      self.ui.$notificationMsg.addClass('govuk-notification-banner--error')
+      self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html(data.msg)
+      self.ui.$submit.prop('disabled', false)
+    })
+
     // EVENT: Allocate claims
     $('.allocation-submit').on('click', function (e) {
       e.preventDefault()
-
       const quantityToAllocate = $('#quantity-to-allocate-field').val() || false
+      const allocationCaseWorkerInput = $('#allocation-case-worker-id-field').val()
       const allocationCaseWorkerId = $('#allocation-case-worker-id-field-select').val()
-
-      if (!allocationCaseWorkerId) {
-        self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--success')
-        self.ui.$notificationMsg.addClass('govuk-notification-banner--error')
-        self.ui.$notificationMsg.find('.govuk-notification-banner__heading').html('Select a case worker.')
+      
+      if (!allocationCaseWorkerInput) {
+        $.publish('/allocation/error/', {
+          msg: 'Select a case worker.'
+        })
         return
       }
 

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -385,10 +385,12 @@ moj.Modules.AllocationDataTable = {
           claim_ids: data
         }
       }).done(function (result) {
+        const allocatedCaseWorkerName = $('#allocation-case-worker-id-field-select').find('option:selected').text()
+        const $quantityToAllocateField = $('#quantity-to-allocate-field')
         self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--error')
         self.ui.$notificationMsg.addClass('govuk-notification-banner--success')
-        self.ui.$notificationMsg.find('.govuk-notification-banner__heading').text(result.allocated_claims.length + ' claims have been allocated to ' + $('#allocation-case-worker-id-field').val())
-        $('#quantity-to-allocate-field').val('')
+        self.ui.$notificationMsg.find('.govuk-notification-banner__heading').text(result.allocated_claims.length + ' claims have been allocated to ' + allocatedCaseWorkerName)
+        $quantityToAllocateField.val('')
         self.resetAutocomplete()
         self.reloadScheme({
           scheme: self.searchConfig.scheme

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -388,7 +388,8 @@ moj.Modules.AllocationDataTable = {
         self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--error')
         self.ui.$notificationMsg.addClass('govuk-notification-banner--success')
         self.ui.$notificationMsg.find('.govuk-notification-banner__heading').text(result.allocated_claims.length + ' claims have been allocated to ' + $('#allocation-case-worker-id-field').val())
-
+        $('#quantity-to-allocate-field').val('')
+        self.resetAutocomplete()
         self.reloadScheme({
           scheme: self.searchConfig.scheme
         })
@@ -436,6 +437,16 @@ moj.Modules.AllocationDataTable = {
         max: null
       }
     })
+  },
+  // Destroy and recreate the accessible-autocomplete to cleanly reset it.
+  // So that the old Case Worker value is cleared and the input field is reset to its default state.
+  resetAutocomplete: function () {
+    const selectEl = document.querySelector('#allocation-case-worker-id-field-select')
+    if (!selectEl) return
+    selectEl.selectedIndex = 0
+    selectEl.id = selectEl.id.replace(/-select$/, '')
+    selectEl.parentElement.querySelector('.autocomplete__wrapper').remove()
+    moj.Modules.AutocompleteWrapper.Autocomplete(selectEl.id)
   },
 
   // Wrapper to clear search & filters

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -349,7 +349,6 @@ moj.Modules.AllocationDataTable = {
       const quantityToAllocate = $('#quantity-to-allocate-field').val() || false
       const allocationCaseWorkerInput = $('#allocation-case-worker-id-field').val()
       const allocationCaseWorkerId = $('#allocation-case-worker-id-field-select').val()
-      
       if (!allocationCaseWorkerInput) {
         $.publish('/allocation/error/', {
           msg: 'Select a case worker.'

--- a/features/allocation.feature
+++ b/features/allocation.feature
@@ -39,3 +39,15 @@ Feature: Case worker admin allocates claims
     And I sign out
 
     And I eject the VCR cassette
+
+  Scenario: I see an error when I try to allocate without selecting a case worker
+    Given submitted claims exist with case numbers "T20160001"
+    And I insert the VCR cassette 'features/case_workers/admin/allocation'
+
+    When I am a signed in case worker admin
+    And I visit the allocation page
+    And I select claims "T20160001"
+    And I click Allocate
+    Then I should see 'Select a case worker.'
+
+    And I eject the VCR cassette


### PR DESCRIPTION
#### What
Fixes case worker input field validation logic on the client side so that if an admin tries to allocate claims without selecting a case worker they are shown an error message.

#### Ticket
[CTSKF-1484](https://dsdmoj.atlassian.net/browse/CTSKF-1484)

#### Why
- So that if no case worker is selected the page doesn't get stuck with message **'Allocating.. please wait a moment..'**
- If a case worker is initially selected but then the field is cleared, they are not able to allocate without selecting again.

#### How
- Added a `subscribe` block so `$.publish('/allocation/error/'` action doesn't fail silently.
- After a successful allocation, the number of claims field and case worker field (accessible autocomplete component) is reset.
- Added an extra feature test.

#### Test
**Scenario 1**
- Log in to CCCD as a caseworker admin
- On the Allocation page, enter 1 in the ‘Number of claims’ field
- Leave the ‘Case worker’ field blank
- Click ‘Allocate’
**Before change**: The message “Allocating.. please wait a moment..” is displayed but no claims are allocated.
**After change**: Page shows message 'Select a caseworker'

**Scenario 2**
- Log in to CCCD as a caseworker admin
- On the Allocation page, enter 1 in the ‘Number of claims’ field
- Select a caseworker from the ‘Case worker’ list
- Click ‘Allocate’
- Confirmation is displayed that the claim has been allocated
- Clear the ‘Case worker’ field
- Click ‘Allocate’
**Before change**: The message “1 claims have been allocated to” is displayed. The claim is actually allocated to the caseworker selected in step 3.
**After change**: Page shows message 'Select a caseworker'

[CTSKF-1484]: https://dsdmoj.atlassian.net/browse/CTSKF-1484?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ