### PR TITLE
Replace jquery-ujs with @rails/ujs

### DIFF
--- a/app/webpack/packs/adp_swagger_application.js
+++ b/app/webpack/packs/adp_swagger_application.js
@@ -1,1 +1,3 @@
-import 'jquery-ujs'
+import Rails from '@rails/ujs'
+
+Rails.start()

--- a/app/webpack/packs/application.js
+++ b/app/webpack/packs/application.js
@@ -2,7 +2,6 @@ import '../stylesheets/application.scss'
 
 import Rails from '@rails/ujs'
 import 'jquery/src/jquery'
-import 'jquery-ujs'
 import 'jquery.iframe-transport'
 import 'chartkick/chart.js'
 import 'stickyfilljs'

--- a/app/webpack/packs/application.js
+++ b/app/webpack/packs/application.js
@@ -1,5 +1,6 @@
 import '../stylesheets/application.scss'
 
+import Rails from '@rails/ujs'
 import 'jquery/src/jquery'
 import 'jquery-ujs'
 import 'jquery.iframe-transport'
@@ -10,6 +11,8 @@ import 'jsrender/jsrender'
 import 'jquery-highlight'
 import 'jquery-throttle-debounce/jquery.ba-throttle-debounce'
 import 'accessible-autocomplete'
+
+Rails.start()
 
 import '../javascripts/vendor/polyfill.object.keys.js'
 import '../javascripts/vendor/bind.js'

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "jquery-datatables-checkboxes": "^1.3.0",
     "jquery-highlight": "^3.5.0",
     "jquery-throttle-debounce": "^1.0.0",
-    "jquery-ujs": "^1.2.3",
     "jquery-xpath": "^0.3.1",
     "jquery.iframe-transport": "^1.0.0",
     "jsrender": "^1.0.16",

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "@babel/plugin-transform-runtime": "^7.29.0",
     "@babel/preset-env": "^7.29.5",
     "@ministryofjustice/frontend": "^9.0.0",
+    "@rails/ujs": "^7.1.3-4",
     "accessible-autocomplete": "^3.0.1",
     "babel-loader": "^10.1.1",
     "babel-plugin-macros": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1152,6 +1152,11 @@
     "@parcel/watcher-win32-ia32" "2.5.6"
     "@parcel/watcher-win32-x64" "2.5.6"
 
+"@rails/ujs@^7.1.3-4":
+  version "7.1.3-4"
+  resolved "https://registry.yarnpkg.com/@rails/ujs/-/ujs-7.1.3-4.tgz#1dddea99d5c042e8513973ea709b2cb7e840dc2d"
+  integrity sha512-z0ckI5jrAJfImcObjMT1RBz2IxH6I5q6ZTMFex6AfxSQKZuuL8JxAXvg2CvBuodGCxKvybFVolDyMHXlBLeYAA==
+
 "@stylistic/eslint-plugin@2.11.0":
   version "2.11.0"
   resolved "https://registry.yarnpkg.com/@stylistic/eslint-plugin/-/eslint-plugin-2.11.0.tgz#50d0289f36f7201055b7fa1729fdc1d8c46e93fa"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3410,11 +3410,6 @@ jquery-throttle-debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/jquery-throttle-debounce/-/jquery-throttle-debounce-1.0.0.tgz#f27daba459b513b36d07d81cf744252e673cdf49"
   integrity sha512-pnyuJ6T1MX9VUhwCLZ0i21Ya8HSewM+A8xWsftLS6VjRUChXjtdfc/9YJ0qL8yRTWEVuizcI9n0sK8xmJucT9g==
 
-jquery-ujs@^1.2.3:
-  version "1.2.3"
-  resolved "https://registry.yarnpkg.com/jquery-ujs/-/jquery-ujs-1.2.3.tgz#dcac6026ab7268e5ee41faf9d31c997cd4ddd603"
-  integrity sha512-59wvfx5vcCTHMeQT1/OwFiAj+UffLIwjRIoXdpO7Z7BCFGepzq9T9oLVeoItjTqjoXfUrHJvV7QU6pUR+UzOoA==
-
 jquery-xpath@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/jquery-xpath/-/jquery-xpath-0.3.1.tgz#9c6e62e618d344364bade3bdb494f0c30df85351"


### PR DESCRIPTION
#### What

Replace then jquery-ujs npm package with @rails/ujs.

#### Ticket

N/A

#### Why

UJS (Unobtrusive Javascript) is used to assist forms in Rails. The original version, jquery-ujs, depended on jQuery and has been replaced by @rails/ujs. It turns out that this is causing issues with the latest upgrade of jQuery (see #9603) due to how it is imported and jquery-ujs is no longer being supported.

#### How

Replace jquery-ujs by @rails/ujs, which no longer depends on jQuery.

Note that;
* @rails/ujs was included in Rails from version 5.1 onwards. However, as we are still using Webpacker it is necessary to include it explicitly.
* More recently, @rails/ujs has been replaced by Turbo and Stimulus. This could be updated later.