### PR TITLE
[CTSKF-1711] Set remove_hidden_field_autocomplete

### DIFF
--- a/app/views/external_users/admin/providers/show.html.haml
+++ b/app/views/external_users/admin/providers/show.html.haml
@@ -33,7 +33,7 @@
 
     .govuk-button-group
       .app-link-group
-        = button_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, form_class: 'inline-form', data: { confirm: t('.confirmation'), module: 'govuk-button' }, class: 'govuk-button', draggable: false
+        = govuk_button_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, form_class: 'inline-form', data: { confirm: t('.confirmation') }
 
         - if can? :edit, @provider
           = govuk_button_link_to(t('.edit_provider'), edit_external_users_admin_provider_path(@provider), secondary: true)

--- a/app/views/external_users/admin/providers/show.html.haml
+++ b/app/views/external_users/admin/providers/show.html.haml
@@ -32,8 +32,7 @@
 
 
     .govuk-button-group
-      .app-link-group
-        = govuk_button_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, form_class: 'inline-form', data: { confirm: t('.confirmation') }
+      = govuk_button_link_to t('.generate_key'), regenerate_api_key_external_users_admin_provider_path(@provider), method: :patch, data: { confirm: t('.confirmation') }
 
-        - if can? :edit, @provider
-          = govuk_button_link_to(t('.edit_provider'), edit_external_users_admin_provider_path(@provider), secondary: true)
+      - if can? :edit, @provider
+        = govuk_button_link_to t('.edit_provider'), edit_external_users_admin_provider_path(@provider), secondary: true

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -58,7 +58,7 @@
 
           .action-wrapper
             - if claim.rejected?
-              = govuk_button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: :patch, form_class: 'inline-form', class: 'resubmit-claim'
+              = govuk_button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: :patch
 
             = govuk_button_link_to(t('.archive'), external_users_claim_path(claim), 'data-method': 'delete', 'data-confirm': t('.confirm_text'))
 

--- a/app/views/shared/_claim_header.html.haml
+++ b/app/views/shared/_claim_header.html.haml
@@ -58,7 +58,7 @@
 
           .action-wrapper
             - if claim.rejected?
-              = button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: :patch, form_class: 'inline-form', class: 'govuk-button resubmit-claim', data: { module: 'govuk-button' }, role: 'button', draggable: false
+              = govuk_button_to t('.redraft'), clone_rejected_external_users_claim_path(claim), method: :patch, form_class: 'inline-form', class: 'resubmit-claim'
 
             = govuk_button_link_to(t('.archive'), external_users_claim_path(claim), 'data-method': 'delete', 'data-confirm': t('.confirm_text'))
 
@@ -68,6 +68,6 @@
               = t('.actions')
 
           .action-wrapper
-            = button_to t('.unarchive'), unarchive_external_users_claim_path(claim), method: :patch, form_class: 'inline-form', class: 'govuk-button', data: { module: 'govuk-button' }, role: 'button', draggable: false
+            = govuk_button_to t('.unarchive'), unarchive_external_users_claim_path(claim), method: :patch
       - elsif cda_view_enabled?
         = govuk_link_to 'Court Data view (experimental)', case_workers_claim_court_data_index_path(@claim)

--- a/app/webpack/stylesheets/_cccd-typography.scss
+++ b/app/webpack/stylesheets/_cccd-typography.scss
@@ -28,16 +28,6 @@ p {
     .button {
       margin-right: $gutter-one-sixth;
     }
-
-    .resubmit-claim {
-      width: $govuk-gutter * 7;
-      padding-left: calc($govuk-gutter / 10);
-    }
-
-    .action-wrapper a:first-child,
-    .action-wrapper .resubmit-claim {
-      margin-right: $gutter-two-thirds;
-    }
   }
 }
 

--- a/app/webpack/stylesheets/_forms.scss
+++ b/app/webpack/stylesheets/_forms.scss
@@ -32,7 +32,3 @@ input[type="radio"] {
 .form-control-full {
   width: govuk-grid-widths('full');
 }
-
-.inline-form {
-  display: inline-block;
-}

--- a/config/initializers/new_framework_defaults_8_1.rb
+++ b/config/initializers/new_framework_defaults_8_1.rb
@@ -71,4 +71,4 @@ Rails.configuration.action_controller.action_on_path_relative_redirect = :raise
 #
 # Applications that want to keep generating the `autocomplete` attribute for those tags can set it to `false`.
 #++
-# Rails.configuration.action_view.remove_hidden_field_autocomplete = true
+Rails.configuration.action_view.remove_hidden_field_autocomplete = true


### PR DESCRIPTION
#### What

Remove the autocomplete option from hidden fields.

#### Ticket

[CCCD: Enable `remove_hidden_field_autocomplete` for Rails 8.1](https://dsdmoj.atlassian.net/browse/CTSKF-1711)

#### Why

The default configuration for Rails 8.1 is to omit the autocomplete option from hidden fields generated by some form helpers. There are three cases where this occurs in CCCD;
* The 'generate key' button on the provider details page
* The 'redraft' and 'unarchive' buttons on the claim page

In each of these cases the `button_to` helper is used. This can be replaced by the `govuk_button_to` helper (see below).

#### How

Set the `remove_hidden_field_autocomplete` option to true.



##### Before

HTML on the 'Redraft this claim' button;

```html
<form class="inline-form" method="post" action="/external_users/claims/84/clone_rejected">
  <input type="hidden" name="_method" value="patch" autocomplete="off">
  <button
    class="govuk-button resubmit-claim"
    data-module="govuk-button"
    role="button"
    draggable="false"
    type="submit" data-govuk-button-init="">Redraft this claim</button>
  <input
    type="hidden"
    name="authenticity_token"
    value="???"
    autocomplete="off">
</form>
```

Action buttons on rejected claims;

<img width="234" height="184" alt="Screenshot 2026-05-29 at 15 24 48" src="https://github.com/user-attachments/assets/9f0066c9-340c-44c5-bfb6-594dbc981e09" />


##### After

HTML on the 'Redraft this claim' button;

```html
<form class="button_to" method="post" action="/external_users/claims/84/clone_rejected">
  <input type="hidden" name="_method" value="patch">
  <button
    class="govuk-button"
    data-module="govuk-button"
    new_tab="false"
    type="submit"
    data-govuk-button-init="">Redraft this claim</button>
  <input
    type="hidden"
    name="authenticity_token"
    value="???">
</form>
```

Action buttons on rejected claims;

<img width="189" height="186" alt="Screenshot 2026-05-29 at 15 24 39" src="https://github.com/user-attachments/assets/f9984056-e220-46f5-be69-d76119a9682e" />

#### Other changes

* The instances of `button_to` have been replaced with `govuk_button_to`. This allows the code to be cleaned up.
* The CSS on the action buttons on rejected claims is further tidied up to remove the `resubmit-claim` class, which adds unnecessary padding and counteracts the `inline-form` class on the form.
* The `button_to` on the 'Generate new key' button of the 'Manage provider' tab for provider admin users has been changed to a `govuk_button_link_to`, changing it from a button in a from to a link. This is done so that it can be grouped with the 'Edit provider' button as a button group. See the [govuk-components gem documentation](https://govuk-components.netlify.app/helpers/button/#other-button-styles) for more details.

##### Before

HTML on the 'Manage provider' buttons;

```html
<div class="govuk-button-group">
  <div class="app-link-group">
    <form
      class="inline-form"
      method="post"
      action="/external_users/admin/providers/1/regenerate_api_key">
      <input type="hidden" name="_method" value="patch" autocomplete="off">
      <button
        data-confirm="Are you sure? Important: the new key will need to be used for all API calls and JSON file claim imports for this provider."
        data-module="govuk-button"
        class="govuk-button"
        draggable="false"
        type="submit"
        data-govuk-button-init="">Generate new key</button>
      <input
        type="hidden"
        name="authenticity_token"
        value="???"
        autocomplete="off">
    </form>
    <a
      class="govuk-button govuk-button--secondary"
      data-module="govuk-button"
      href="/external_users/admin/providers/1/edit"
      data-govuk-button-init="">Edit provider</a>
  </div>
</div>
```

##### After

HTML on the 'Manage provider' buttons;

```html
<div class="govuk-button-group">
  <a
    class="govuk-button"
    data-module="govuk-button"
    data-confirm="Are you sure? Important: the new key will need to be used for all API calls and JSON file claim imports for this provider."
    rel="nofollow"
    data-method="patch"
    href="/external_users/admin/providers/1/regenerate_api_key"
    data-govuk-button-init="">Generate new key</a>
  <a
    class="govuk-button govuk-button--secondary"
    data-module="govuk-button"
    href="/external_users/admin/providers/1/edit"
    data-govuk-button-init="">Edit provider</a>
</div>
```

#### To do

- [x] Replace button_to with govuk_button_to