### PR TITLE
Enable escape_json_responses

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -25,7 +25,7 @@
 #
 # Applications that want to keep the escaping behavior can set the config to `true`.
 #++
-# Rails.configuration.action_controller.escape_json_responses = false
+Rails.configuration.action_controller.escape_json_responses = false
 
 ###
 # Skips escaping LINE SEPARATOR (U+2028) and PARAGRAPH SEPARATOR (U+2029) in JSON.


### PR DESCRIPTION
#### What
Skips escaping HTML entities and line separators. When set to `false`, the


#### Ticket

[CCCD: Enable `escape_json_responses` for Rails 8.1](https://dsdmoj.atlassian.net/browse/CTSKF-1706)

#### Why

JSON renderer no longer escapes these to improve performance.

#### How
Uncomment this line. 
Set the Rails.configuration.action_controller.escape_json_responses = false as the default value for Rails 8.1.
