### PR TITLE
[CTSKF-1037] Fix Dangerous Eval warnings

### DIFF
--- a/app/models/claim/base_claim.rb
+++ b/app/models/claim/base_claim.rb
@@ -515,10 +515,8 @@ module Claim
     # This will ensure proper route paths are generated
     # when using helpers like: edit_polymorphic_path(claim)
     def self.route_key_name(name)
-      model_name.class_eval %(
-        def singular_route_key; '#{name}'; end
-        def route_key; '#{name.pluralize}'; end
-      ), __FILE__, __LINE__ - 3
+      model_name.define_singleton_method(:singular_route_key) { name }
+      model_name.define_singleton_method(:route_key) { name.pluralize }
     end
 
     def self.fee_associations

--- a/app/services/remote/simple_associations.rb
+++ b/app/services/remote/simple_associations.rb
@@ -15,12 +15,14 @@ module Remote
 
       def has_relationship(kind, name, options)
         klass = options.fetch(:class_name, "Remote::#{name.to_s.classify}".constantize)
-        assignment = kind == :one ? "#{klass}.new(attrs)" : "attrs.map { |e| #{klass}.new(e) }"
 
-        class_eval <<-CODE, __FILE__, __LINE__ + 1
-          def #{name}=(attrs); @#{name} = #{assignment}; end
-          def #{name}; @#{name}; end
-        CODE
+        define_method(:"#{name}=") do |attrs|
+          instance_variable_set(:"@#{name}", kind == :one ? klass.new(attrs) : attrs.map { |e| klass.new(e) })
+        end
+
+        define_method(name) do
+          instance_variable_get(:"@#{name}")
+        end
       end
     end
   end

--- a/config/brakeman.ignore
+++ b/config/brakeman.ignore
@@ -24,54 +24,6 @@
       "note": ""
     },
     {
-      "warning_type": "Dangerous Eval",
-      "warning_code": 13,
-      "fingerprint": "2a4d5faf318702c8de64c418639d03c968e5523a3defd514bed34442b326ed7c",
-      "check_name": "Evaluation",
-      "message": "Dynamic string evaluated as code",
-      "file": "app/services/remote/simple_associations.rb",
-      "line": 20,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
-      "code": "class_eval(\"          def #{name}=(attrs); @#{name} = #{(\"#{options.fetch(:class_name, \"Remote::#{name.to_s.classify}\".constantize)}.new(attrs)\" or \"attrs.map { |e| #{options.fetch(:class_name, \"Remote::#{name.to_s.classify}\".constantize)}.new(e) }\")}; end\\n          def #{name}; @#{name}; end\\n\", \"app/services/remote/simple_associations.rb\", 21)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Remote::SimpleAssociations::ClassMethods",
-        "method": "has_relationship"
-      },
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        913,
-        95
-      ],
-      "note": "Metaprogramming required to allow Active Record like 'has_one' and 'has_many' relationships."
-    },
-    {
-      "warning_type": "Dangerous Eval",
-      "warning_code": 13,
-      "fingerprint": "64032ddbecad23020e03e74d6251eb61ef3c379208e6752a38986d21afe90ca7",
-      "check_name": "Evaluation",
-      "message": "Dynamic string evaluated as code",
-      "file": "app/models/claim/base_claim.rb",
-      "line": 518,
-      "link": "https://brakemanscanner.org/docs/warning_types/dangerous_eval/",
-      "code": "model_name.class_eval(\"\\n        def singular_route_key; '#{name}'; end\\n        def route_key; '#{name.pluralize}'; end\\n      \", \"app/models/claim/base_claim.rb\", 518)",
-      "render_path": null,
-      "location": {
-        "type": "method",
-        "class": "Claim::BaseClaim",
-        "method": "Claim::BaseClaim.route_key_name"
-      },
-      "user_input": null,
-      "confidence": "Weak",
-      "cwe_id": [
-        913,
-        95
-      ],
-      "note": ""
-    },
-    {
       "warning_type": "Redirect",
       "warning_code": 18,
       "fingerprint": "66dafbaaa2cbe7420e0b8ca4945e033589f76437a60ead3e42cd576f6caa50fa",


### PR DESCRIPTION

#### What

Brakeman flags two places where `class_eval` is used to define methods on the fly. This is insecure because it can be used to execute arbitrary code. The use of `class_eval` can be replaced with `define_method` and `define_singleton_method`, which are safer ways to define methods dynamically.

This commit makes the following changes:
- `simple_associations.rb`: Uses `define_method` to define getter/setter methods for `has_one`/`has_many` relationships on `Remote` objects
- `base_claim.rb`: Uses `define_singleton_method` on `model_name` to override `singular_route_key` and `route_key`
- `brakeman.ignore`: Removes the entries that were ignoring these warnings


#### Ticket

[CTSKF-1037](https://dsdmoj.atlassian.net/browse/CTSKF-1037)


[CTSKF-1037]: https://dsdmoj.atlassian.net/browse/CTSKF-1037?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ