### PR TITLE
Enable raise_on_missing_required_finder_order_columns for Rails 8.1

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -43,7 +43,7 @@ Rails.configuration.action_controller.escape_json_responses = false
 # The current behavior of not raising an error has been deprecated, and this configuration option will be removed in
 # Rails 8.2.
 #++
-# Rails.configuration.active_record.raise_on_missing_required_finder_order_columns = true
+Rails.configuration.active_record.raise_on_missing_required_finder_order_columns = true
 
 ###
 # Controls how Rails handles path relative URL redirects.


### PR DESCRIPTION
#### What
Raises an error when order dependent finder methods (e.g. `#first`, `#second`) are called without `order` values
on the relation, and the model does not have any order columns (`implicit_order_column`, `query_constraints`, or
`primary_key`) to fall back on.
The current behavior of not raising an error has been deprecated, and this configuration option will be removed in  Rails 8.2.
#### Ticket

[CCCD: Enable `raise_on_missing_required_finder_order_columns` for Rails 8.1](https://dsdmoj.atlassian.net/browse/CTSKF-1708)

#### Why

Updating to rails 8.1

#### How


