### PR TITLE
Add Rainbow call to RakeUtils method

### DIFF
--- a/lib/tasks/rake_helpers/rake_utils.rb
+++ b/lib/tasks/rake_helpers/rake_utils.rb
@@ -5,7 +5,7 @@ module Tasks
     module RakeUtils
       def continue?(prompt = nil)
         prompt = prompt || 'Continue?'
-        printf prompt.yellow + ": [no/yes] "
+        printf Rainbow(prompt).yellow + ": [no/yes] "
         response = STDIN.gets.chomp
         exit unless response.match?(/^(y|yes)$/i)
         true


### PR DESCRIPTION
#### What

Removing AwesomePrint means that calling a colour method on a string will no longer work. Most such calls have been updated to use Rainbow, but the RakeUtils method `continue?` was missed. This prevents rake tasks which use that method, such as fee scheme seeders, to fail.

This updates the `continue?` method to use Rainbow for colouring.
