### PR TITLE
[CTSKF-867] Sortable table consistency

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -68,7 +68,6 @@ module ApplicationHelper
 
   def sortable(column, title = nil, options = {})
     title ||= column.titleize
-    title = ("#{title} " + column_sort_icon) if column == sort_column
 
     css_class = column == sort_column ? "current #{sort_direction}" : nil
     direction = column == sort_column && sort_direction == 'asc' ? 'desc' : 'asc'
@@ -79,10 +78,6 @@ module ApplicationHelper
     html_options = options.merge(class: css_class)
 
     govuk_link_to [title].join(' ').html_safe, query_params, **html_options
-  end
-
-  def column_sort_icon
-    sort_direction == 'asc' ? "\u25B2" : "\u25BC"
   end
 
   def dom_id(record, prefix = nil)

--- a/app/views/case_workers/admin/allocations/_allocation.html.haml
+++ b/app/views/case_workers/admin/allocations/_allocation.html.haml
@@ -52,7 +52,7 @@
         = row.with_cell(text: '')
         = row.with_cell(text: t('.case_number'))
         = row.with_cell(text: t('.court'))
-        = row.with_cell(text: t('.defendents'))
+        = row.with_cell(text: t('.defendants'))
         = row.with_cell(text: t('.type'))
         = row.with_cell(text: t('.submitted'), numeric: true)
         = row.with_cell(text: t('.total'), numeric: true)

--- a/app/views/case_workers/claims/_claims_list.html.haml
+++ b/app/views/case_workers/claims/_claims_list.html.haml
@@ -4,7 +4,7 @@
       = pagy_info(@pagy).html_safe
 
   .govuk-grid-column-full
-    = govuk_table(classes: 'app-table--responsive') do |table|
+    = govuk_table(classes: 'app-table--responsive', html_attributes: { data: { module: 'moj-sortable-table' } }) do |table|
       = table.with_caption(classes: 'govuk-visually-hidden') do
         = params[:action] == 'archived' ? t('case_workers.table_headings.archived_claims') : t('case_workers.table_headings.your_claims')
 

--- a/app/views/external_users/claims/_main_claims_list.html.haml
+++ b/app/views/external_users/claims/_main_claims_list.html.haml
@@ -1,4 +1,4 @@
-= govuk_table(classes: 'app-table--responsive') do |table|
+= govuk_table(classes: 'app-table--responsive', html_attributes: { data: { module: 'moj-sortable-table' } }) do |table|
   = table.with_caption(size: 's') do
     .govuk-grid-row
       .govuk-grid-column-one-half

--- a/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
+++ b/app/webpack/javascripts/modules/Modules.AllocationDataTable.js
@@ -42,6 +42,7 @@ moj.Modules.AllocationDataTable = {
   // See: https://datatables.net/reference/option/
   // => https://datatables.net/reference/
   options: {
+    autoWidth: false,
 
     // default order settings
     // =>/option/order

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -81,7 +81,7 @@ tr {
 
     tbody tr:nth-child(odd),
     tbody tr:nth-child(even) {
-      background-color: none;
+      background-color: transparent;
     }
 
     th::before,

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -181,3 +181,94 @@ td.active {
   --dt-row-selected-text: 0,0,0;
   --dt-row-selected-link: 26, 101, 166;
 }
+
+// Style sortable table column headers using MOJ Sortable Table styling
+$sortable-indicator-size: 22px;
+$sortable-indicator-mask-unsorted: "data:image/svg+xml,%3Csvg width='22' height='22' viewBox='0 0 22 22' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M8.1875 9.5L10.9609 3.95703L13.7344 9.5H8.1875Z' fill='black'/%3E%3Cpath d='M13.7344 12.0781L10.9609 17.6211L8.1875 12.0781H13.7344Z' fill='black'/%3E%3C/svg%3E";
+$sortable-indicator-mask-asc: "data:image/svg+xml,%3Csvg width='22' height='22' viewBox='0 0 22 22' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M6.5625 15.5L11 6.63125L15.4375 15.5H6.5625Z' fill='black'/%3E%3C/svg%3E";
+$sortable-indicator-mask-desc: "data:image/svg+xml,%3Csvg width='22' height='22' viewBox='0 0 22 22' xmlns='http://www.w3.org/2000/svg'%3E%3Cpath d='M15.4375 7L11 15.8687L6.5625 7L15.4375 7Z' fill='black'/%3E%3C/svg%3E";
+
+@mixin sortable-indicator-image($url) {
+  -webkit-mask-image: url($url);
+  mask-image: url($url);
+}
+
+table[data-module='moj-sortable-table'] {
+  thead th a,
+  thead th[aria-sort] > button,
+  .mobile-sort a {
+    display: inline-flex;
+    position: relative;
+    margin: 0;
+    padding: 0;
+    border-width: 0;
+    color: $govuk-link-colour;
+    background-color: transparent;
+    box-shadow: none;
+    font-family: inherit;
+    font-size: 1em;
+    font-weight: inherit;
+    text-align: inherit;
+    text-decoration: none;
+    align-items: flex-start;
+
+    &::after {
+      content: '';
+      display: inline-block;
+      width: $sortable-indicator-size;
+      height: $sortable-indicator-size;
+      margin-left: 4px;
+      background-color: currentcolor;
+      -webkit-mask-repeat: no-repeat;
+      -webkit-mask-position: center;
+      -webkit-mask-size: $sortable-indicator-size $sortable-indicator-size;
+      mask-repeat: no-repeat;
+      mask-position: center;
+      mask-size: $sortable-indicator-size $sortable-indicator-size;
+      vertical-align: top;
+      @include sortable-indicator-image($sortable-indicator-mask-unsorted);
+    }
+  }
+
+  thead th a,
+  .mobile-sort a {
+    &:visited {
+      color: $govuk-link-colour;
+    }
+
+    &:hover {
+      color: $govuk-link-hover-colour;
+    }
+
+    &:active {
+      color: $govuk-link-active-colour;
+    }
+  }
+
+  thead th a:focus,
+  .mobile-sort a:focus,
+  thead th[aria-sort] > button:focus {
+    outline: none;
+    color: govuk-functional-colour(focus-text);
+    background-color: govuk-functional-colour(focus);
+    box-shadow:
+      0 -2px govuk-functional-colour(focus),
+      0 4px govuk-functional-colour(focus-text);
+  }
+
+  thead th a.current.asc::after,
+  thead th[aria-sort='ascending'] > button::after,
+  .mobile-sort a.current.asc::after {
+    @include sortable-indicator-image($sortable-indicator-mask-asc);
+  }
+
+  thead th a.current.desc::after,
+  thead th[aria-sort='descending'] > button::after,
+  .mobile-sort a.current.desc::after {
+    @include sortable-indicator-image($sortable-indicator-mask-desc);
+  }
+
+  thead th[aria-sort] > button svg {
+    display: none;
+  }
+}

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -89,7 +89,6 @@ tr {
       content: attr(data-label);
       float: left;
       font-weight: 700;
-      text-transform: uppercase;
     }
 
     .unique-id-small {

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -103,6 +103,31 @@ tr {
     td .state-display {
       display: block;
     }
+
+    &.app-jq-datatable tbody tr td:first-child {
+      display: flex;
+      align-items: flex-start;
+      justify-content: space-between;
+
+      &::before {
+        margin-right: govuk-spacing(2);
+        float: none;
+      }
+
+      .govuk-form-group {
+        margin: 0;
+        flex: 0 0 auto;
+      }
+
+      .govuk-checkboxes,
+      .govuk-checkboxes__item {
+        margin: 0;
+      }
+
+      .govuk-checkboxes__input {
+        top: 0;
+      }
+    }
   }
 }
 

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -98,6 +98,11 @@ tr {
     .state {
       display: inline;
     }
+
+    td .claim-state,
+    td .state-display {
+      display: block;
+    }
   }
 }
 

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -67,7 +67,7 @@ tr {
     }
 
     tbody tr td:first-child {
-      background-color: $govuk-border-colour;
+      background-color: govuk-colour("light-grey");
       font-weight: 700;
 
       a {

--- a/app/webpack/stylesheets/components/_table.scss
+++ b/app/webpack/stylesheets/components/_table.scss
@@ -31,7 +31,7 @@ tr {
     tr {
       display: block;
       margin-bottom: $gutter-one-third;
-      border-bottom: 3px solid govuk-colour("black", $variant: "tint-95");
+      border-bottom: 3px solid $govuk-border-colour;
 
       .govuk-table__header:last-child,
       .govuk-table__cell:last-child,
@@ -39,7 +39,7 @@ tr {
       td {
         display: block;
         padding: $gutter-half;
-        border-bottom: 1px solid govuk-colour("black", $variant: "tint-95");
+        border-bottom: 1px solid $govuk-border-colour;
         text-align: right;
 
         br {

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -2759,7 +2759,7 @@ en:
           clear_filters: Clear filter
           allocate: Allocate
           allocation_queue: Allocation queue
-          defendents: Defendants
+          defendants: Defendants
           error_summary: 'This claim allocation has '
           filter_claims: Filter claims
           page_heading: Allocation


### PR DESCRIPTION
#### What

Addresses a number of issues with the following sortable tables:

**Advocate/Litigator**: Your claims, Your claim archive

**Caseworker**: Your claims, Your archive, Allocation

#### Ticket

[CTSKF-867)](https://dsdmoj.atlassian.net/browse/CTSKF-867)

#### Why

To improve accessibility and align with design standards

#### How

This PR combines the following fixes:

1) [fefb7abcadfac04e9b16fec8d79369660bcc3edf] prevents upper-casing of labels in the mobile versions of tables by removing the `text-transform: uppercase` styling.

<img width="196" height="354" alt="image" src="https://github.com/user-attachments/assets/b39bc8e0-b4fe-472e-8f22-bcade0475a58" />
<img width="161" height="368" alt="image" src="https://github.com/user-attachments/assets/e23de579-2574-42d0-b5bb-7dd4cf2b0afb" />

------

2) [ead2ff3351b6609e60e521911d8371de0989cb15] changes the headers of the mobile versions of tables to a more accessible shade of grey by updating `background-color` to `govuk-colour("light-grey")`.

<img width="307" height="59" alt="image" src="https://github.com/user-attachments/assets/274ae048-a896-4136-a295-45880a3341ac" />
 <img width="311" height="54" alt="image" src="https://github.com/user-attachments/assets/0822e959-9ebe-48c6-b2c8-7ae31938f872" />

------

3) [8ccc47610db1b62ca2fdf39ac2796df25c823f32] changes the row separators of mobile versions of tables to a more accessible shade of grey by setting `border-bottom` to `$govuk-border-colour`

<img width="309" height="363" alt="image" src="https://github.com/user-attachments/assets/7db913e1-ff7b-4bd8-92fa-08f2bd8e2dfb" /> <img width="316" height="397" alt="image" src="https://github.com/user-attachments/assets/d7d41d66-c8f7-4237-bd5d-2b04fb02b0bc" />

------

4) [7ca7f466ded2e43a4b05f1d1c4338d6c450db5e0] adds MOJ design system [sortable table](https://design-patterns.service.justice.gov.uk/components/sortable-table/) styling to the 'Your claims' and 'Your archive' tables for providers and caseworkers. Note that this does not use the actual sortable table component as that is only compatible with client-side tables whereas all our tables rely on server-side sorting and pagination. Instead the styling is copied to our own `_tables.scss` file. Additionally, it is not applied to the allocation and reallocation tables as the use of the DataTables gem makes adding bespoke styling to those tables challenging.

<img width="1021" height="86" alt="image" src="https://github.com/user-attachments/assets/74952352-8328-4997-b81c-ec6baa6528ba" />
<img width="992" height="75" alt="image" src="https://github.com/user-attachments/assets/d38cf27f-f536-40c2-87db-bfb52e1ef3b5" />

------

5) [a651f59936bc3588f5fd9c7192f4cdbdaf3dc228] fixes the width of the mobile version of the allocations table, which was previously too narrow, by setting the DataTables `autoWidth` variable to `false`.

<img width="312" height="472" alt="image" src="https://github.com/user-attachments/assets/2a6be6b0-f7fa-4bd1-b49a-449f390b94ab" />

<img width="311" height="407" alt="image" src="https://github.com/user-attachments/assets/214a93f7-c15d-45e3-ab0b-ebe54e92e29e" />

------

6) [1fa38254af7469e3d2344d8e63ffedf8bbc36949] fixes an issue on mobile tables where the Case Type field, which is a combination of the case type and the claim state separated by a line break, is being displayed without the line break, as concatenated text on a single line, which makes it hard to read, buy adding `display: block;` styling.

<img width="183" height="33" alt="image" src="https://github.com/user-attachments/assets/2b5b1e40-8893-4666-9d00-e6156a1bd053" />
 
<img width="298" height="44" alt="image" src="https://github.com/user-attachments/assets/88445767-5a8a-4ad6-96f1-abb78e9fba9e" />

------

7) [0ec10b8668514f911b0543766575d69e88de2bd0] fixes the alignment of checkboxes on the mobile version of the allocations table by adding some additional styling.

<img width="178" height="57" alt="image" src="https://github.com/user-attachments/assets/987a1bbd-c399-447e-8280-404eccf8b9ee" />
<img width="288" height="41" alt="image" src="https://github.com/user-attachments/assets/eeeb896e-3982-4de4-8b6f-3824c5b05f30" />






