### PR TITLE
Filter Google Tag Manager CSP violations from alerts

### DIFF
--- a/app/controllers/csp_reports_controller.rb
+++ b/app/controllers/csp_reports_controller.rb
@@ -3,7 +3,7 @@ class CspReportsController < ApplicationController
   skip_forgery_protection
 
   def create
-    unless report['source-file'] == 'chrome-extension'
+    unless ignorable_violation?
       slack_notifier.build_payload(
         icon: ':security:',
         title: 'Content Security Policy violation',
@@ -24,6 +24,16 @@ class CspReportsController < ApplicationController
       formatter: SlackNotifier::Formatter::Generic.new,
       slack_bot_name: 'CSP'
     )
+  end
+
+  def ignorable_violation?
+    report['source-file']&.include?('chrome-extension') ||
+      google_tag_manager_eval_violation?
+  end
+
+  def google_tag_manager_eval_violation?
+    report['blocked-uri'] == 'eval' &&
+      report['source-file']&.end_with?('googletagmanager.com/gtm.js')
   end
 
   def report

--- a/spec/requests/csp_report_spec.rb
+++ b/spec/requests/csp_report_spec.rb
@@ -44,5 +44,30 @@ RSpec.describe 'Content Security Policy reports' do
       it { expect(response).to be_successful }
       it { expect(a_request(:post, 'https://slack')).not_to have_been_made }
     end
+
+    context 'when the violation is a Google Tag Manager eval' do
+      let(:source_file) { 'https://www.googletagmanager.com/gtm.js' }
+      let(:params) do
+        {
+          'csp-report': {
+            'document-uri': 'https://staging.claim-crown-court-defence.service.justice.gov.uk/',
+            referrer: '',
+            'violated-directive': 'script-src',
+            'effective-directive': 'script-src',
+            'original-policy': "script-src 'self' 'wasm-unsafe-eval' 'unsafe-inline' https: https://*.googletagmanager.com",
+            disposition: 'report',
+            'blocked-uri': 'eval',
+            'line-number': 5,
+            'column-number': 33,
+            'source-file': source_file,
+            'status-code': 200,
+            'script-sample': ''
+          }
+        }.to_json
+      end
+
+      it { expect(response).to be_successful }
+      it { expect(a_request(:post, 'https://slack')).not_to have_been_made }
+    end
   end
 end


### PR DESCRIPTION
#### What

Google Tag Manager's `gtm.js` uses `eval()` internally, which violates our `script-src` directive (which intentionally omits `'unsafe-eval'`). Since the CSP is report-only, nothing is blocked, but every page load generates a noisy Slack alert.

This commit filters these violations in `CspReportsController`, matching the existing pattern for `chrome-extension` violations.

#### Why

To reduce noise in the `#laa-cccd-alerts` Slack channel, which makes monitoring for legitimate alerts difficult and may mean genuine issues go unnoticed.
