### PR TITLE
Fix caseworker access to documents on archived claims

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -65,7 +65,7 @@ class Ability
     can_administer_any_provider if persona.roles.include?('provider_management')
     can %i[upload delete], Document
     can %i[show download], Document do |document|
-      document.claim.case_workers.include?(persona)
+      document.claim.case_workers.include?(persona) || Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES.include?(document.claim.state)
     end
     can %i[index feedback], CourtData
     can_manage_own_password(persona)

--- a/spec/models/ability_spec.rb
+++ b/spec/models/ability_spec.rb
@@ -455,6 +455,15 @@ RSpec.describe Ability do
       end
     end
 
+    context 'can view and download documents on archived claims that are not allocated to them' do
+      let(:archived_claim) { create(:advocate_claim, :archived_pending_delete) }
+      let(:archived_document) { create(:document, claim: archived_claim) }
+
+      %i[show download].each do |action|
+        it { should be_able_to(action, archived_document) }
+      end
+    end
+
     context 'can view their own profile' do
       it { should be_able_to(:show, case_worker) }
     end


### PR DESCRIPTION
#### What

A recent change (https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/pull/9225) restricted caseworker access so that they can only view documents on claims that are allocated to them. This has caused some problems for caseworkers who have a legitimate need to view documents on claims that have already been assessed by another caseworker (for example where the claims is for a co-defendant on a case they are assessing a claim for).

This fix relaxes the restriction on caseworker access to documents so that they can view documents on claims that are in an archived state, even if they are not allocated to them.

Note: for caseworkers, claims appear in the archive as soon as they have been assessed. Claims may be in any of the following states: `authorised`, `part_authorised`, `rejected`, `refused`, `archived_pending_delete`, or `archived_pending_review`. This change uses the `Claims::StateMachine::CASEWORKER_DASHBOARD_ARCHIVED_STATES` constant to check for archived states, which includes all of the above.