### PR TITLE
Security fixes

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -477,9 +477,9 @@
     "@babel/helper-plugin-utils" "^7.28.6"
 
 "@babel/plugin-transform-modules-systemjs@^7.29.0":
-  version "7.29.0"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz#e458a95a17807c415924106a3ff188a3b8dee964"
-  integrity sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==
+  version "7.29.4"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz#f621105da99919c15cf4bde6fcc7346ef95e7b20"
+  integrity sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==
   dependencies:
     "@babel/helper-module-transforms" "^7.28.6"
     "@babel/helper-plugin-utils" "^7.28.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2574,9 +2574,9 @@ fast-levenshtein@^2.0.6:
   integrity sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==
 
 fast-uri@^3.0.1:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.0.tgz#66eecff6c764c0df9b762e62ca7edcfb53b4edfa"
-  integrity sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/fast-uri/-/fast-uri-3.1.2.tgz#8af3d4fc9d3e71b11572cc2673b514a7d1a8c8ec"
+  integrity sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==
 
 fastest-levenshtein@^1.0.12, fastest-levenshtein@^1.0.16:
   version "1.0.16"


### PR DESCRIPTION
#### What

Update;

* [fast-uri](https://www.npmjs.com/package/fast-uri) to from 3.1.0 to 3.1.2
* [@babel/plugin-transform-modules-systemjs](https://www.npmjs.com/package/@babel/plugin-transform-modules-systemjs) from 7.29.0 to 7.29.4

#### Ticket

N/A

#### Why

The Software Composition Analysis pipeline has flagged security vulnerabilities in these two libraries and the remediation is to upgrade to the latest version of each. See;

* https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/actions/runs/25607541820/job/75171942741?pr=9536
  * https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/security/dependabot/166
  * https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/security/dependabot/169
* https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/actions/runs/25585632617/job/75113476101?pr=9535
  * https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/security/dependabot/170 

As there are issues in separate libraries ~neither can live while the other survives~ neither can be fixed independently of the other. Therefore, although dependabot has created the necessary PRs, they need to be updated together.

#### How

Cherry-pick the fixes provided by dependabot.
