### PR TITLE
Ctskf 1625 cccd accessibility claim multi select selected row contrast issues

### DIFF
--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -178,5 +178,5 @@ td.active {
 
 // Override the default colour of a selected row to use the recommended GOVUK colour
 :root {
-  --dt-row-selected: 29,112,184;  // DataTables requires an RGB value to set the colour. This equates to govuk-colour("blue")	(#1d70b8)
+  --dt-row-selected: 244,248,251;  // DataTables requires an RGB value to set the colour. This equates to govuk-colour("blue", $variant: "shade-95")	(#f4f8fb)
 }

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -176,7 +176,9 @@ td.active {
   text-align: center;
 }
 
-// Override the default colour of a selected row to use the recommended GOVUK colour
+// Override the default colour of a selected row, text and the link - to use the recommended GOVUK colour.
 :root {
-  --dt-row-selected: 244,248,251;  // DataTables requires an RGB value to set the colour. This equates to govuk-colour("blue", $variant: "shade-95")	(#f4f8fb)
+  --dt-row-selected: 244,248,251;
+  --dt-row-selected-text: 0,0,0;
+  --dt-row-selected-link: 26, 101, 166;
 }


### PR DESCRIPTION
#### What
Updates the default settings of the javascript AllocationDataTable.

#### Ticket

[CCCD - Accessibility - claim multi-select selected row contrast issues](https://dsdmoj.atlassian.net/browse/CTSKF-1625)

#### Why
When a user clicks on a row or checkbox on the allocation queue page the row has a box shadow (govuk-colour(“blue”) with 90% opacity. If the row contains errors (injection etc.) then the text and border for this component use govuk-colour(“Red”). This contrast fails WCAG AA standards.

#### How
Colours are:
Row highlight
RGB: 244, 248, 251, 100% 

Row text on highlight
Same as text used when not highlighted, e.g. color: var(--govuk-text-colour, #0b0c0c);

Case# hyperlink
26, 101, 166, 100%
