### PR TITLE
[CTSKF-1709] Raise exceptions on potentially unsafe redirects

### DIFF
--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -58,7 +58,7 @@ Rails.configuration.active_record.raise_on_missing_required_finder_order_columns
 # Applications that want to allow these redirects can set the config to `:log` (previous default)
 # to only log warnings, or `:notify` to send ActiveSupport notifications.
 #++
-# Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
+Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
 
 ###
 # Use a Ruby parser to track dependencies between Action View templates


### PR DESCRIPTION
#### What

Configure to raise exceptions on redirects without a leading /.

#### Ticket

[CCCD: Enable `action_on_path_relative_redirect` for Rails 8.1](https://dsdmoj.atlassian.net/browse/CTSKF-1709)

#### Why

Redirects that do not have a leading / are potentially unsafe and by default Rails 8.1 will raise exceptions when these occur.

#### How

Set the `action_on_path_relative_redirect` option to `:raise`.