### PR TITLE
Fix issue with claims params on redeterminations

### DIFF
--- a/app/controllers/case_workers/claims_controller.rb
+++ b/app/controllers/case_workers/claims_controller.rb
@@ -74,7 +74,7 @@ module CaseWorkers
         claim: [:state, :refuse_reason_text, :reject_reason_text, :additional_information,
                 {
                   assessment_attributes: %i[id fees expenses disbursements vat_amount],
-                  redeterminations_attributes: %i[id fees expenses disbursements vat_amount],
+                  redeterminations_attributes: [%i[id fees expenses disbursements vat_amount]],
                   state_reason: []
                 }]
       )

--- a/spec/controllers/case_workers/claims_controller_spec.rb
+++ b/spec/controllers/case_workers/claims_controller_spec.rb
@@ -127,6 +127,70 @@ RSpec.describe CaseWorkers::ClaimsController do
     end
   end
 
+  describe 'PATCH #update when authorising with determination values' do
+    let(:claim) { create(:allocated_claim) }
+
+    before do
+      claim.case_workers << @case_worker
+    end
+
+    context 'with assessment_attributes' do
+      before do
+        patch :update, params: {
+          id: claim,
+          claim: {
+            state: 'authorised',
+            assessment_attributes: { fees: '100.00', expenses: '50.00', disbursements: '0.00' }
+          },
+          commit: 'Update'
+        }
+      end
+
+      it { expect(response).to redirect_to(case_workers_claim_path) }
+      it { expect(claim.reload.state).to eq('authorised') }
+    end
+
+    context 'with redeterminations_attributes on a redetermination claim' do
+      let(:claim) { create(:claim, :redetermination) }
+
+      before do
+        claim.allocate!
+        claim.case_workers << @case_worker
+        patch :update, params: {
+          id: claim,
+          claim: {
+            state: 'authorised',
+            redeterminations_attributes: { '0' => { fees: '100.00', expenses: '50.00', disbursements: '0.00' } }
+          },
+          commit: 'Update'
+        }
+      end
+
+      it { expect(response).to redirect_to(case_workers_claim_path) }
+      it { expect(claim.reload.state).to eq('authorised') }
+    end
+
+    context 'with redeterminations_attributes on an awaiting written reasons claim' do
+      let(:claim) { create(:claim, :awaiting_written_reasons) }
+
+      before do
+        claim.allocate!
+        claim.case_workers << @case_worker
+        patch :update, params: {
+          id: claim,
+          claim: {
+            state: 'authorised',
+            redeterminations_attributes: { '0' => { fees: '100.00', expenses: '50.00', disbursements: '0.00' } }
+          },
+          commit: 'Update'
+        }
+      end
+
+      it { expect(response).to redirect_to(case_workers_claim_path) }
+      it { expect(claim.reload.state).to eq('authorised') }
+    end
+  end
+
   context 'GET #archived' do
     before(:all) do
       @case_worker = create(:case_worker)


### PR DESCRIPTION
#### What

Following a change to the way strong params are handled in Rails 8, caseworkers are seeing errors when attempting to assess claims with redeterminations. When making a decision on a claim the caseworker sees: 

<img width="800" height="152" alt="image" src="https://github.com/user-attachments/assets/05a6c914-fac3-4807-89a7-4f82840d3baa" />


This is due to the `redeterminations_attributes` being expected as an array of hashes rather than a single hash, as a redetermination means there will be multiple attributes 

This PR updates the strong params in the controller so that they are in the correct format and adds tests for this scenario.


