### PR TITLE
Tag @chb-devs in Snyk Slack alerts

### DIFF
--- a/.github/workflows/docker_image_scan.yml
+++ b/.github/workflows/docker_image_scan.yml
@@ -52,7 +52,7 @@ jobs:
         SLACK_ICON_EMOJI: ':snyk:'
         SLACK_COLOR: ${{ steps.image-scan.outcome }}
         SLACK_TITLE: Scanned ${{ github.repository }}
-        SLACK_MESSAGE: docker scan detected vulnerabilites! @laa-claim-for-payment-devs
+        SLACK_MESSAGE: docker scan detected vulnerabilites! @chb-devs
         SLACK_LINK_NAMES: true
         SLACK_FOOTER:
 


### PR DESCRIPTION
#### What

When Snyk docker scanning detects vulnerabilities, an alert is posted to th #laa-cccd-alerts Slack channel tagging the @laa-claim-for-payment-devs group.

This group is outdated and only contains two (soon to be one) active members of the team.

This commit updates the alert so that it will now tag the @chb-devs group, which contains all active members of the team, ensuring appropriate visibility of alerts.
