### PR TITLE
[CTSKF-1723] Upgrade rack-livereload gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -74,7 +74,7 @@ group :development, :test do
   gem 'parallel_tests'
   gem 'pry-byebug'
   gem 'pry-rails'
-  gem 'rack-livereload', '~> 0.5.2'
+  gem 'rack-livereload', '~> 0.6.1'
   gem 'rspec-rails', '~> 8.0.4'
   gem 'rspec-collection_matchers'
   gem 'rspec_junit_formatter'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -493,18 +493,18 @@ GEM
       nio4r (~> 2.0)
     raabro (1.4.0)
     racc (1.8.1)
-    rack (2.2.23)
+    rack (3.1.21)
     rack-contrib (2.5.0)
       rack (< 4)
-    rack-livereload (0.5.2)
-      rack (< 3)
-    rack-session (1.0.2)
-      rack (< 3)
+    rack-livereload (0.6.1)
+      rack (>= 3.0, < 3.2)
+    rack-session (2.1.2)
+      base64 (>= 0.1.0)
+      rack (>= 3.0.0)
     rack-test (2.2.0)
       rack (>= 1.3)
-    rackup (1.0.1)
-      rack (< 3)
-      webrick
+    rackup (2.3.1)
+      rack (>= 3)
     rails (8.0.5)
       actioncable (= 8.0.5)
       actionmailbox (= 8.0.5)
@@ -741,7 +741,6 @@ GEM
       addressable (>= 2.8.0)
       crack (>= 0.3.2)
       hashdiff (>= 0.4.0, < 2.0.0)
-    webrick (1.9.2)
     websocket (1.2.11)
     websocket-driver (0.8.0)
       base64
@@ -828,7 +827,7 @@ DEPENDENCIES
   pry-byebug
   pry-rails
   puma
-  rack-livereload (~> 0.5.2)
+  rack-livereload (~> 0.6.1)
   rails (~> 8.0.5)
   rails-controller-testing
   redis (~> 5.4.1)
@@ -1054,12 +1053,12 @@ CHECKSUMS
   puma (8.0.1) sha256=7b94e50c07655718c1fb8ae41a11fc06c7d61293208b3aa608ff71a46d3ad37c
   raabro (1.4.0) sha256=d4fa9ff5172391edb92b242eed8be802d1934b1464061ae5e70d80962c5da882
   racc (1.8.1) sha256=4a7f6929691dbec8b5209a0b373bc2614882b55fc5d2e447a21aaa691303d62f
-  rack (2.2.23) sha256=a8fe9d7e07064770b8ec123663fded8a59ef7e2b6db5cda7173d45a5718ab69c
+  rack (3.1.21) sha256=285c5f228eef30dbd1dc147859a880b71bc44412fea575cc58c28797f2db9777
   rack-contrib (2.5.0) sha256=51bd2ce82b8a3270f9173130c4cdaea72aab8b03dce8cd6af1c4344d84a32d02
-  rack-livereload (0.5.2) sha256=422672b5f408b1297be732a20ca8a3f260843acdab4a39fd863f2af43025f03b
-  rack-session (1.0.2) sha256=a02115e5420b4de036839b9811e3f7967d73446a554b42aa45106af335851d76
+  rack-livereload (0.6.1) sha256=34337d2bdbea44327b9f7bd99f2595b04f90d8b2cf5305648c0e4860f3a30539
+  rack-session (2.1.2) sha256=595434f8c0c3473ae7d7ac56ecda6cc6dfd9d37c0b2b5255330aa1576967ffe8
   rack-test (2.2.0) sha256=005a36692c306ac0b4a9350355ee080fd09ddef1148a5f8b2ac636c720f5c463
-  rackup (1.0.1) sha256=ba86604a28989fe1043bff20d819b360944ca08156406812dca6742b24b3c249
+  rackup (2.3.1) sha256=6c79c26753778e90983761d677a48937ee3192b3ffef6bc963c0950f94688868
   rails (8.0.5) sha256=4cb40f90948be292fa15cc7cb37757b97266585145c6e76957464b40edfd5be6
   rails-controller-testing (1.0.5) sha256=741448db59366073e86fc965ba403f881c636b79a2c39a48d0486f2607182e94
   rails-dom-testing (2.3.0) sha256=8acc7953a7b911ca44588bf08737bc16719f431a1cc3091a292bca7317925c1d
@@ -1146,7 +1145,6 @@ CHECKSUMS
   virtus (2.0.0) sha256=8841dae4eb7fcc097320ba5ea516bf1839e5d056c61ee27138aa4bddd6e3d1c2
   warden (1.2.9) sha256=46684f885d35a69dbb883deabf85a222c8e427a957804719e143005df7a1efd0
   webmock (3.26.2) sha256=774556f2ea6371846cca68c01769b2eac0d134492d21f6d0ab5dd643965a4c90
-  webrick (1.9.2) sha256=beb4a15fc474defed24a3bda4ffd88a490d517c9e4e6118c3edce59e45864131
   websocket (1.2.11) sha256=b7e7a74e2410b5e85c25858b26b3322f29161e300935f70a0e0d3c35e0462737
   websocket-driver (0.8.0) sha256=ed0dba4b943c22f17f9a734817e808bc84cdce6a7e22045f5315aa57676d4962
   websocket-extensions (0.1.5) sha256=1c6ba63092cda343eb53fc657110c71c754c56484aad42578495227d717a8241

--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -7,9 +7,11 @@ module CaseWorkers
 
       skip_load_and_authorize_resource only: %i[index download generate create]
       before_action -> { authorize! :view, :management_information }, only: %i[index download generate create]
-      before_action :validate_report_type, only: %i[download generate create]
-      before_action :validate_report_type_is_updatable, only: %i[generate create]
-      before_action :validate_and_set_date, only: %i[create]
+      before_action :validate_report_type, only: %i[download generate]
+      before_action :validate_report_type_is_updatable, only: :generate
+      before_action :validate_report_type_with_date, only: :create
+      before_action :validate_report_type_is_updatable_with_date, only: :create
+      before_action :validate_and_set_date, only: :create
 
       def index
         @available_reports = Stats::StatsReport::REPORTS.index_with do |report|
@@ -54,11 +56,20 @@ module CaseWorkers
         redirect_to case_workers_admin_management_information_url, alert: t('.report_cannot_be_updated')
       end
 
+      def validate_report_type_with_date
+        return if Stats::StatsReport.reports[report_params[:report_type]]
+
+        redirect_to case_workers_admin_management_information_url, alert: t('.invalid_report_type')
+      end
+
+      def validate_report_type_is_updatable_with_date
+        return if Stats::StatsReport.reports[report_params[:report_type]].updatable?
+
+        redirect_to case_workers_admin_management_information_url, alert: t('.report_cannot_be_updated')
+      end
+
       def report_params
-        params.permit(
-          :report_type,
-          :start_at
-        )
+        params.require(:report).permit(:report_type, :start_at)
       end
 
       def validate_and_set_date

--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -9,7 +9,8 @@ module CaseWorkers
       before_action -> { authorize! :view, :management_information }, only: %i[index create]
       before_action :validate_report_type, only: :create
       before_action :validate_report_type_is_updatable, only: :create, if: -> { report_params[:update].present? }
-      before_action :validate_and_set_date, only: :create, if: -> { report_params[:update].present? && Stats::StatsReport.reports[report_params[:report_type]].date_required? }
+      before_action :validate_date, only: :create, if: -> { report_params[:update].present? && Stats::StatsReport.reports[report_params[:report_type]].date_required? }
+      before_action :set_date, only: :create, if: -> { report_params[:update].present? && Stats::StatsReport.reports[report_params[:report_type]].date_required? }
 
       def index
         @available_reports = Stats::StatsReport::REPORTS.index_with do |report|
@@ -58,7 +59,13 @@ module CaseWorkers
         params.expect(report: %i[report_type start_at update])
       end
 
-      def validate_and_set_date
+      def validate_date
+        return if report_params['start_at(1i)'].present?
+
+        redirect_to(case_workers_admin_management_information_index_url, alert: t('.invalid_report_date'))
+      end
+
+      def set_date
         @start_at ||= Date.new(report_params['start_at(1i)'].to_i,
                                report_params['start_at(2i)'].to_i,
                                report_params['start_at(3i)'].to_i)

--- a/app/controllers/case_workers/admin/management_information_controller.rb
+++ b/app/controllers/case_workers/admin/management_information_controller.rb
@@ -5,13 +5,11 @@ module CaseWorkers
     class ManagementInformationController < CaseWorkers::Admin::ApplicationController
       include ActiveStorage::SetCurrent
 
-      skip_load_and_authorize_resource only: %i[index download generate create]
-      before_action -> { authorize! :view, :management_information }, only: %i[index download generate create]
-      before_action :validate_report_type, only: %i[download generate]
-      before_action :validate_report_type_is_updatable, only: :generate
-      before_action :validate_report_type_with_date, only: :create
-      before_action :validate_report_type_is_updatable_with_date, only: :create
-      before_action :validate_and_set_date, only: :create
+      skip_load_and_authorize_resource only: %i[index create]
+      before_action -> { authorize! :view, :management_information }, only: %i[index create]
+      before_action :validate_report_type, only: :create
+      before_action :validate_report_type_is_updatable, only: :create, if: -> { report_params[:update].present? }
+      before_action :validate_and_set_date, only: :create, if: -> { report_params[:update].present? && Stats::StatsReport.reports[report_params[:report_type]].date_required? }
 
       def index
         @available_reports = Stats::StatsReport::REPORTS.index_with do |report|
@@ -19,57 +17,45 @@ module CaseWorkers
         end
       end
 
-      def download
-        log_download_start
-        record = Stats::StatsReport.most_recent_by_type(params[:report_type])
-
-        if record.document.attached?
-          redirect_to record.document.blob.url(disposition: 'attachment'), allow_other_host: true
-        else
-          redirect_to case_workers_admin_management_information_url, alert: t('.missing_report')
-        end
-      end
-
-      def generate
-        StatsReportGenerationJob.perform_later(report_type: params[:report_type])
-        message = t('case_workers.admin.management_information.job_scheduled')
-        redirect_to case_workers_admin_management_information_url, flash: { notification: message }
-      end
-
       def create
-        StatsReportGenerationJob.perform_later(report_type: report_params[:report_type], start_at: @start_at)
-        message = t('case_workers.admin.management_information.job_scheduled')
-        redirect_to case_workers_admin_management_information_url, flash: { notification: message }
+        return update_report if report_params[:update].present?
+
+        download_report
       end
 
       private
 
-      def validate_report_type
-        return if Stats::StatsReport.reports[params[:report_type]]
+      def update_report
+        StatsReportGenerationJob.perform_later(report_type: report_params[:report_type], start_at: @start_at)
+        message = t('case_workers.admin.management_information.job_scheduled')
+        redirect_to case_workers_admin_management_information_index_url, flash: { notification: message }
+      end
 
-        redirect_to case_workers_admin_management_information_url, alert: t('.invalid_report_type')
+      def download_report
+        log_download_start
+        record = Stats::StatsReport.most_recent_by_type(report_params[:report_type])
+
+        if record.document.attached?
+          redirect_to record.document.blob.url(disposition: 'attachment'), allow_other_host: true
+        else
+          redirect_to case_workers_admin_management_information_index_url, alert: t('.missing_report')
+        end
+      end
+
+      def validate_report_type
+        return if Stats::StatsReport.reports[report_params[:report_type]]
+
+        redirect_to case_workers_admin_management_information_index_url, alert: t('.invalid_report_type')
       end
 
       def validate_report_type_is_updatable
-        return if Stats::StatsReport.reports[params[:report_type]].updatable?
-
-        redirect_to case_workers_admin_management_information_url, alert: t('.report_cannot_be_updated')
-      end
-
-      def validate_report_type_with_date
-        return if Stats::StatsReport.reports[report_params[:report_type]]
-
-        redirect_to case_workers_admin_management_information_url, alert: t('.invalid_report_type')
-      end
-
-      def validate_report_type_is_updatable_with_date
         return if Stats::StatsReport.reports[report_params[:report_type]].updatable?
 
-        redirect_to case_workers_admin_management_information_url, alert: t('.report_cannot_be_updated')
+        redirect_to case_workers_admin_management_information_index_url, alert: t('.report_cannot_be_updated')
       end
 
       def report_params
-        params.require(:report).permit(:report_type, :start_at)
+        params.expect(report: %i[report_type start_at update])
       end
 
       def validate_and_set_date
@@ -77,7 +63,7 @@ module CaseWorkers
                                report_params['start_at(2i)'].to_i,
                                report_params['start_at(3i)'].to_i)
       rescue Date::Error
-        redirect_to case_workers_admin_management_information_url, alert: t('.invalid_report_date')
+        redirect_to case_workers_admin_management_information_index_url, alert: t('.invalid_report_date')
       end
 
       def log_download_start

--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -32,5 +32,5 @@ class CspReportsController < ApplicationController
     @report ||= { error: 'Unable to parse data' }
   end
 
-  def body = @body ||= request.body.read
+  def body = @body ||= request.raw_post
 end

--- a/app/controllers/external_users/expenses/distances_controller.rb
+++ b/app/controllers/external_users/expenses/distances_controller.rb
@@ -9,7 +9,7 @@ module ExternalUsers
         respond_to do |format|
           format.json do
             if result.error.present?
-              render json: { error: t(".errors.#{result.error}") }, status: :unprocessable_entity
+              render json: { error: t(".errors.#{result.error}") }, status: :unprocessable_content
             else
               render json: { distance: result.value }
             end

--- a/app/controllers/external_users/fees/prices_controller.rb
+++ b/app/controllers/external_users/fees/prices_controller.rb
@@ -17,7 +17,7 @@ module ExternalUsers
         respond_to do |format|
           format.html
           format.json do
-            render json: response, status: response.success? ? :ok : :unprocessable_entity
+            render json: response, status: response.success? ? :ok : :unprocessable_content
           end
         end
       end

--- a/app/controllers/super_admins/stats_controller.rb
+++ b/app/controllers/super_admins/stats_controller.rb
@@ -26,13 +26,25 @@ module SuperAdmins
       @date_err = graph_data.date_err
     end
 
-    def parse_time(date)
-      Time.zone.parse("#{params["#{date}(3i)"]}-#{params["#{date}(2i)"]}-#{params["#{date}(1i)"]}")
+    def parse_date(date)
+      return if stats_params[:stats].nil?
+
+      Date.new(
+        stats_params[:stats]["#{date}(1i)"].to_i,
+        stats_params[:stats]["#{date}(2i)"].to_i,
+        stats_params[:stats]["#{date}(3i)"].to_i
+      )
+    rescue Date::Error
+      nil
     end
 
     def set_times
-      @from = parse_time('date_from') || Time.current.at_beginning_of_month
-      @to = parse_time('date_to')
+      @from = parse_date('date_from') || Time.current.at_beginning_of_month
+      @to = parse_date('date_to')
+    end
+
+    def stats_params
+      params.permit(stats: %i[date_from date_to])
     end
   end
 end

--- a/app/views/case_workers/admin/management_information/_stats_report.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report.html.haml
@@ -10,11 +10,13 @@
   %p
     = t('unavailable_report', scope: i18n_scope)
 
-.govuk-button-group
-  - if report_rec&.started_at.present?
-    = govuk_button_link_to(t('download_html', scope: i18n_scope, report_name: report_name_html),
-                      case_workers_admin_management_information_download_url(report_type: report_object.name, format: :csv))
+= form_with url: case_workers_admin_management_information_index_path, scope: :report do |f|
+  = f.hidden_field :report_type, value: report_object.name
 
-  - if report_object.updatable?
-    = govuk_button_link_to(t('update_report_html', scope: i18n_scope, report_name: report_name_html),
-                                case_workers_admin_management_information_generate_url(report_type: report_object.name), secondary: true)
+  = f.govuk_submit(t('download_html', scope: i18n_scope, report_name: report_name_html), disabled: report_rec&.started_at.blank?) do
+    - if report_object.updatable?
+      = f.button t('update_report_html', scope: i18n_scope, report_name: report_name_html),
+        type: 'submit',
+        class: 'govuk-button govuk-button--secondary',
+        name: 'report[update]',
+        value: true

--- a/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
@@ -13,7 +13,7 @@
   %p
     = t('unavailable_report', scope: i18n_scope)
 
-= form_with url: case_workers_admin_management_information_create_path do |f|
+= form_with url: case_workers_admin_management_information_create_path, scope: :report do |f|
   = f.hidden_field :report_type, value: report_object.name
   = f.govuk_date_field :start_at,
                        legend: { text: t('start_date', scope: i18n_scope) },

--- a/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
+++ b/app/views/case_workers/admin/management_information/_stats_report_with_date_form.html.haml
@@ -6,17 +6,18 @@
         scope: i18n_scope,
         datetime: report_rec.started_at.iso8601,
         time: report_rec.started_at.strftime(Settings.report_date_format))
-
-  = govuk_button_link_to(t('download_html', scope: i18n_scope, report_name: report_name_html),
-                      case_workers_admin_management_information_download_url(report_type: report_object.name, format: :csv))
 - else
   %p
     = t('unavailable_report', scope: i18n_scope)
 
-= form_with url: case_workers_admin_management_information_create_path, scope: :report do |f|
+= form_with url: case_workers_admin_management_information_index_path, scope: :report do |f|
+  = f.hidden_field :report_type, value: report_object.name
+  = f.govuk_submit(t('download_html', scope: i18n_scope, report_name: report_name_html), disabled: report_rec&.started_at.blank?)
+
+= form_with url: case_workers_admin_management_information_index_path, scope: :report do |f|
   = f.hidden_field :report_type, value: report_object.name
   = f.govuk_date_field :start_at,
                        legend: { text: t('start_date', scope: i18n_scope) },
                        hint: { text: t('daily_report_count_hint', scope: i18n_scope) }
 
-  = f.govuk_submit(t('update_report_html', scope: i18n_scope, report_name: report_name_html), class: 'govuk-button--secondary')
+  = f.govuk_submit(t('update_report_html', scope: i18n_scope, report_name: report_name_html), name: 'report[update]', value: true, class: 'govuk-button--secondary')

--- a/app/views/layouts/_primary_navigation.html.haml
+++ b/app/views/layouts/_primary_navigation.html.haml
@@ -27,6 +27,6 @@
       - if current_user.persona.provider_management?
         = sn.with_navigation_item(text: t('.manage_providers'), href: provider_management_providers_path)
       - if current_user.persona.admin?
-        = sn.with_navigation_item(text: t('.management_information'), href: case_workers_admin_management_information_path)
+        = sn.with_navigation_item(text: t('.management_information'), href: case_workers_admin_management_information_index_path)
     - else
       = sn.with_navigation_item(text: t('.error'), href: '/')

--- a/app/views/super_admins/stats/show.html.haml
+++ b/app/views/super_admins/stats/show.html.haml
@@ -11,13 +11,12 @@
 
 .govuk-width-container
   .govuk-grid-row
-  = form_with url: super_admins_stats_path, method: 'post' do |f|
+  = form_with url: super_admins_stats_path, method: 'post', scope: :stats do |f|
     .govuk-grid-column-one-third
       = f.govuk_date_field :date_from, legend: { size: 'm',
                                                  tag: 'h2',
                                                  text: 'From'},
                                        maxlength_enabled: true
-
     .govuk-grid-column-one-third
       = f.govuk_date_field :date_to, legend: { size: 'm',
                                                  tag: 'h2',

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -48,29 +48,6 @@
       "note": "Metaprogramming required to allow Active Record like 'has_one' and 'has_many' relationships."
     },
     {
-      "warning_type": "Redirect",
-      "warning_code": 18,
-      "fingerprint": "463781a59c65a58aad10746c6698db3f169b58a20435304888eff3fe9449b2ec",
-      "check_name": "Redirect",
-      "message": "Possible unprotected redirect",
-      "file": "app/controllers/case_workers/admin/management_information_controller.rb",
-      "line": 25,
-      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
-      "code": "redirect_to(Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.url(:disposition => \"attachment\"), :allow_other_host => true)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "CaseWorkers::Admin::ManagementInformationController",
-        "method": "download"
-      },
-      "user_input": "Stats::StatsReport.most_recent_by_type(params[:report_type]).document.blob.url(:disposition => \"attachment\")",
-      "confidence": "Weak",
-      "cwe_id": [
-        601
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Dangerous Eval",
       "warning_code": 13,
       "fingerprint": "64032ddbecad23020e03e74d6251eb61ef3c379208e6752a38986d21afe90ca7",
@@ -91,6 +68,29 @@
       "cwe_id": [
         913,
         95
+      ],
+      "note": ""
+    },
+    {
+      "warning_type": "Redirect",
+      "warning_code": 18,
+      "fingerprint": "66dafbaaa2cbe7420e0b8ca4945e033589f76437a60ead3e42cd576f6caa50fa",
+      "check_name": "Redirect",
+      "message": "Possible unprotected redirect",
+      "file": "app/controllers/case_workers/admin/management_information_controller.rb",
+      "line": 39,
+      "link": "https://brakemanscanner.org/docs/warning_types/redirect/",
+      "code": "redirect_to(Stats::StatsReport.most_recent_by_type(report_params[:report_type]).document.blob.url(:disposition => \"attachment\"), :allow_other_host => true)",
+      "render_path": null,
+      "location": {
+        "type": "method",
+        "class": "CaseWorkers::Admin::ManagementInformationController",
+        "method": "download_report"
+      },
+      "user_input": "Stats::StatsReport.most_recent_by_type(report_params[:report_type]).document.blob.url(:disposition => \"attachment\")",
+      "confidence": "Weak",
+      "cwe_id": [
+        601
       ],
       "note": ""
     },
@@ -118,5 +118,5 @@
       "note": "Caseworkers need to identify the downloads correspond to the cases they are processing"
     }
   ],
-  "brakeman_version": "7.1.0"
+  "brakeman_version": "8.0.4"
 }

--- a/config/locales/en/views/management_information.yml
+++ b/config/locales/en/views/management_information.yml
@@ -7,6 +7,10 @@ en:
           invalid_report_type: &invalid_report_type The requested report type is not supported
         validate_report_type_is_updatable:
           report_cannot_be_updated: &report_cannot_be_updated The requested report type cannot be updated
+        validate_report_type_with_date:
+          invalid_report_type: &invalid_report_type The requested report type is not supported
+        validate_report_type_is_updatable_with_date:
+          report_cannot_be_updated: &report_cannot_be_updated The requested report type cannot be updated
         validate_and_set_date:
           invalid_report_date: &invalid_report_date The supplied date is invalid
         create:

--- a/config/locales/en/views/management_information.yml
+++ b/config/locales/en/views/management_information.yml
@@ -7,8 +7,10 @@ en:
           invalid_report_type: &invalid_report_type The requested report type is not supported
         validate_report_type_is_updatable:
           report_cannot_be_updated: &report_cannot_be_updated The requested report type cannot be updated
-        validate_and_set_date:
+        validate_date:
           invalid_report_date: &invalid_report_date The supplied date is invalid
+        set_date:
+          invalid_report_date: *invalid_report_date
         create:
           invalid_report_type: *invalid_report_type
           invalid_report_date: *invalid_report_date

--- a/config/locales/en/views/management_information.yml
+++ b/config/locales/en/views/management_information.yml
@@ -7,17 +7,15 @@ en:
           invalid_report_type: &invalid_report_type The requested report type is not supported
         validate_report_type_is_updatable:
           report_cannot_be_updated: &report_cannot_be_updated The requested report type cannot be updated
-        validate_report_type_with_date:
-          invalid_report_type: &invalid_report_type The requested report type is not supported
-        validate_report_type_is_updatable_with_date:
-          report_cannot_be_updated: &report_cannot_be_updated The requested report type cannot be updated
         validate_and_set_date:
           invalid_report_date: &invalid_report_date The supplied date is invalid
         create:
           invalid_report_type: *invalid_report_type
           invalid_report_date: *invalid_report_date
           report_cannot_be_updated: *report_cannot_be_updated
-        download:
+          invalid_report_type: &invalid_report_type The requested report type is not supported
+          missing_report: The requested report is missing
+        download_report:
           invalid_report_type: *invalid_report_type
           missing_report: The requested report is missing
         generate:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -195,10 +195,7 @@ Rails.application.routes.draw do
         get '/', to: 'allocations#new', on: :collection
       end
 
-      get 'management_information', to: 'management_information#index', as: :management_information
-      get 'management_information/download', to: 'management_information#download', as: :management_information_download
-      get 'management_information/generate', to: 'management_information#generate', as: :management_information_generate
-      post 'management_information/create', to: 'management_information#create', as: :management_information_create
+      resources :management_information, only: [:index, :create]
     end
 
   end

--- a/features/step_definitions/super_admins_stats_steps.rb
+++ b/features/step_definitions/super_admins_stats_steps.rb
@@ -16,16 +16,16 @@ end
 
 And("I enter the From date {string}") do |date|
   split_date = date.split("/")
-  find('#_date_from_3i').set(split_date[0])
-  find('#_date_from_2i').set(split_date[1])
-  find('#_date_from_1i').set(split_date[2])
+  find('#stats_date_from_3i').set(split_date[0])
+  find('#stats_date_from_2i').set(split_date[1])
+  find('#stats_date_from_1i').set(split_date[2])
 end
 
 And("I enter the To date {string}") do |date|
   split_date = date.split("/")
-  find('#_date_to_3i').set(split_date[0])
-  find('#_date_to_2i').set(split_date[1])
-  find('#_date_to_1i').set(split_date[2])
+  find('#stats_date_to_3i').set(split_date[0])
+  find('#stats_date_to_2i').set(split_date[1])
+  find('#stats_date_to_1i').set(split_date[2])
 end
 
 And("I click Update") do

--- a/spec/controllers/external_users/fees/prices_controller_spec.rb
+++ b/spec/controllers/external_users/fees/prices_controller_spec.rb
@@ -16,7 +16,7 @@ end
 
 RSpec.shared_examples 'a failed price calculation response' do
   it 'returns unprocessible entity' do
-    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response).to have_http_status(:unprocessable_content)
   end
 
   it 'returns JSON' do

--- a/spec/requests/case_workers/admin/management_information_spec.rb
+++ b/spec/requests/case_workers/admin/management_information_spec.rb
@@ -179,10 +179,10 @@ RSpec.describe 'Management information administration' do
 
     context 'with a valid report type and valid date' do
       let(:params) do
-        { report_type:,
-          'start_at(3i)' => '25',
-          'start_at(2i)' => '12',
-          'start_at(1i)' => '2020' }
+        { report: { report_type:,
+                    'start_at(3i)' => '25',
+                    'start_at(2i)' => '12',
+                    'start_at(1i)' => '2020' } }
       end
 
       let(:report_type) { 'agfs_management_information_statistics' }
@@ -211,10 +211,10 @@ RSpec.describe 'Management information administration' do
 
     context 'with an invalid report type and valid date' do
       let(:params) do
-        { report_type: 'invalid_report_type',
-          'day(3i)' => '25',
-          'day(2i)' => '12',
-          'day(1i)' => '2020' }
+        { report: { report_type: 'invalid_report_type',
+                    'start_at(3i)' => '25',
+                    'start_at(2i)' => '12',
+                    'start_at(1i)' => '2020' } }
       end
 
       it_behaves_like 'report validator'
@@ -222,7 +222,7 @@ RSpec.describe 'Management information administration' do
 
     context 'with valid report type but no date' do
       let(:params) do
-        { report_type: 'agfs_management_information_statistics' }
+        { report: { report_type: 'agfs_management_information_statistics' } }
       end
 
       it_behaves_like 'date validator'
@@ -230,10 +230,10 @@ RSpec.describe 'Management information administration' do
 
     context 'with valid report type but an invalid date' do
       let(:params) do
-        { report_type: 'agfs_management_information_statistics',
-          'day(3i)' => '-1',
-          'day(2i)' => '12',
-          'day(1i)' => '2020' }
+        { report: { report_type: 'agfs_management_information_statistics',
+                    'start_at(3i)' => '-1',
+                    'start_at(2i)' => '12',
+                    'start_at(1i)' => '2020' } }
       end
 
       it_behaves_like 'date validator'

--- a/spec/requests/case_workers/admin/management_information_spec.rb
+++ b/spec/requests/case_workers/admin/management_information_spec.rb
@@ -33,7 +33,7 @@ RSpec.shared_examples 'external user not authorized' do
 end
 
 RSpec.shared_examples 'report validator' do
-  it { is_expected.to redirect_to(case_workers_admin_management_information_url) }
+  it { is_expected.to redirect_to(case_workers_admin_management_information_index_url) }
 
   it 'displays message to indicate report job schedule failure' do
     subject
@@ -42,7 +42,7 @@ RSpec.shared_examples 'report validator' do
 end
 
 RSpec.shared_examples 'date validator' do
-  it { is_expected.to redirect_to(case_workers_admin_management_information_url) }
+  it { is_expected.to redirect_to(case_workers_admin_management_information_index_url) }
 
   it 'displays message to indicate date is invalid' do
     subject
@@ -55,8 +55,8 @@ RSpec.describe 'Management information administration' do
 
   let(:persona) { create(:case_worker, :admin) }
 
-  describe '#GET /case_workers/admin/management_information/index' do
-    subject(:request) { get case_workers_admin_management_information_path }
+  describe '#GET /case_workers/admin/management_information' do
+    subject(:request) { get case_workers_admin_management_information_index_path }
 
     let(:expected_report_types) do
       %w[management_information
@@ -92,151 +92,124 @@ RSpec.describe 'Management information administration' do
     end
   end
 
-  describe '#GET /case_workers/admin/management_information/download' do
-    subject(:request) do
-      get case_workers_admin_management_information_download_path(params: { report_type: })
-    end
-
-    it_behaves_like 'case worker not authorized'
-    it_behaves_like 'external user not authorized'
-
-    context 'with a valid report type' do
-      let(:report_type) { 'management_information' }
-      let(:test_url) { 'https://document.storage/mi_report.csv#123abc' }
-
-      before do
-        stats_report = create(:stats_report, :with_document, report_name: report_type)
-        allow(Stats::StatsReport).to receive(:most_recent_by_type).and_return(stats_report)
-        allow(stats_report.document.blob).to receive(:url).and_return(test_url)
-
-        request
-      end
-
-      it { is_expected.to redirect_to test_url }
-    end
-
-    context 'with a report type that is valid and completed but the file is missing' do
-      before { create(:stats_report, report_name: report_type) }
-
-      let(:report_type) { 'management_information' }
-
-      it { is_expected.to redirect_to case_workers_admin_management_information_url }
-
-      it 'displays error message' do
-        request
-        expect(flash[:alert]).to eq('The requested report is missing')
-      end
-    end
+  describe '#POST /case_workers/admin/management_information' do
+    subject(:request) { post case_workers_admin_management_information_index_path(params:) }
 
     context 'with an invalid report type' do
-      let(:report_type) { 'invalid_report_type' }
+      let(:params) { { report: { report_type: 'invalid_report_type' } } }
 
       it_behaves_like 'report validator'
     end
-  end
-
-  describe '#GET /case_workers/admin/management_information/generate' do
-    subject(:request) do
-      get case_workers_admin_management_information_generate_path(params: { report_type: })
-    end
-
-    it_behaves_like 'case worker not authorized'
-    it_behaves_like 'external user not authorized'
 
     context 'with a valid report type' do
-      let(:report_type) { 'management_information' }
+      let(:params) { { report: { report_type: 'management_information' } } }
 
-      before { ActiveJob::Base.queue_adapter = :test }
+      it_behaves_like 'case worker not authorized'
+      it_behaves_like 'external user not authorized'
 
-      it 'enqueues a StatsReportGenerationJob for specified report' do
-        request
-        expect(StatsReportGenerationJob)
-          .to have_been_enqueued.with(report_type:)
-                                .on_queue('stats_reports')
-                                .at(:no_wait)
+      context 'when the file is present' do
+        let(:test_url) { 'https://document.storage/mi_report.csv#123abc' }
+
+        before do
+          stats_report = create(:stats_report, :with_document, report_name: 'management_information')
+          allow(Stats::StatsReport).to receive(:most_recent_by_type).and_return(stats_report)
+          allow(stats_report.document.blob).to receive(:url).and_return(test_url)
+
+          request
+        end
+
+        it { is_expected.to redirect_to(test_url) }
       end
 
-      it 'displays message to indicate background job enqueued' do
-        request
-        expect(flash[:notification])
-          .to eq('Refresh this page in a few minutes to download the new report.')
+      context 'when the file is missing' do
+        before { create(:stats_report, report_name: 'management_information') }
+
+        it { is_expected.to redirect_to(case_workers_admin_management_information_index_path) }
+
+        it 'displays error message' do
+          request
+          expect(flash[:alert]).to eq('The requested report is missing')
+        end
       end
 
-      it { is_expected.to redirect_to(case_workers_admin_management_information_url) }
-    end
+      context 'with an update parameter' do
+        let(:params) { { report: { report_type: 'management_information', update: 'true' } } }
 
-    context 'with an invalid report type' do
-      let(:report_type) { 'invalid_report_type' }
+        before { ActiveJob::Base.queue_adapter = :test }
 
-      it_behaves_like 'report validator'
-    end
-  end
+        it_behaves_like 'case worker not authorized'
+        it_behaves_like 'external user not authorized'
 
-  describe '#POST /case_workers/admin/management_information/create' do
-    subject(:request) { post case_workers_admin_management_information_create_path(params:) }
+        it 'enqueues a StatsReportGenerationJob for specified report' do
+          request
+          expect(StatsReportGenerationJob)
+            .to have_been_enqueued.with(hash_including(report_type: 'management_information'))
+                                  .on_queue('stats_reports')
+                                  .at(:no_wait)
+        end
 
-    before { ActiveJob::Base.queue_adapter = :test }
+        it 'displays message to indicate background job enqueued' do
+          request
+          expect(flash[:notification])
+            .to eq('Refresh this page in a few minutes to download the new report.')
+        end
 
-    context 'with a valid report type and valid date' do
-      let(:params) do
-        { report: { report_type:,
-                    'start_at(3i)' => '25',
-                    'start_at(2i)' => '12',
-                    'start_at(1i)' => '2020' } }
+        it { is_expected.to redirect_to(case_workers_admin_management_information_index_url) }
       end
 
-      let(:report_type) { 'agfs_management_information_statistics' }
+      context 'with an update parameter for a report that requires a date' do
+        let(:params) do
+          {
+            report: {
+              report_type: 'agfs_management_information_statistics',
+              update: 'true',
+              'start_at(3i)' => '25',
+              'start_at(2i)' => '12',
+              'start_at(1i)' => '2020'
+            }
+          }
+        end
 
-      it 'enqueues a StatsReportGenerationJob for specified report with date' do
-        request
-        expect(StatsReportGenerationJob)
-          .to have_been_enqueued.with(report_type:, start_at: Date.parse('2020-12-25'))
-                                .on_queue('stats_reports')
-                                .at(:no_wait)
+        before { ActiveJob::Base.queue_adapter = :test }
+
+        it 'enqueues a StatsReportGenerationJob for specified report with date' do
+          request
+          expect(StatsReportGenerationJob).to have_been_enqueued.with(
+            report_type: 'agfs_management_information_statistics',
+            start_at: Date.parse('2020-12-25')
+          ).on_queue('stats_reports').at(:no_wait)
+        end
+
+        it 'displays message to indicate background job enqueued' do
+          request
+          expect(flash[:notification])
+            .to eq('Refresh this page in a few minutes to download the new report.')
+        end
+
+        it { is_expected.to redirect_to(case_workers_admin_management_information_index_url) }
       end
 
-      it 'displays message to indicate background job enqueued' do
-        request
-        expect(flash[:notification])
-          .to eq('Refresh this page in a few minutes to download the new report.')
+      context 'with an update parameter for a report that requires a date with the date missing' do
+        let(:params) { { report: { report_type: 'agfs_management_information_statistics', update: 'true' } } }
+
+        it_behaves_like 'date validator'
       end
 
-      it 'returns http redirect' do
-        request
-        expect(response).to have_http_status(:redirect)
+      context 'with an update parameter for a report that requires a date with an invalid date' do
+        let(:params) do
+          {
+            report: {
+              report_type: 'agfs_management_information_statistics',
+              update: 'true',
+              'start_at(3i)' => '32',
+              'start_at(2i)' => '13',
+              'start_at(1i)' => '2020'
+            }
+          }
+        end
+
+        it_behaves_like 'date validator'
       end
-
-      it { is_expected.to redirect_to(case_workers_admin_management_information_url) }
-    end
-
-    context 'with an invalid report type and valid date' do
-      let(:params) do
-        { report: { report_type: 'invalid_report_type',
-                    'start_at(3i)' => '25',
-                    'start_at(2i)' => '12',
-                    'start_at(1i)' => '2020' } }
-      end
-
-      it_behaves_like 'report validator'
-    end
-
-    context 'with valid report type but no date' do
-      let(:params) do
-        { report: { report_type: 'agfs_management_information_statistics' } }
-      end
-
-      it_behaves_like 'date validator'
-    end
-
-    context 'with valid report type but an invalid date' do
-      let(:params) do
-        { report: { report_type: 'agfs_management_information_statistics',
-                    'start_at(3i)' => '-1',
-                    'start_at(2i)' => '12',
-                    'start_at(1i)' => '2020' } }
-      end
-
-      it_behaves_like 'date validator'
     end
   end
 end

--- a/spec/requests/case_workers/admin/management_information_spec.rb
+++ b/spec/requests/case_workers/admin/management_information_spec.rb
@@ -210,6 +210,22 @@ RSpec.describe 'Management information administration' do
 
         it_behaves_like 'date validator'
       end
+
+      context 'with an update parameter for a report that requires a date with a missing year' do
+        let(:params) do
+          {
+            report: {
+              report_type: 'agfs_management_information_statistics',
+              update: 'true',
+              'start_at(3i)' => '25',
+              'start_at(2i)' => '12',
+              'start_at(1i)' => ''
+            }
+          }
+        end
+
+        it_behaves_like 'date validator'
+      end
     end
   end
 end

--- a/spec/requests/csp_report_spec.rb
+++ b/spec/requests/csp_report_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe 'Content Security Policy reports' do
       stub_request(:post, 'https://slack').and_return(status: 200)
       allow(Settings).to receive(:slack).and_return(Struct.new(:bot_url).new('https://slack'))
 
-      post csp_report_url, params:
+      post csp_report_url, params:, headers: { 'Content-Type' => 'application/json' }
     end
 
     it { expect(response).to be_successful }

--- a/spec/requests/documents_spec.rb
+++ b/spec/requests/documents_spec.rb
@@ -39,7 +39,7 @@ RSpec.shared_examples 'failed document upload' do
 
   it 'returns status unprocessable entity' do
     create_document
-    expect(response).to have_http_status(:unprocessable_entity)
+    expect(response).to have_http_status(:unprocessable_content)
   end
 
   it 'returns errors in response' do

--- a/spec/requests/external_users/expenses/distance_calculation_spec.rb
+++ b/spec/requests/external_users/expenses/distance_calculation_spec.rb
@@ -57,7 +57,7 @@ RSpec.describe 'Distance calculation for travel expenses' do
         calculate_distance
 
         expect(response.media_type).to eq('application/json')
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_body).to eq('error' => 'Cannot calculate distance without a valid claim')
       end
     end
@@ -69,7 +69,7 @@ RSpec.describe 'Distance calculation for travel expenses' do
         calculate_distance
 
         expect(response.media_type).to eq('application/json')
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_body).to eq('error' => 'Cannot calculate distance for this type of claim')
       end
     end
@@ -81,7 +81,7 @@ RSpec.describe 'Distance calculation for travel expenses' do
         calculate_distance
 
         expect(response.media_type).to eq('application/json')
-        expect(response).to have_http_status(:unprocessable_entity)
+        expect(response).to have_http_status(:unprocessable_content)
         expect(json_body).to eq('error' => 'Supplier associated with the claim does not have a postcode')
       end
     end

--- a/spec/requests/super_admins/stats_request_spec.rb
+++ b/spec/requests/super_admins/stats_request_spec.rb
@@ -4,8 +4,10 @@ def post_with_params(from, to)
   from = from.split('/')
   to = to.split('/')
 
-  post '/super_admins/stats', params: { 'date_from(3i)': from[0], 'date_from(2i)': from[1], 'date_from(1i)': from[2],
-                                        'date_to(3i)': to[0], 'date_to(2i)': to[1], 'date_to(1i)': to[2] }
+  post '/super_admins/stats', params: { stats: {
+    'date_from(3i)': from[0], 'date_from(2i)': from[1], 'date_from(1i)': from[2],
+    'date_to(3i)': to[0], 'date_to(2i)': to[1], 'date_to(1i)': to[2]
+  } }
 end
 
 RSpec.describe 'Stats' do


### PR DESCRIPTION
#### What

Upgrade the rack-livereload gem

#### Ticket

[CCCD - Upgrade Rack from version 2 to 3](https://dsdmoj.atlassian.net/browse/CTSKF-1723)

#### Why

We missed updating rack-livereload as it was bundled in with the rails 7.2 dependabot PR, which we closed. See #7614. Once closed, dependabot ignores the gem until there is a new version and there hasn't been one since.

#### How

Update `Gemfile`:

```ruby
gem 'rack-livereload', '~> 0.6.1'
```

Rack version 3, which comes as a result of this update, updates the naming of HTTP status 422 from 'Unprocessable Entity' to 'Unprocessable Content' and deprecated the old name. There were some changes required to use the new helper. See rack/rack#2137

To deal with the change of the multi-part date fields correctly a scope is added to the submission form, so for the `start_at` dates in the management information page (for example) the fields are now `report[start_at(1i)]`, `report[start_at(2i)` and `report[start_at(3i)]`. The strong params are then handled in the `ManagementInformationController#report_params` using the nested `params.expect(report: %i[report_type start_at update])` instead of the un-nested `params.permit(:report_type, :start_at)`. To allow for this, all buttons on the page have been changed to buttons in forms instead of link styled as buttons, as they were before, and they now all route to a `POST` create endpoint instead of `GET`s to `download` or `generate`.

#### To do

The handling of parameters has been modified in Rack 3 so that square brackets, when they are not part of nested attributes, are included in the field name. This means that a field in a form with the name `[field]` will appear in `params` with the square brackets whereas in Rack 2 the brackets were removed. This occurs when a form is created with a `url` and no model and causes problems with multi field dates such where the date is constructed by three fields for day, month and year. See cd626025ddc02ae5bf6253931b6ba96066cc1d31 for example.

Places where this may need to be fixed:

* [x] `SuperAdmins::StatsController#parse_time` in `app/controllers/super_admins/stats_controller.rb`
* [x] `CaseWorkers::Admin::ManagementInformationController#validate_and_set_date` in `app/controllers/case_workers/admin/management_information_controller.rb`
* [ ] ~`MultiparameterAttributeCleaner#find_and_clean_date` in `app/controllers/concerns/multiparameter_attribute_cleaner.rb`~ This didn't need to be fixed as the form in this case includes a model