### PR TITLE
Enable escape_js_separators_in_json as false for rails 8.1

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -33,7 +33,7 @@ Rails.configuration.action_controller.escape_json_responses = false
 # Historically these characters were not valid inside JavaScript literal strings but that changed in ECMAScript 2019.
 # As such it's no longer a concern in modern browsers: https://caniuse.com/mdn-javascript_builtins_json_json_superset.
 #++
-# Rails.configuration.active_support.escape_js_separators_in_json = false
+Rails.configuration.active_support.escape_js_separators_in_json = false
 
 ###
 # Raises an error when order dependent finder methods (e.g. `#first`, `#second`) are called without `order` values


### PR DESCRIPTION
#### What
Set Rails.configuration.active_support.escape_js_separators_in_json = false as the default value for Rails 8.1.

#### Ticket

[CCCD: Enable `escape_js_separators_in_json` for Rails 8.1](https://dsdmoj.atlassian.net/browse/CTSKF-1707)

#### Why
Updated to Rails 8.1

#### How

Uncomment this line `Rails.configuration.active_support.escape_js_separators_in_json = false` 
Check nothing is broken. 