### PR TITLE
Update tmp to 0.2.6

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -4870,9 +4870,9 @@ tinyglobby@^0.2.15:
     picomatch "^4.0.4"
 
 tmp@^0.2.5:
-  version "0.2.5"
-  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.5.tgz#b06bcd23f0f3c8357b426891726d16015abfd8f8"
-  integrity sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==
+  version "0.2.6"
+  resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.2.6.tgz#0dfac10fd09a9319288eb0e8f0ed524604e183b4"
+  integrity sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==
 
 to-regex-range@^5.0.1:
   version "5.0.1"


### PR DESCRIPTION
#### What

Update the tmp npm package.

#### Ticket

N/A

#### Why

The SCA pipeline has recently started flagging this package and there is a new version to resolve this. tmp is a dependency on selenium-webdriver.

#### How

Update tmp to 0.2.6.