### PR TITLE
Attempt to fix flaky cucumber test

### DIFF
--- a/features/step_definitions/sign_in_steps.rb
+++ b/features/step_definitions/sign_in_steps.rb
@@ -147,6 +147,7 @@ Given(/^I am a signed in super admin$/) do
   make_accounts('super admin')
   visit new_user_session_path
   sign_in(@super_admin.user, 'PasswordForTest')
+  expect(page).to have_current_path('/super_admins')
 end
 
 Then(/^I should see an Manage advocates link and it should work$/) do


### PR DESCRIPTION
#### What

One specific cucumber test has started failing intermittently: `features/super_admins/stats.feature`. This PR attempts to fix it by adding a short delay to the affected step, which will hopefully give the page enough time to load before the assertion is run.

#### Why

To reduce failed tests and speed up successful completion of the test suite, reducing costs and preventing developers wasting their time.
