### PR TITLE
[CTSKF-1693] Retain form details after allocating claims

### DIFF
--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -349,7 +349,8 @@ moj.Modules.AllocationDataTable = {
       const quantityToAllocate = $('#quantity-to-allocate-field').val() || false
       const allocationCaseWorkerInput = $('#allocation-case-worker-id-field').val()
       const allocationCaseWorkerId = $('#allocation-case-worker-id-field-select').val()
-      if (!allocationCaseWorkerInput) {
+      const selectedCaseWorkerName = $('#allocation-case-worker-id-field-select').find('option:selected').text()
+      if (!allocationCaseWorkerInput || !allocationCaseWorkerId || allocationCaseWorkerInput !== selectedCaseWorkerName) {
         $.publish('/allocation/error/', {
           msg: 'Select a case worker.'
         })

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -386,11 +386,11 @@ moj.Modules.AllocationDataTable = {
       }).done(function (result) {
         const allocatedCaseWorkerName = $('#allocation-case-worker-id-field-select').find('option:selected').text()
         const $quantityToAllocateField = $('#quantity-to-allocate-field')
+        const $quantityToAllocate = $quantityToAllocateField.val()
         self.ui.$notificationMsg.removeClass('govuk-!-display-none govuk-notification-banner--error')
         self.ui.$notificationMsg.addClass('govuk-notification-banner--success')
         self.ui.$notificationMsg.find('.govuk-notification-banner__heading').text(result.allocated_claims.length + ' claims have been allocated to ' + allocatedCaseWorkerName)
-        $quantityToAllocateField.val('')
-        self.resetAutocomplete()
+        $quantityToAllocateField.val($quantityToAllocate)
         self.reloadScheme({
           scheme: self.searchConfig.scheme
         })
@@ -438,16 +438,6 @@ moj.Modules.AllocationDataTable = {
         max: null
       }
     })
-  },
-  // Destroy and recreate the accessible-autocomplete to cleanly reset it.
-  // So that the old Case Worker value is cleared and the input field is reset to its default state.
-  resetAutocomplete: function () {
-    const selectEl = document.querySelector('#allocation-case-worker-id-field-select')
-    if (!selectEl) return
-    selectEl.selectedIndex = 0
-    selectEl.id = selectEl.id.replace(/-select$/, '')
-    selectEl.parentElement.querySelector('.autocomplete__wrapper').remove()
-    moj.Modules.AutocompleteWrapper.Autocomplete(selectEl.id)
   },
 
   // Wrapper to clear search & filters

--- a/features/allocation.feature
+++ b/features/allocation.feature
@@ -26,6 +26,8 @@ Feature: Case worker admin allocates claims
     And I select case worker "John Smith"
     And I click Allocate
     Then I should see '2 claims have been allocated to John Smith'
+    And the text field 'Number of claims' should be filled with '2'
+    And the text field 'Case worker' should be filled with 'John Smith'
     And claims "T20160003, T20160004" should no longer be displayed
 
     When I sign out


### PR DESCRIPTION
#### What

Retain previously entered data for 'Number of claims' and 'Case worker' after allocating claims

#### Ticket

[CTSKF-1693](https://dsdmoj.atlassian.net/browse/CTSKF-1693)

#### Why

A recent change fixed a bug which allowed claims to be allocated without an allocator entering a caseworker to allocate them to. This change has affected the behaviour of the allocation screen slightly.

Previously, after an allocator entered a number of claims and a caseworker and clicked allocate, the values in the number of claims and caseworker fields were retained so that they could be reused. After the fix these fields are reset.

Allocators have asked for that functionality to be restored.

#### How

Updates javascript in `app/webpack/javascripts/modules/Modules.AllocationDataTable.js` to remove code to reset fields after allocating and instead display the existing data.

Also updates validation of the entered caseworker data to prevent allocating claims when an non-existent or partially-complete caseworker name has been entered.



[CTSKF-1693]: https://dsdmoj.atlassian.net/browse/CTSKF-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ