### PR TITLE
Replace XPath selectors with Capybara CSS equivalents

### DIFF
--- a/features/step_definitions/govuk_component_steps.rb
+++ b/features/step_definitions/govuk_component_steps.rb
@@ -10,7 +10,7 @@ end
 
 When('I choose govuk radio {string} for {string}') do |label, legend|
   find('.govuk-fieldset__legend', text: legend)
-    .find(:xpath, '..')
+    .sibling('.govuk-radios')
     .find('.govuk-radios__item label', text: label).click
 end
 

--- a/features/step_definitions/offence_steps.rb
+++ b/features/step_definitions/offence_steps.rb
@@ -1,12 +1,12 @@
 
 # AGFS 9/LGFS only
 Then(/^the offence class list is set to '(.*?)'$/) do |text|
-  expect(page).to have_xpath("//option[text()='#{text}']")
+  expect(page).to have_css('option', text: text)
 end
 
 # AGFS 9/LGFS only
 Then(/^the offence class list has (.*?) options$/) do |count|
-  expect(page).to have_xpath('//select[@id="claim-offence-class-field"]/option', count: count)
+  expect(page).to have_css('#claim-offence-class-field option', count: count)
 end
 
 # AGFS 10 only
@@ -22,8 +22,10 @@ end
 # AGFS 10/11 only
 Then(/^I select the first search result$/) do
   sleep Capybara.default_max_wait_time
-  find(:xpath, '//*[@id="offence-list"]/div[3]/div').hover
-  find(:xpath, '//*[@id="offence-list"]/div[3]/div/div[2]/a').click
+  within('#offence-list') do
+    first('.offence-item').hover
+    first('.offence-item-button').click
+  end
   wait_for_ajax
 end
 

--- a/features/support/select_helper.rb
+++ b/features/support/select_helper.rb
@@ -11,16 +11,15 @@ module SelectHelper
   end
 
   # http://ruby-journal.com/how-to-do-jqueryui-autocomplete-with-capybara-2/
-  # It requires jQuery to parse XPath, making use of a plugin: https://github.com/ilinsky/jquery-xpath
   #
   def fill_autocomplete(field, options = {})
     dropdown = find(:select, field, visible: false)
-    container = dropdown.find(:xpath, '..')
+    container = dropdown.ancestor('.govuk-form-group')
     input_field = container.find('input.tt-input')
     input_field.set options[:with]
 
-    page.execute_script %Q{ $(document.body).xpath('#{input_field.path}').trigger('focus') }
-    page.execute_script %Q{ $(document.body).xpath('#{input_field.path}').trigger('keydown') }
+    page.execute_script %Q{ $('##{input_field[:id]}').trigger('focus') }
+    page.execute_script %Q{ $('##{input_field[:id]}').trigger('keydown') }
 
     selector = %Q{.tt-menu .tt-suggestion:contains("#{options[:with]}")}
     filter = %Q{function() { return $(this).text() === "#{options[:with]}" }} # needed to rule out multiple matches

--- a/package.json
+++ b/package.json
@@ -42,7 +42,6 @@
     "jquery-datatables-checkboxes": "^1.3.0",
     "jquery-highlight": "^3.5.0",
     "jquery-throttle-debounce": "^1.0.0",
-    "jquery-xpath": "^0.3.1",
     "jsrender": "^1.0.16",
     "mini-css-extract-plugin": "^2.10.2",
     "postcss": "^8.5.15",

--- a/spec/support/capybara_extensions/govuk_component/matchers.rb
+++ b/spec/support/capybara_extensions/govuk_component/matchers.rb
@@ -46,11 +46,11 @@ module CapybaraExtensions
       end
 
       def has_govuk_error_fieldset?(locator, text: nil, id: nil)
-        fieldset = find('.govuk-fieldset__legend', text: locator).find(:xpath, '..')
+        legend = find('.govuk-fieldset__legend', text: locator)
 
         [
-          fieldset.find('.govuk-error-message').has_text?(text),
-          fieldset.first('label')[:for].eql?(id || fieldset.first('label')[:for])
+          legend.sibling('.govuk-error-message').has_text?(text),
+          id.nil? || legend.sibling('.govuk-radios, .govuk-checkboxes').first('label')[:for].eql?(id)
         ].all?
       end
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3404,13 +3404,6 @@ jquery-throttle-debounce@^1.0.0:
   resolved "https://registry.yarnpkg.com/jquery-throttle-debounce/-/jquery-throttle-debounce-1.0.0.tgz#f27daba459b513b36d07d81cf744252e673cdf49"
   integrity sha512-pnyuJ6T1MX9VUhwCLZ0i21Ya8HSewM+A8xWsftLS6VjRUChXjtdfc/9YJ0qL8yRTWEVuizcI9n0sK8xmJucT9g==
 
-jquery-xpath@^0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/jquery-xpath/-/jquery-xpath-0.3.1.tgz#9c6e62e618d344364bade3bdb494f0c30df85351"
-  integrity sha512-KlzObKL9QNPuXsuHXvNTypIsWDQ7qIQqERq4CCUA7xcKa6jY53FaU9Q+nHeAOYbuB65vm22yG2wamOcJf27OdA==
-  dependencies:
-    jquery ">=1.0.0"
-
 "jquery@>= 1.0.0", jquery@>=1.0.0, jquery@>=1.7, jquery@^3.7.1:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"


### PR DESCRIPTION
#### What

[This](https://github.com/ministryofjustice/Claim-for-Crown-Court-Defence/issues/2454) very old issue suggests replacing the use of XPath selectors with SitePrism functionality in step definitions and support files for cucumber and rspec tests. This does not appear to be possible however Capybara's CSS selectors can be used instead, which improves test readability and maintainability.

This change updates several files to use Capybara CSS selectors instead of XPath and removes the now unused `jquery-xpath` javascript dependency.
