### PR TITLE
[CTSKF-1689] AGFS scheme 17: Claim additional prep fees on Guilty plea cases

### DIFF
--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -32,7 +32,8 @@ class CaseType < ApplicationRecord
   scope :fixed_fee,               -> { where(is_fixed_fee: true) }
   scope :not_fixed_fee,           -> { where(is_fixed_fee: false) }
   scope :graduated_fees,          -> { where(fee_type_code: Fee::GraduatedFeeType.select(:unique_code)) }
-  scope :trial_fees,              -> { where(fee_type_code: %w[GRCBR GRRAK GRRTR GRTRL]) }
+  scope :trial_fees,              -> { where(fee_type_code: TRIAL_FEE_TYPES) }
+  scope :trial_and_guilty_plea_fees, -> { where(fee_type_code: TRIAL_FEE_TYPES + %w[GRGLT]) }
   scope :requires_cracked_dates,  -> { where(requires_cracked_dates: true) }
   scope :requires_trial_dates,    -> { where(requires_trial_dates: true) }
   scope :requires_retrial_dates,  -> { where(requires_retrial_dates: true) }

--- a/app/models/fee/misc_fee_type.rb
+++ b/app/models/fee/misc_fee_type.rb
@@ -5,12 +5,14 @@ module Fee
                                          MIDSE MIDSU MIPHC MISHR MISHU MIUMU MIUMO MISTE MIAPF MIFCM].freeze
     AGFS_SUPPLEMENTARY_TYPES = (AGFS_SUPPLEMENTARY_ONLY_TYPES + AGFS_SUPPLEMENTARY_SHARED_TYPES).freeze
     TRIAL_ONLY_TYPES = %w[MIUMU MIUMO MISTE MIAPF].freeze
+    TRIAL_ONLY_TYPES_EXCLUDING_MIAPF = %w[MIUMU MIUMO MISTE].freeze
 
     default_scope { order(Arel.sql("regexp_replace(\"fee_types\".\"description\", '[()]', '', 'g')")) }
 
     scope :without_supplementary_only, -> { where.not(unique_code: AGFS_SUPPLEMENTARY_ONLY_TYPES) }
     scope :supplementary, -> { where(unique_code: AGFS_SUPPLEMENTARY_TYPES) }
     scope :without_trial_fee_only, -> { where.not(unique_code: TRIAL_ONLY_TYPES) }
+    scope :without_trial_fee_only_excluding_miapf, -> { where.not(unique_code: TRIAL_ONLY_TYPES_EXCLUDING_MIAPF) }
 
     def fee_category_name
       'Miscellaneous Fees'

--- a/app/models/fee_scheme.rb
+++ b/app/models/fee_scheme.rb
@@ -63,6 +63,10 @@ class FeeScheme < ApplicationRecord
     agfs? && version.eql?(17)
   end
 
+  def agfs_scheme_17_or_later?
+    agfs? && version >= 17
+  end
+
   def claims
     date_range = agfs_scheme_13? ? (Settings.clar_release_date..end_date) : (start_date..end_date)
 

--- a/app/services/claims/fetch_eligible_misc_fee_types.rb
+++ b/app/services/claims/fetch_eligible_misc_fee_types.rb
@@ -93,11 +93,11 @@ module Claims
       claim.fee_scheme&.agfs_scheme_17_or_later? && case_type&.fee_type_code == 'GRGLT'
     end
 
-    def filter_trial_only_types(relation, filter)
+    def filter_trial_only_types(misc_fees, filter)
       if agfs_scheme_17_or_later_guilty_plea?
-        filter ? relation.without_trial_fee_only_excluding_miapf : relation
+        filter ? misc_fees.without_trial_fee_only_excluding_miapf : misc_fees
       else
-        filter ? relation.without_trial_fee_only : relation
+        filter ? misc_fees.without_trial_fee_only : misc_fees
       end
     end
   end

--- a/app/services/claims/fetch_eligible_misc_fee_types.rb
+++ b/app/services/claims/fetch_eligible_misc_fee_types.rb
@@ -89,8 +89,16 @@ module Claims
       claim.transfer? && claim.transfer_detail&.case_conclusion == 'Guilty plea'
     end
 
+    def agfs_scheme_17_or_later_guilty_plea?
+      claim.fee_scheme&.agfs_scheme_17_or_later? && case_type&.fee_type_code == 'GRGLT'
+    end
+
     def filter_trial_only_types(relation, filter)
-      filter ? relation.without_trial_fee_only : relation
+      if agfs_scheme_17_or_later_guilty_plea?
+        filter ? relation.without_trial_fee_only_excluding_miapf : relation
+      else
+        filter ? relation.without_trial_fee_only : relation
+      end
     end
   end
 end

--- a/app/validators/fee/agfs/fee_type_rules.rb
+++ b/app/validators/fee/agfs/fee_type_rules.rb
@@ -30,7 +30,7 @@ module Fee
 
         with_set_for_fee_type('MIAPF') do |set|
           set << add_rule(:quantity, :equal, 1, message: :miapf_numericality)
-          set << add_rule(*graduated_fee_type_only_rule)
+          set << add_rule(*trial_and_guilty_plea_only_rule)
         end
       end
     end

--- a/app/validators/fee/concerns/fee_type_rules_creator.rb
+++ b/app/validators/fee/concerns/fee_type_rules_creator.rb
@@ -31,6 +31,16 @@ module Fee
                attribute_for_error: :fee_type,
                allow_nil: true }]
         end
+
+        def trial_and_guilty_plea_only_rule
+          @trial_and_guilty_plea_only_rule ||=
+            ['claim.case_type_id',
+             :inclusion,
+             CaseType.trial_and_guilty_plea_fees.ids,
+             { message: 'case_type_inclusion',
+               attribute_for_error: :fee_type,
+               allow_nil: true }]
+        end
       end
 
       class_methods do

--- a/features/claims/advocate/scheme_seventeen/advocate_final_graduated_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_seventeen/advocate_final_graduated_fee_claim_submit.feature
@@ -117,7 +117,7 @@ Feature: Advocate submits an AGFS Fee Scheme 17 final graduated fee claims
     When I click on misc fees helper text
     Then I should see the following miscellaneous fees listed:
       | Abuse of process hearings                             |
-    # | Additional preparation fee                            |
+      | Additional preparation fee                            |
       | Application to dismiss a charge                       |
       | Confiscation hearings                                 |
       | Deferred sentence hearings                            |
@@ -142,12 +142,12 @@ Feature: Advocate submits an AGFS Fee Scheme 17 final graduated fee claims
       | Written / oral advice                                 |
 
 
-    # Then I add a govuk calculated miscellaneous fee 'Additional preparation fee'
+    Then I add a govuk calculated miscellaneous fee 'Additional preparation fee'
     And I add a govuk calculated miscellaneous fee 'Paper heavy case'
     And I add a govuk calculated miscellaneous fee 'Deferred sentence hearings'
     Then the following govuk fee details should exist:
       | section       | fee_description                  | rate   | hint            | help |
-      #| miscellaneous | Additional preparation fee       | 81.00  | Number of fees  | true |
+      | miscellaneous | Additional preparation fee       | 81.00  | Number of fees  | true |
       | miscellaneous | Paper heavy case                 | 45.30  | Number of hours | true |
       | miscellaneous | Deferred sentence hearings       | 201.00 | Number of days  | true |
 

--- a/spec/models/case_type_spec.rb
+++ b/spec/models/case_type_spec.rb
@@ -144,5 +144,15 @@ RSpec.describe CaseType do
       it { is_expected.not_to be_empty }
       it { expect(trial_fees.map(&:fee_type_code)).to all(be_one_of(%w[GRCBR GRRAK GRRTR GRTRL])) }
     end
+
+    describe '.trial_and_guilty_plea_fees' do
+      subject(:trial_and_guilty_plea_fees) { described_class.trial_and_guilty_plea_fees }
+
+      it { is_expected.not_to be_empty }
+
+      it {
+        expect(trial_and_guilty_plea_fees.map(&:fee_type_code)).to all(be_one_of(%w[GRCBR GRRAK GRRTR GRTRL GRGLT]))
+      }
+    end
   end
 end

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -154,6 +154,28 @@ RSpec.describe FeeScheme do
     end
   end
 
+  describe '#agfs_scheme_17_or_later?' do
+    subject { fee_scheme.agfs_scheme_17_or_later? }
+
+    context 'with an agfs scheme 17 claim' do
+      let(:claim) { create(:advocate_claim, :agfs_scheme_17) }
+
+      it { is_expected.to be_truthy }
+    end
+
+    context 'with an agfs scheme 16 claim' do
+      let(:claim) { create(:advocate_claim, :agfs_scheme_16) }
+
+      it { is_expected.to be_falsey }
+    end
+
+    context 'with an lgfs claim' do
+      let(:claim) { create(:litigator_claim) }
+
+      it { is_expected.to be_falsey }
+    end
+  end
+
   describe '#claims' do
     subject { fee_scheme.claims }
 

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -353,6 +353,37 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
             end
           end
         end
+
+        context 'with a scheme 17 claim' do
+          let(:claim) { create(:advocate_claim, :agfs_scheme_17, case_type:) }
+
+          context 'with "trial" case type' do
+            let(:case_type) { CaseType.find_by(fee_type_code: 'GRTRL') }
+
+            it { is_expected.not_to include(*supplementary_only_types) }
+            it { is_expected.to include(*unused_materials_types) }
+            it { is_expected.to include(*section_twenty_eight_types) }
+            it { is_expected.to include(*additional_prep_fee_types) }
+          end
+
+          context 'with "guilty plea" case type' do
+            let(:case_type) { CaseType.find_by(fee_type_code: 'GRGLT') }
+
+            it { is_expected.not_to include(*supplementary_only_types) }
+            it { is_expected.not_to include(*unused_materials_types) }
+            it { is_expected.not_to include(*section_twenty_eight_types) }
+            it { is_expected.to include(*additional_prep_fee_types) }
+          end
+
+          context 'with "discontinuance" case type' do
+            let(:case_type) { CaseType.find_by(fee_type_code: 'GRDIS') }
+
+            it { is_expected.not_to include(*supplementary_only_types) }
+            it { is_expected.not_to include(*unused_materials_types) }
+            it { is_expected.not_to include(*section_twenty_eight_types) }
+            it { is_expected.not_to include(*additional_prep_fee_types) }
+          end
+        end
       end
 
       context 'with hardship claim' do

--- a/vcr/cassettes/features/claims/advocate/scheme_seventeen/graduated_fee_calculations.yml
+++ b/vcr/cassettes/features/claims/advocate/scheme_seventeen/graduated_fee_calculations.yml
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:39 GMT
+      - Thu, 02 Jul 2026 12:16:37 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:39 GMT
+      - Thu, 02 Jul 2026 12:16:37 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -116,7 +116,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:39 GMT
+      - Thu, 02 Jul 2026 12:16:37 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -160,7 +160,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:40 GMT
+      - Thu, 02 Jul 2026 12:16:38 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -205,7 +205,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:41 GMT
+      - Thu, 02 Jul 2026 12:16:38 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -257,7 +257,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:41 GMT
+      - Thu, 02 Jul 2026 12:16:38 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -301,7 +301,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:41 GMT
+      - Thu, 02 Jul 2026 12:16:39 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -346,7 +346,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:41 GMT
+      - Thu, 02 Jul 2026 12:16:39 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -398,7 +398,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:41 GMT
+      - Thu, 02 Jul 2026 12:16:39 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -444,7 +444,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:42 GMT
+      - Thu, 02 Jul 2026 12:16:40 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -489,7 +489,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:43 GMT
+      - Thu, 02 Jul 2026 12:16:40 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -541,7 +541,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:43 GMT
+      - Thu, 02 Jul 2026 12:16:40 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -587,7 +587,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
+      - Thu, 02 Jul 2026 12:16:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -632,7 +632,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
+      - Thu, 02 Jul 2026 12:16:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -677,7 +677,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
+      - Thu, 02 Jul 2026 12:16:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -729,289 +729,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
+      - Thu, 02 Jul 2026 12:16:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1063,7 +781,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
+      - Thu, 02 Jul 2026 12:16:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1107,7 +825,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:44 GMT
+      - Thu, 02 Jul 2026 12:16:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1151,7 +869,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:46 GMT
+      - Thu, 02 Jul 2026 12:16:42 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1196,7 +914,148 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:46 GMT
+      - Thu, 02 Jul 2026 12:16:42 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:42 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:42 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:42 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1248,7 +1107,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:46 GMT
+      - Thu, 02 Jul 2026 12:16:42 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1292,97 +1151,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:47 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:47 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:47 GMT
+      - Thu, 02 Jul 2026 12:16:44 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1427,7 +1196,193 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:47 GMT
+      - Thu, 02 Jul 2026 12:16:44 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:44 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:45 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:45 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1479,59 +1434,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:47 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:48 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1583,7 +1486,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:48 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1627,192 +1530,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:48 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1856,7 +1574,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1901,7 +1619,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1946,201 +1664,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2192,7 +1716,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2244,7 +1768,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2288,7 +1812,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
+      - Thu, 02 Jul 2026 12:16:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2315,94 +1839,6 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
     body:
       encoding: US-ASCII
@@ -2420,7 +1856,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2465,97 +1901,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2600,7 +1946,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2652,7 +1998,149 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:46 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:46 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:46 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2704,59 +2192,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2808,51 +2244,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2896,7 +2288,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2920,6 +2312,623 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:46 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:46 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -2940,7 +2949,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2967,200 +2976,6 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -3178,7 +2993,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3205,7 +3020,7 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -3222,7 +3037,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:50 GMT
+      - Thu, 02 Jul 2026 12:16:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3236,7 +3051,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '279'
+      - '277'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3245,388 +3060,7 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -3647,7 +3081,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
+      - Thu, 02 Jul 2026 12:16:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3674,6 +3108,51 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
     body:
       encoding: US-ASCII
@@ -3691,7 +3170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
+      - Thu, 02 Jul 2026 12:16:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3743,191 +3222,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
+      - Thu, 02 Jul 2026 12:16:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3971,7 +3266,97 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4016,7 +3401,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
+      - Thu, 02 Jul 2026 12:16:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4051,6 +3436,288 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -4068,7 +3735,199 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:51 GMT
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4112,7 +3971,148 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4157,7 +4157,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4202,7 +4202,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4247,7 +4247,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4292,7 +4292,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4337,7 +4337,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4389,7 +4389,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4441,7 +4441,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4493,7 +4493,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4545,7 +4545,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4577,6 +4577,182 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -4597,606 +4773,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:53 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5240,7 +4817,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5285,7 +4862,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5330,52 +4907,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5420,7 +4952,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5472,7 +5004,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5524,7 +5056,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5556,103 +5088,6 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -5673,7 +5108,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5700,6 +5135,50 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -5717,7 +5196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5744,7 +5223,7 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -5761,7 +5240,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5775,7 +5254,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '277'
+      - '186'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -5784,7 +5263,98 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -5805,7 +5375,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5840,6 +5410,295 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -5857,7 +5716,615 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5901,7 +6368,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5946,7 +6413,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5991,7 +6458,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6016,6 +6483,356 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -6036,7 +6853,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6063,162 +6880,6 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -6236,7 +6897,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6280,7 +6941,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6304,623 +6965,6 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -6941,7 +6985,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6969,50 +7013,6 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -7030,7 +7030,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7074,7 +7074,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7119,7 +7119,97 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7164,7 +7254,104 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7216,7 +7403,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7251,185 +7438,6 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
     body:
       encoding: US-ASCII
@@ -7447,7 +7455,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7499,7 +7507,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7543,7 +7551,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7575,102 +7583,6 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -7691,7 +7603,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7718,6 +7630,94 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -7735,7 +7735,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:56 GMT
+      - Thu, 02 Jul 2026 12:16:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7780,7 +7780,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7825,7 +7825,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7870,7 +7870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7915,7 +7915,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7960,7 +7960,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8005,7 +8005,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8057,7 +8057,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8109,7 +8109,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8161,7 +8161,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8213,7 +8213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8245,50 +8245,6 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -8309,7 +8265,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8336,6 +8292,50 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -8353,7 +8353,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8381,623 +8381,6 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -9015,7 +8398,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9059,7 +8442,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9086,6 +8469,623 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:16:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
@@ -9103,7 +9103,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9147,7 +9147,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:25:57 GMT
+      - Thu, 02 Jul 2026 12:16:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9192,7 +9192,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:33 GMT
+      - Thu, 02 Jul 2026 12:32:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9236,7 +9236,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:33 GMT
+      - Thu, 02 Jul 2026 12:32:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9263,6 +9263,270 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:32:58 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:32:58 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:32:59 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:32:59 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:00 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:00 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
     body:
       encoding: US-ASCII
@@ -9280,7 +9544,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:36 GMT
+      - Thu, 02 Jul 2026 12:33:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9324,7 +9588,95 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:37 GMT
+      - Thu, 02 Jul 2026 12:33:00 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:01 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9368,7 +9720,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:38 GMT
+      - Thu, 02 Jul 2026 12:33:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9395,6 +9747,94 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:01 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:03 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
     body:
       encoding: US-ASCII
@@ -9412,7 +9852,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:38 GMT
+      - Thu, 02 Jul 2026 12:33:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9439,6 +9879,95 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:03 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:03 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '521'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448266,"scenario":2,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
     body:
       encoding: US-ASCII
@@ -9456,7 +9985,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:39 GMT
+      - Thu, 02 Jul 2026 12:33:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9500,7 +10029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:39 GMT
+      - Thu, 02 Jul 2026 12:33:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9545,7 +10074,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:39 GMT
+      - Thu, 02 Jul 2026 12:33:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9573,6 +10102,50 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 02 Jul 2026 12:33:04 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+- request:
+    method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
     body:
       encoding: US-ASCII
@@ -9590,7 +10163,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:39 GMT
+      - Thu, 02 Jul 2026 12:33:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9617,7 +10190,7 @@ http_interactions:
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
     body:
       encoding: US-ASCII
       string: ''
@@ -9634,7 +10207,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:40 GMT
+      - Thu, 02 Jul 2026 12:33:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9648,7 +10221,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '279'
+      - '278'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -9657,7 +10230,7 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 - request:
     method: get
@@ -9678,7 +10251,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:40 GMT
+      - Thu, 02 Jul 2026 12:33:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9723,7 +10296,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:26:40 GMT
+      - Thu, 02 Jul 2026 12:33:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9747,50 +10320,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:26:40 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '521'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448266,"scenario":2,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
   recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
 recorded_with: VCR 6.4.0


### PR DESCRIPTION
#### What

Additional prep fees (`MIAPF`) were previously restricted to trial-only case types. From AGFS fee scheme 17 onwards, it should also be claimable on guilty plea cases.

#### Ticket

[CTSKF-1689](https://dsdmoj.atlassian.net/browse/CTSKF-1689)

#### Why

To comply with policy changes.

#### How

- Updates `FetchEligibleMiscFeeTypes` to include `MIAPF` for scheme 17+ guilty pleas and adds `TRIAL_ONLY_TYPES_EXCLUDING_MIAPF` constant and scope to the `MiscFeeType` model to enable this.
- Adds `agfs_scheme_17_or_later?` method to the `FeeScheme` model to future-proof scheme checks.
- Updates validation of `MIAPF` fees to allow additional prep fees to be saved on guilty plea claims and adds `trial_and_guilty_plea_fees` scope to the `CaseType` model to support this.
- Adds specs for new scopes and eligibility scenarios.
- Updates feature test to verify `MIAPF` appears for guilty plea claims.


[CTSKF-1689]: https://dsdmoj.atlassian.net/browse/CTSKF-1689?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ