### PR TITLE
Update code to allow additional preparation fees to be available in t…

### DIFF
--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -22,6 +22,7 @@ class CaseType < ApplicationRecord
   include Roles
 
   TRIAL_FEE_TYPES = %w[GRCBR GRRAK GRRTR GRTRL].freeze
+  GUILTY_FEE_TYPES = %w[MIUAV1 MIUAV2].freeze
 
   has_many :case_stages, dependent: :destroy
 
@@ -33,6 +34,7 @@ class CaseType < ApplicationRecord
   scope :not_fixed_fee,           -> { where(is_fixed_fee: false) }
   scope :graduated_fees,          -> { where(fee_type_code: Fee::GraduatedFeeType.select(:unique_code)) }
   scope :trial_fees,              -> { where(fee_type_code: %w[GRCBR GRRAK GRRTR GRTRL]) }
+  scope :guilty_fees,             -> { where(fee_type_code: %w[MIUAV1 MIUAV2]) }
   scope :requires_cracked_dates,  -> { where(requires_cracked_dates: true) }
   scope :requires_trial_dates,    -> { where(requires_trial_dates: true) }
   scope :requires_retrial_dates,  -> { where(requires_retrial_dates: true) }
@@ -62,5 +64,9 @@ class CaseType < ApplicationRecord
 
   def is_trial_fee?
     TRIAL_FEE_TYPES.include?(fee_type_code)
+  end
+
+  def is_guilty_fee?
+    GUILTY_FEE_TYPES.include?(fee_type_code)
   end
 end

--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -22,7 +22,7 @@ class CaseType < ApplicationRecord
   include Roles
 
   TRIAL_FEE_TYPES = %w[GRCBR GRRAK GRRTR GRTRL].freeze
-  GUILTY_FEE_TYPES = %w[MIUAV1 MIUAV2].freeze
+  GUILTY_FEE_TYPES = %w[GRGLT].freeze
 
   has_many :case_stages, dependent: :destroy
 
@@ -34,7 +34,7 @@ class CaseType < ApplicationRecord
   scope :not_fixed_fee,           -> { where(is_fixed_fee: false) }
   scope :graduated_fees,          -> { where(fee_type_code: Fee::GraduatedFeeType.select(:unique_code)) }
   scope :trial_fees,              -> { where(fee_type_code: %w[GRCBR GRRAK GRRTR GRTRL]) }
-  scope :guilty_fees,             -> { where(fee_type_code: %w[MIUAV1 MIUAV2]) }
+  scope :guilty_fees,             -> { where(fee_type_code: %w[GRGLT]) }
   scope :requires_cracked_dates,  -> { where(requires_cracked_dates: true) }
   scope :requires_trial_dates,    -> { where(requires_trial_dates: true) }
   scope :requires_retrial_dates,  -> { where(requires_retrial_dates: true) }

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -5,12 +5,14 @@ module Fee
                                          MIDSE MIDSU MIPHC MISHR MISHU MIUMU MIUMO MISTE MIAPF MIFCM].freeze
     AGFS_SUPPLEMENTARY_TYPES = (AGFS_SUPPLEMENTARY_ONLY_TYPES + AGFS_SUPPLEMENTARY_SHARED_TYPES).freeze
     TRIAL_ONLY_TYPES = %w[MIUMU MIUMO MISTE MIAPF].freeze
+    GUILTY_ONLY_TYPES = %w[MIUAV1 MIUAV2].freeze
 
     default_scope { order(Arel.sql("regexp_replace(\"fee_types\".\"description\", '[()]', '', 'g')")) }
 
     scope :without_supplementary_only, -> { where.not(unique_code: AGFS_SUPPLEMENTARY_ONLY_TYPES) }
     scope :supplementary, -> { where(unique_code: AGFS_SUPPLEMENTARY_TYPES) }
     scope :without_trial_fee_only, -> { where.not(unique_code: TRIAL_ONLY_TYPES) }
+    scope :without_guilty_fee_only, -> { where.not(unique_code: GUILTY_ONLY_TYPES) }
 
     def fee_category_name
       'Miscellaneous Fees'

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -5,7 +5,7 @@ module Fee
                                          MIDSE MIDSU MIPHC MISHR MISHU MIUMU MIUMO MISTE MIAPF MIFCM].freeze
     AGFS_SUPPLEMENTARY_TYPES = (AGFS_SUPPLEMENTARY_ONLY_TYPES + AGFS_SUPPLEMENTARY_SHARED_TYPES).freeze
     TRIAL_ONLY_TYPES = %w[MIUMU MIUMO MISTE MIAPF].freeze
-    GUILTY_ONLY_TYPES = %w[MIUAV1 MIUAV2].freeze
+    GUILTY_ONLY_TYPES = %w[GRGLT].freeze
 
     default_scope { order(Arel.sql("regexp_replace(\"fee_types\".\"description\", '[()]', '', 'g')")) }
 

--- a/app/services/ccr/fee/misc_fee_adapter.rb
+++ b/app/services/ccr/fee/misc_fee_adapter.rb
@@ -46,7 +46,7 @@ module CCR
         MIAPF: zip(%w[AGFS_MISC_FEES AGFS_PREP_FEE]) # Additional preparation fee - AGFS 15+ only
       }.freeze
 
-      MISC_FEE_BILL_MAPPING_EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO MIAPF].freeze
+      MISC_FEE_BILL_MAPPING_EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO].freeze
 
       def claimed?
         maps? && charges?

--- a/app/services/claims/fetch_eligible_misc_fee_types.rb
+++ b/app/services/claims/fetch_eligible_misc_fee_types.rb
@@ -31,6 +31,7 @@ module Claims
     end
 
     def eligible_agfs_misc_fee_types
+      return filter_guilty_only_types(filtered_trial_results, apply_guilty_fee_filter?) if case_type&.is_guilty_fee?
       filter_trial_only_types(agfs_fee_types_by_claim_type, apply_trial_fee_filter?)
     end
 
@@ -79,6 +80,10 @@ module Claims
       case_type && !case_type.is_trial_fee?
     end
 
+    def apply_guilty_fee_filter?
+      case_type && !case_type.is_guilty_fee?
+    end
+
     def apply_clar_rep_order_filter?
       claim&.earliest_representation_order_date &&
         (claim.earliest_representation_order_date < Settings.clar_release_date.to_date.beginning_of_day)
@@ -90,6 +95,10 @@ module Claims
 
     def filter_trial_only_types(relation, filter)
       filter ? relation.without_trial_fee_only : relation
+    end
+
+    def filter_guilty_only_types(relation, filter)
+      filter && agfs_scheme_15? ? relation.without_guilty_fee_only : relation
     end
   end
 end

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -352,6 +352,14 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
               )
             end
           end
+
+          context 'with a "guilty plea" case type' do
+            let(:case_type) { CaseType.find_by(fee_type_code: 'MIUAV1') }
+
+            it 'returns additional preparation fee types' do
+              is_expected.to include(*additional_prep_fee_types)
+            end
+          end
         end
       end
 


### PR DESCRIPTION
…he miscellaneious drop down

#### What
One of the potential changes to the AGFS fee schemes being discussed by policy is to amend the regulations to allow additional preparation fees on guilty pleas.
The objective of this spike is to identify where these failsafes are operating in CCCD that would prevent payment of an additional preparation fixed fee being added to a guilty plea.
Investigate CCCD to see if there are similar failsafes in place with regards additional fixed fees and guilty pleas.

This PR attempts to see how it would be done. 

#### Ticket
[Investigate CCCD failsafes ahead of potential AGFS fee scheme changes](https://dsdmoj.atlassian.net/browse/CTSKF-1635)

#### Why
To allow users under the AGFS Scheme 15+ to claim for additional preparation fees for a guilty‑plea‑specific 

#### How
Introduced explicit guilty‑plea‑only misc fee definitions

##### Added a GUILTY_ONLY_TYPES constant to Fee::MiscFeeType.
These codes define miscellaneous fees that are only applicable to guilty‑plea bill types.
The same codes are reused by CaseType#is_guilty_fee?

##### Added a guilty‑plea fee filter
Implemented a new private method, filter_guilty_only_types, in Claims::FetchEligibleMiscFeeTypes.
This mirrors the existing filter_trial_only_types approach, conditionally excluding guilty‑only fees when they are not applicable.

The filter is explicitly limited to AGFS Scheme 15+, preserving behaviour for earlier schemes.

##### Updated AGFS misc fee eligibility flow

Updated eligible_agfs_misc_fee_types to apply guilty‑plea filtering when the claim case type represents a guilty‑plea fee.
Added apply_guilty_fee_filter? to keep the intent of the filtering logic clear and readable.
Trial‑only and guilty‑only fee concerns remain separate, predictable, and easy to extend.