### PR TITLE
[CTSKF-1690] AGFS scheme 17: Additional preparation fee claim injection

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -14,7 +14,7 @@ FactoryBot/FactoryAssociationWithStrategy:
     - 'spec/factories/claim/transfer_details.rb'
     - 'spec/factories/expenses.rb'
 
-# Offense count: 563
+# Offense count: 564
 # This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: Max, AllowHeredoc, AllowURI, AllowQualifiedName, URISchemes, AllowRBSInlineAnnotation, AllowCopDirectives, AllowedPatterns, SplitStrings.
 # URISchemes: http, https
@@ -125,7 +125,7 @@ Layout/LineLength:
     - 'spec/validators/defendant_validator_spec.rb'
     - 'spec/validators/representation_order_validator_spec.rb'
 
-# Offense count: 65
+# Offense count: 64
 # Configuration parameters: AllowedMethods.
 # AllowedMethods: enums
 Lint/ConstantDefinitionInBlock:
@@ -316,11 +316,12 @@ Metrics/MethodLength:
     - 'spec/support/factory_helpers.rb'
     - 'spec/support/scheme_date_helpers.rb'
 
-# Offense count: 7
+# Offense count: 8
 # Configuration parameters: CountComments, Max, CountAsOne.
 Metrics/ModuleLength:
   Exclude:
     - 'app/helpers/application_helper.rb'
+    - 'app/interfaces/api/helpers/search_result_helpers.rb'
     - 'app/models/claims/calculations.rb'
     - 'app/models/claims/state_machine.rb'
     - 'app/presenters/concerns/management_information_reportable.rb'
@@ -494,7 +495,7 @@ RSpec/BeforeAfterAll:
     - 'spec/services/claims/update_claim_spec.rb'
     - 'spec/services/claims/update_draft_spec.rb'
 
-# Offense count: 1302
+# Offense count: 1303
 # Configuration parameters: Prefixes, AllowedPatterns.
 # Prefixes: when, with, without
 RSpec/ContextWording:
@@ -863,7 +864,7 @@ RSpec/ImplicitSubject:
     - 'spec/validators/claim/advocate_interim_claim_web_validations_spec.rb'
     - 'spec/validators/expense_validator_spec.rb'
 
-# Offense count: 348
+# Offense count: 349
 # This cop supports unsafe autocorrection (--autocorrect-all).
 RSpec/IncludeExamples:
   Exclude:
@@ -1028,7 +1029,7 @@ RSpec/LeadingSubject:
     - 'spec/support/shared_examples_for_roles.rb'
     - 'spec/validators/claim/advocate_interim_claim_web_validations_spec.rb'
 
-# Offense count: 59
+# Offense count: 58
 RSpec/LeakyConstantDeclaration:
   Exclude:
     - 'spec/api/error_response_spec.rb'
@@ -1145,7 +1146,7 @@ RSpec/MultipleDescribes:
     - 'spec/models/claim/base_claim_spec.rb'
     - 'spec/routing/claims_controller_spec.rb'
 
-# Offense count: 612
+# Offense count: 613
 # Configuration parameters: Max.
 RSpec/MultipleExpectations:
   Exclude:
@@ -1397,7 +1398,7 @@ RSpec/NamedSubject:
     - 'spec/services/injection_response_service_spec.rb'
     - 'spec/validators/expense_validator_spec.rb'
 
-# Offense count: 761
+# Offense count: 768
 # Configuration parameters: Max, AllowedGroups.
 RSpec/NestedGroups:
   Exclude:

--- a/app/interfaces/api/entities/ccr/base_claim.rb
+++ b/app/interfaces/api/entities/ccr/base_claim.rb
@@ -56,7 +56,7 @@ module API
         end
 
         def misc_fee_adapter
-          ::CCR::Fee::MiscFeeAdapter.new
+          ::CCR::Fee::MiscFeeAdapter.new(agfs_scheme_17_or_later: object.fee_scheme&.agfs_scheme_17_or_later?)
         end
 
         # CCR miscellaneous fees cover CCCD basic, fixed and miscellaneous fees

--- a/app/interfaces/api/entities/search_result.rb
+++ b/app/interfaces/api/entities/search_result.rb
@@ -138,7 +138,7 @@ module API
       end
 
       def additional_prep_fee_warning
-        (last_injection_attempt_succeeded? && contains_additional_prep_fee?).to_i
+        (last_injection_attempt_succeeded? && contains_additional_prep_fee? && !agfs_scheme_17_or_later?).to_i
       end
 
       def supplementary

--- a/app/interfaces/api/helpers/search_result_helpers.rb
+++ b/app/interfaces/api/helpers/search_result_helpers.rb
@@ -117,6 +117,12 @@ module API
           ].all?
         end&.any?
       end
+
+      def agfs_scheme_17_or_later?
+        return false if object.earliest_representation_order_date.blank?
+
+        object.scheme == 'agfs' && Date.parse(object.earliest_representation_order_date) >= Settings.agfs_scheme_17
+      end
     end
   end
 end

--- a/app/interfaces/api/v2/query_helper.rb
+++ b/app/interfaces/api/v2/query_helper.rb
@@ -52,7 +52,8 @@ module API::V2
           c.allocation_type,
           last_injection_attempt.error_messages AS injection_errors,
           last_injection_attempt.succeeded AS last_injection_succeeded,
-          dt.transfer_stage_id AS transfer_stage_id
+          dt.transfer_stage_id AS transfer_stage_id,
+          MIN(ro.representation_order_date) AS earliest_representation_order_date
         FROM claims AS c
           LEFT OUTER JOIN defendants AS d
             ON c.id = d.claim_id

--- a/app/services/ccr/fee/misc_fee_adapter.rb
+++ b/app/services/ccr/fee/misc_fee_adapter.rb
@@ -46,7 +46,13 @@ module CCR
         MIAPF: zip(%w[AGFS_MISC_FEES AGFS_PREP_FEE]) # Additional preparation fee - AGFS 15+ only
       }.freeze
 
-      MISC_FEE_BILL_MAPPING_EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO MIAPF].freeze
+      MISC_FEE_BILL_MAPPING_EXCLUSIONS_PRE_SCHEME_17 = %i[BACAV MIPHC MIUMU MIUMO MIAPF].freeze
+      MISC_FEE_BILL_MAPPING_EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO].freeze
+
+      def initialize(exclusions: true, agfs_scheme_17_or_later: false)
+        @agfs_scheme_17_or_later = agfs_scheme_17_or_later
+        super(exclusions:)
+      end
 
       def claimed?
         maps? && charges?
@@ -59,7 +65,13 @@ module CCR
       end
 
       def exclusions
-        exclusions? ? MISC_FEE_BILL_MAPPING_EXCLUSIONS : []
+        return [] unless exclusions?
+
+        if @agfs_scheme_17_or_later
+          MISC_FEE_BILL_MAPPING_EXCLUSIONS
+        else
+          MISC_FEE_BILL_MAPPING_EXCLUSIONS_PRE_SCHEME_17
+        end
       end
 
       def bill_key

--- a/app/views/warnings/_injection_warnings_summary.html.haml
+++ b/app/views/warnings/_injection_warnings_summary.html.haml
@@ -16,7 +16,7 @@
       %span.form-hint.govuk-error-summary__body
         = t('shared.injection_errors.clar_fees_warning.message')
 
-- if claim&.last_injection_attempt&.succeeded && claim.has_additional_prep_fee?
+- if claim&.last_injection_attempt&.succeeded && claim.has_additional_prep_fee? && !claim.fee_scheme&.agfs_scheme_17_or_later?
   .js-callout-injection-warning
     .warning-summary.govuk-error-summary{ role: 'group', 'aria-labelledby': 'warning-summary-heading', tabindex: '-1' }
       %h2.govuk-heading-m.govuk-error-summary__title{ id: 'warning-summary-heading' }

--- a/spec/api/entities/ccr/adapted_misc_fee_spec.rb
+++ b/spec/api/entities/ccr/adapted_misc_fee_spec.rb
@@ -81,5 +81,28 @@ describe API::Entities::CCR::AdaptedMiscFee, type: :adapter do
     it 'exposes bill_subtype as nil' do
       expect(response).to include(bill_subtype: nil)
     end
+
+    context 'when fee type is MIAPF with agfs_scheme_17_or_later' do
+      let(:miapf_fee_type) { create(:misc_fee_type, :miapf) }
+      let(:misc_fee) { build(:misc_fee, fee_type: miapf_fee_type, claim:, quantity: 1, rate: 81) }
+      let(:adapted_misc_fee) { CCR::Fee::MiscFeeAdapter.new(agfs_scheme_17_or_later: true).call(misc_fee) }
+
+      it 'exposes MIAPF bill mappings' do
+        expect(response).to include(
+          bill_type: 'AGFS_MISC_FEES',
+          bill_subtype: 'AGFS_PREP_FEE'
+        )
+      end
+    end
+
+    context 'when fee type is MIAPF without agfs_scheme_17_or_later' do
+      let(:miapf_fee_type) { create(:misc_fee_type, :miapf) }
+      let(:misc_fee) { build(:misc_fee, fee_type: miapf_fee_type, claim:, quantity: 1, rate: 81) }
+      let(:adapted_misc_fee) { CCR::Fee::MiscFeeAdapter.new.call(misc_fee) }
+
+      it 'excludes MIAPF (nil bill_type and bill_subtype)' do
+        expect(response).to include(bill_type: nil, bill_subtype: nil)
+      end
+    end
   end
 end

--- a/spec/api/entities/search_result_spec.rb
+++ b/spec/api/entities/search_result_spec.rb
@@ -33,7 +33,8 @@ describe API::Entities::SearchResult do
       'MockClaim', Struct.new(:id, :uuid, :scheme, :scheme_type, :case_number, :state, :court_name, :case_type, :total,
                               :disk_evidence, :external_user, :maat_references, :defendants, :fees, :last_submitted_at,
                               :class_letter, :is_fixed_fee, :fee_type_code, :graduated_fee_types, :injection_errors,
-                              :allocation_type, :last_injection_succeeded, :transfer_stage_id)
+                              :allocation_type, :last_injection_succeeded, :transfer_stage_id,
+                              :earliest_representation_order_date)
     )
   end
 
@@ -134,11 +135,23 @@ describe API::Entities::SearchResult do
         include_examples 'returns expected JSON filter values'
       end
 
-      context 'when passed an advocate claim with an Additional Prep fee and without an injection attempt error' do
+      context 'when passed a scheme 16 advocate claim with an Additional Prep fee and no injection attempt error' do
         before do
           claim.last_injection_succeeded = 'true'
           claim.fees = '1.0~Additional preparation fee~Fee::MiscFeeType'
+          claim.earliest_representation_order_date = (Settings.agfs_scheme_17 - 1.day).to_s
           result.merge!(graduated_fees: 1, additional_prep_fee_warning: 1)
+        end
+
+        include_examples 'returns expected JSON filter values'
+      end
+
+      context 'when passed a scheme 17 advocate claim with an Additional Prep fee and no injection attempt error' do
+        before do
+          claim.last_injection_succeeded = 'true'
+          claim.fees = '1.0~Additional preparation fee~Fee::MiscFeeType'
+          claim.earliest_representation_order_date = Settings.agfs_scheme_17.to_s
+          result.merge!(graduated_fees: 1, additional_prep_fee_warning: 0)
         end
 
         include_examples 'returns expected JSON filter values'

--- a/spec/api/v2/ccr_claim_spec.rb
+++ b/spec/api/v2/ccr_claim_spec.rb
@@ -600,6 +600,34 @@ RSpec.describe API::V2::CCRClaim, feature: :injection do
               expect(parsed['bills'].size).to eq(0)
             end
           end
+
+          context 'with Additional preparation fee' do
+            let(:miapf_fee_type) { create(:misc_fee_type, :miapf) }
+            let(:misc_fees) { [build(:misc_fee, fee_type: miapf_fee_type, quantity: 1, rate: 81)] }
+            let(:parsed) { JSON.parse(subject) }
+
+            context 'when claim is scheme 17 or later' do
+              let(:claim) do
+                claim = create_claim(:submitted_claim, :without_fees, case_type:, misc_fees:)
+                create(:defendant, scheme: 'scheme 17', claim:)
+                claim.reload
+              end
+
+              it 'added to bills' do
+                expect(parsed['bills'].size).to eq 1
+                expect(parsed.dig('bills', 0, 'bill_type')).to eq 'AGFS_MISC_FEES'
+                expect(parsed.dig('bills', 0, 'bill_subtype')).to eq 'AGFS_PREP_FEE'
+              end
+            end
+
+            context 'when claim is pre-scheme 17' do
+              let(:claim) { create_claim(:submitted_claim, :without_fees, case_type:, misc_fees:) }
+
+              it 'not added to bills' do
+                expect(parsed['bills']).to be_empty
+              end
+            end
+          end
         end
 
         context 'when CCCD fee maps to a CCR misc fee' do

--- a/spec/services/ccr/fee/misc_fee_adapter_spec.rb
+++ b/spec/services/ccr/fee/misc_fee_adapter_spec.rb
@@ -12,7 +12,8 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
 
   it_behaves_like 'a mapping fee adapter'
 
-  EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO MIAPF].freeze
+  EXCLUSIONS_PRE_SCHEME_17 = %i[BACAV MIPHC MIUMU MIUMO MIAPF].freeze
+  EXCLUSIONS = %i[BACAV MIPHC MIUMU MIUMO].freeze
 
   MAPPINGS = {
     BACAV: %w[AGFS_MISC_FEES AGFS_CONFERENCE], # Conferences and views (basic fee)
@@ -60,7 +61,7 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
   }.freeze
 
   def self.mappings(exclusions: true)
-    exclusions ? MAPPINGS.except(*EXCLUSIONS) : MAPPINGS
+    exclusions ? MAPPINGS.except(*EXCLUSIONS_PRE_SCHEME_17) : MAPPINGS
   end
 
   describe '#bill_type' do
@@ -105,7 +106,7 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
     end
 
     context 'mapping exclusions' do
-      EXCLUSIONS.each do |code|
+      EXCLUSIONS_PRE_SCHEME_17.each do |code|
         context "with unique_code #{code}" do
           before { allow(fee_type).to receive(:unique_code).and_return code }
 
@@ -128,6 +129,24 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
 
             it { is_expected.to eql bill_subtype }
           end
+        end
+      end
+    end
+
+    context 'with agfs_scheme_17_or_later' do
+      subject { described_class.new(agfs_scheme_17_or_later: true).call(fee).bill_subtype }
+
+      context 'MIAPF is no longer excluded' do
+        before { allow(fee_type).to receive(:unique_code).and_return 'MIAPF' }
+
+        it { is_expected.to eql 'AGFS_PREP_FEE' }
+      end
+
+      EXCLUSIONS.each do |code|
+        context "with unique_code #{code}" do
+          before { allow(fee_type).to receive(:unique_code).and_return code }
+
+          it { is_expected.to be_nil }
         end
       end
     end
@@ -160,6 +179,16 @@ RSpec.describe CCR::Fee::MiscFeeAdapter, type: :adapter do
       allow(fee).to receive_messages(quantity: 1, rate: 1, amount: 1)
       allow(fee_type).to receive(:unique_code).and_return 'BACAV'
       is_expected.to be false
+    end
+
+    context 'with agfs_scheme_17_or_later' do
+      subject { described_class.new(agfs_scheme_17_or_later: true).call(fee).claimed? }
+
+      it 'returns true for MIAPF when it has charges' do
+        allow(fee).to receive_messages(quantity: 1, rate: 1, amount: 1)
+        allow(fee_type).to receive(:unique_code).and_return 'MIAPF'
+        is_expected.to be true
+      end
     end
   end
 end

--- a/spec/views/case_workers/claims/show_spec.rb
+++ b/spec/views/case_workers/claims/show_spec.rb
@@ -392,12 +392,13 @@ RSpec.describe 'case_workers/claims/show.html.haml' do
   end
 
   context 'with fee injection warnings' do
+    let(:warnings_claim) { trial_claim }
+
     before do
-      claim = trial_claim
-      assign(:claim, claim)
-      request.path_parameters[:id] = claim.id
-      create(:injection_attempt, claim:)
-      create(:misc_fee, fee_type:, claim:, quantity: 1, amount: 100.00)
+      assign(:claim, warnings_claim)
+      request.path_parameters[:id] = warnings_claim.id
+      create(:injection_attempt, claim: warnings_claim)
+      create(:misc_fee, fee_type:, claim: warnings_claim, quantity: 1, amount: 100.00)
       render
     end
 
@@ -420,6 +421,13 @@ RSpec.describe 'case_workers/claims/show.html.haml' do
 
       it { is_expected.to have_css('div.js-callout-injection-warning') }
       it { is_expected.to have_text('Warning: Additional preparation fee was not injected') }
+    end
+
+    context 'with Additional Prep fee on a scheme 17 claim' do
+      let(:fee_type) { build(:misc_fee_type, :miapf) }
+      let(:warnings_claim) { trial_claim(nil, :agfs_scheme_17) }
+
+      it { is_expected.to have_no_text('Warning: Additional preparation fee was not injected') }
     end
   end
 
@@ -491,9 +499,9 @@ RSpec.describe 'case_workers/claims/show.html.haml' do
     claim
   end
 
-  def trial_claim(trial_prefix = nil)
-    claim = create(:submitted_claim, case_type: create(:case_type, :"#{trial_prefix}trial"),
-                                     evidence_checklist_ids: [1, 9])
+  def trial_claim(trial_prefix = nil, *traits)
+    claim = create(:submitted_claim, *traits, case_type: create(:case_type, :"#{trial_prefix}trial"),
+                                              evidence_checklist_ids: [1, 9])
     case_worker.claims << claim
     create(:document, claim_id: claim.id, form_id: claim.form_id)
     @message = claim.messages.build


### PR DESCRIPTION
#### What

Additional preparation fees are currently excluded from injection into CCR. From AGFS scheme 17, this fee can be injected. Changes are required to enable those fees to be injected and to ensure that warnings displayed to caseworkers on claims where additional preparation fees have _not_ been injected, are not displayed on scheme 17 claims.

#### Ticket

[CTSKF-1690](https://dsdmoj.atlassian.net/browse/CTSKF-1690)

#### Why

To make caseworkers lives easier by automatically creating additional preparation fees in CCR rather than make them manually create them.

#### How

1. To enable the injection of additional preparation fees on scheme 17 claims, this updates `API::Entities::CCR::BaseClaim` to  pass a new `agfs_scheme_17_or_later` flag from to the `CCR::Fee::MiscFeeAdapter`, which is used to determine whether additional preparation fees should be excluded from injection or not.

2. There are two places where warnings about additional preparation fee injection are displayed to caseworkers. To suppress these in both places this:
    - adds extra logic to `app/views/warnings/_injection_warnings_summary.html.haml` to check for scheme 17+ eligibility
    - adds a new method to `API::Helpers::SearchResultHelpers` to determine scheme 17+ eligibility, via the earliest representation order date from the claim's defendants, which is added to the unallocated claims SQL query in `API::V2::QueryHelper`.

[CTSKF-1690]: https://dsdmoj.atlassian.net/browse/CTSKF-1690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ