### PR TITLE
Ctskf 1550 cccd replace awesome print

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,6 @@ gem 'auto_strip_attributes',  '~> 2.6.0'
 gem 'aws-sdk-s3',             '~> 1'
 gem 'aws-sdk-sns',            '~> 1'
 gem 'aws-sdk-sqs',            '~> 1'
-gem 'awesome_print'
 gem 'bootsnap', require: false
 gem 'cancancan',              '~> 3.6'
 gem 'chartkick',              '~> 5.2.1'

--- a/Gemfile
+++ b/Gemfile
@@ -37,6 +37,7 @@ gem 'pagy'
 gem 'paper_trail', '~> 17.0.0'
 gem 'pg',                     '~> 1.6.3'
 gem 'rails', '~> 8.1.3'
+gem 'rainbow', '>= 3.1.1'
 gem 'redis',                  '~> 5.4.1'
 gem 'rubyzip'
 gem 'config',                 '~> 5.6' # this gem provides our Settings.xxx mechanism

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -105,7 +105,6 @@ GEM
       version_gem (~> 1.1, >= 1.1.10)
     auto_strip_attributes (2.6.0)
       activerecord (>= 4.0)
-    awesome_print (1.9.2)
     aws-eventstream (1.4.0)
     aws-partitions (1.1262.0)
     aws-sdk-core (3.252.0)
@@ -754,6 +753,7 @@ PLATFORMS
   arm64-darwin-24
   arm64-darwin-25
   x86_64-darwin-24
+  x86_64-darwin-25
   x86_64-linux-gnu
 
 DEPENDENCIES
@@ -761,7 +761,6 @@ DEPENDENCIES
   active_storage_validations
   amoeba (~> 3.3.0)
   auto_strip_attributes (~> 2.6.0)
-  awesome_print
   aws-sdk-s3 (~> 1)
   aws-sdk-sns (~> 1)
   aws-sdk-sqs (~> 1)
@@ -878,7 +877,6 @@ CHECKSUMS
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
   auth-sanitizer (0.2.2) sha256=300112debb67fe5e7a4f67a697790cea09744970e816745afb1f4235d6f27bae
   auto_strip_attributes (2.6.0) sha256=a7e2e0cf744de2bcd947fd68014220702bcc88c81274c1cd9ce6f7316aae39b0
-  awesome_print (1.9.2) sha256=e99b32b704acff16d768b3468680793ced40bfdc4537eb07e06a4be11133786e
   aws-eventstream (1.4.0) sha256=116bf85c436200d1060811e6f5d2d40c88f65448f2125bc77ffce5121e6e183b
   aws-partitions (1.1262.0) sha256=77e9b1dd3e8f616673f2959d2fc4e762065f83a43140e2cb82274525afbaccf7
   aws-sdk-core (3.252.0) sha256=09c042cbfc2acf2239441cc9b982ebab2a999bed2ef6bdc51849e7b3d6e48a1c

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -821,6 +821,7 @@ DEPENDENCIES
   rack-livereload (~> 0.6.1)
   rails (~> 8.1.3)
   rails-controller-testing
+  rainbow (>= 3.1.1)
   redis (~> 5.4.1)
   rspec-collection_matchers
   rspec-html-matchers (~> 0.10.0)

--- a/db/seed_helper.rb
+++ b/db/seed_helper.rb
@@ -1,3 +1,5 @@
+require 'rainbow'
+
 module SeedHelper
   class << self
     def update_or_create_case_stage!(options)

--- a/db/seeds/fee_types/csv_seeder.rb
+++ b/db/seeds/fee_types/csv_seeder.rb
@@ -23,7 +23,7 @@ module Seeds
 
         reset_pk_sequence!
 
-        log "Created: #{total_created} | Updated: #{total_updated} | Error: #{total_with_error} | Processed: #{total}".yellow
+        log Rainbow("Created: #{total_created} | Updated: #{total_updated} | Error: #{total_with_error} | Processed: #{total}").yellow
       end
 
       protected
@@ -65,8 +65,8 @@ module Seeds
           new_attributes = attributes.symbolize_keys
           return if current_attributes.eql?(new_attributes)
 
-          log "Updating: #{record.description}".yellow
-          log "Attribute Diff: #{Hashdiff.diff(current_attributes, new_attributes)}".yellow
+          log Rainbow("Updating: #{record.description}").yellow
+          log Rainbow("Attribute Diff: #{Hashdiff.diff(current_attributes, new_attributes)}").yellow
           record.update!(attributes) unless dry_mode
           self.total_updated += 1
         else

--- a/db/seeds/schemas/add_agfs_fee_scheme_12.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_12.rb
@@ -54,23 +54,23 @@ module Seeds
 
       def destroy_agfs_scheme_12_offences
         if pretending?
-          puts "Would delete #{scheme_12_offence_count} scheme 12 offences".yellow
-          puts "Would reset offence PK sequence to max id value: #{Offence.ids.max}".yellow
+          puts Rainbow("Would delete #{scheme_12_offence_count} scheme 12 offences").yellow
+          puts Rainbow("Would reset offence PK sequence to max id value: #{Offence.ids.max}").yellow
         else
           scheme_12_offences = Offence.joins(:fee_schemes).merge(FeeScheme.twelve).merge(FeeScheme.agfs).distinct
           before_count = scheme_12_offences.count
-          puts "Deleted #{before_count} scheme 12 offences".green if scheme_12_offences.destroy_all
-          puts "Reset offence pk sequence to #{Offence.ids.max}".green if set_offence_pk_sequence(Offence.ids.max)
+          puts Rainbow("Deleted #{before_count} scheme 12 offences").green if scheme_12_offences.destroy_all
+          puts Rainbow("Reset offence pk sequence to #{Offence.ids.max}").green if set_offence_pk_sequence(Offence.ids.max)
         end
       end
 
       def destroy_scheme_12_only_fee_types
         if pretending?
-          puts "Would delete scheme 12 fee types: #{scheme_12_only_fee_types.count} #{scheme_12_only_fee_types.pluck(:id, :description).join(', ') || 'none to delete'}".yellow
+          puts Rainbow("Would delete scheme 12 fee types: #{scheme_12_only_fee_types.count} #{scheme_12_only_fee_types.pluck(:id, :description).join(', ') || 'none to delete'}").yellow
         else
           # do not apply callback dependency: :destroy
           scheme_12_only_fee_types.delete_all
-          puts "Deleted #{scheme_12_only_fee_types.count} fee_types #{scheme_12_only_fee_types.map(&:description).join(', ')}".green
+          puts Rainbow("Deleted #{scheme_12_only_fee_types.count} fee_types #{scheme_12_only_fee_types.map(&:description).join(', ')}").green
         end
       end
 
@@ -78,7 +78,7 @@ module Seeds
         scheme_10_fee_types_with_scheme_12_role = Fee::BaseFeeType.agfs_scheme_10s.select { |ft| ft.roles.include?('agfs_scheme_12') }
 
         if pretending?
-          puts "Would remove agfs_scheme_12 role from #{scheme_10_fee_types_with_scheme_12_role.count} fee_types".yellow
+          puts Rainbow("Would remove agfs_scheme_12 role from #{scheme_10_fee_types_with_scheme_12_role.count} fee_types").yellow
         else
           ActiveRecord::Base.transaction do
             scheme_10_fee_types_with_scheme_12_role.each do |ft|
@@ -86,56 +86,56 @@ module Seeds
               ft.save!
             end
           end
-          puts "Removed agfs scheme 12 role from #{scheme_10_fee_types_with_scheme_12_role.count} fee_types".green
+          puts Rainbow("Removed agfs scheme 12 role from #{scheme_10_fee_types_with_scheme_12_role.count} fee_types").green
         end
       end
 
       def destroy_scheme_12_update_11
         if pretending?
-          puts "Would delete fee scheme 12: #{agfs_fee_scheme_12&.attributes || 'does not exist'}".yellow
-          puts "Would update #{agfs_fee_scheme_11.attributes} end date to nil".yellow
-          puts "Would reset fee_schemes PK sequence to max id value".yellow
+          puts Rainbow("Would delete fee scheme 12: #{agfs_fee_scheme_12&.attributes || 'does not exist'}").yellow
+          puts Rainbow("Would update #{agfs_fee_scheme_11.attributes} end date to nil").yellow
+          puts Rainbow("Would reset fee_schemes PK sequence to max id value").yellow
         else
-          puts 'Deleted fee scheme 12'.green if agfs_fee_scheme_12&.destroy
-          puts 'Updated fee scheme 11 end date to nil'.green if agfs_fee_scheme_11&.update(end_date: nil)
-          puts "Reset fee_schemes pk sequence to #{FeeScheme.ids.max}".green \
+          puts Rainbow('Deleted fee scheme 12').green if agfs_fee_scheme_12&.destroy
+          puts Rainbow('Updated fee scheme 11 end date to nil').green if agfs_fee_scheme_11&.update(end_date: nil)
+          puts Rainbow("Reset fee_schemes pk sequence to #{FeeScheme.ids.max}").green \
             if ActiveRecord::Base.connection.set_pk_sequence!('fee_schemes', FeeScheme.ids.max)
         end
       end
 
       def create_or_update_agfs_scheme_eleven
-        print "Finding AGFS scheme 11".yellow
+        print Rainbow("Finding AGFS scheme 11").yellow
         agfs_fee_scheme_eleven = FeeScheme.find_by(name: 'AGFS', version: 11, start_date: Settings.agfs_scheme_11_release_date.beginning_of_day)
-        agfs_fee_scheme_eleven ? print("...found\n".green) : print("...not found\n".red)
+        agfs_fee_scheme_eleven ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating AGFS scheme 11 end date to #{Settings.clar_release_date.end_of_day-1.day}".yellow
-        print "...not updated\n".green if pretending?
+        print Rainbow("Updating AGFS scheme 11 end date to #{Settings.clar_release_date.end_of_day-1.day}").yellow
+        print Rainbow("...not updated\n").green if pretending?
         return if pretending?
 
         agfs_fee_scheme_eleven.update(end_date: Settings.clar_release_date.end_of_day-1.day)
-        print "...updated\n".green
+        print Rainbow("...updated\n").green
       end
 
       def create_agfs_scheme_twelve
-        print "Finding or creating scheme 12 with start date #{Settings.clar_release_date.beginning_of_day}...".yellow
-        print "...not created\n".green if pretending?
+        print Rainbow("Finding or creating scheme 12 with start date #{Settings.clar_release_date.beginning_of_day}...").yellow
+        print Rainbow("...not created\n").green if pretending?
         return if pretending?
 
         FeeScheme.find_or_create_by(name: 'AGFS', version: 12, start_date: Settings.clar_release_date.beginning_of_day)
-        print "...created\n".green
+        print Rainbow("...created\n").green
       end
 
       def create_agfs_scheme_twelve_offences
-        puts "Scheme 12 offence count before: #{scheme_12_offence_count}".yellow
+        puts Rainbow("Scheme 12 offence count before: #{scheme_12_offence_count}").yellow
         copy_scheme_11_offences
-        puts "Scheme 12 offence count after: #{scheme_12_offence_count}".yellow
+        puts Rainbow("Scheme 12 offence count after: #{scheme_12_offence_count}").yellow
       end
 
       def create_scheme_twelve_fee_types
-        puts "Scheme 12 fee type count before: #{scheme_12_fee_type_count}".yellow
+        puts Rainbow("Scheme 12 fee type count before: #{scheme_12_fee_type_count}").yellow
         require Rails.root.join('db', 'seeds', 'fee_types', 'csv_seeder')
         Seeds::FeeTypes::CsvSeeder.new(dry_mode: pretending?, stdout: false).call
-        puts "Scheme 12 fee type count after: #{scheme_12_fee_type_count}".yellow
+        puts Rainbow("Scheme 12 fee type count after: #{scheme_12_fee_type_count}").yellow
       end
 
       def scheme_12_offence_count
@@ -152,18 +152,18 @@ module Seeds
 
       def copy_scheme_11_offences
         set_offence_pk_sequence(5000)
-        puts 'Adding scheme 12 offences'.yellow
+        puts Rainbow('Adding scheme 12 offences').yellow
 
         Offence.transaction do
           agfs_scheme_eleven_offences.each do |offence|
             if pretending?
-              puts "[WOULD-COPY] " + "#{offence.unique_code} => #{offence.unique_code.sub('~11','~12')}".yellow
+              puts Rainbow("[WOULD-COPY] " + "#{offence.unique_code} => #{offence.unique_code.sub('~11','~12')}").yellow
             else
               new_offence = offence.dup
               new_offence.unique_code = new_offence.unique_code.sub('~11','~12')
               new_offence.fee_schemes << agfs_fee_scheme_12
               new_offence.save!
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
@@ -173,8 +173,8 @@ module Seeds
 
       def set_offence_pk_sequence(sequence_start)
         if pretending?
-          print "Resetting offences sequence to max offence id unless Offence.ids.max > sequence_start (#{Offence.ids.max} > #{sequence_start})...".yellow
-          puts 'not resetting'.green
+          print Rainbow("Resetting offences sequence to max offence id unless Offence.ids.max > sequence_start (#{Offence.ids.max} > #{sequence_start})...").yellow
+          puts Rainbow('not resetting').green
           return
         end
         raise StandardError, "Sequence cannot be set to value less than greatest id in use - #{Offence.ids.max} > #{sequence_start}" if Offence.ids.max > sequence_start

--- a/db/seeds/schemas/add_agfs_fee_scheme_13.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_13.rb
@@ -52,13 +52,13 @@ module Seeds
 
       def destroy_agfs_scheme_13_offences
         if pretending?
-          puts "Would delete #{scheme_13_offence_count} scheme 13 offences".yellow
-          puts "Would reset offence PK sequence to max id value: #{Offence.ids.max}".yellow
+          puts Rainbow("Would delete #{scheme_13_offence_count} scheme 13 offences").yellow
+          puts Rainbow("Would reset offence PK sequence to max id value: #{Offence.ids.max}").yellow
         else
           scheme_13_offences = Offence.joins(:fee_schemes).merge(FeeScheme.thirteen).merge(FeeScheme.agfs).distinct
           before_count = scheme_13_offences.count
-          puts "Deleted #{before_count} scheme 13 offences".green if scheme_13_offences.destroy_all
-          puts "Reset offence pk sequence to #{Offence.ids.max}".green if set_offence_pk_sequence(Offence.ids.max)
+          puts Rainbow("Deleted #{before_count} scheme 13 offences").green if scheme_13_offences.destroy_all
+          puts Rainbow("Reset offence pk sequence to #{Offence.ids.max}").green if set_offence_pk_sequence(Offence.ids.max)
         end
       end
 
@@ -66,7 +66,7 @@ module Seeds
         scheme_12_fee_types_with_scheme_13_role = Fee::BaseFeeType.agfs_scheme_12s.select { |ft| ft.roles.include?('agfs_scheme_13') }
 
         if pretending?
-          puts "Would remove agfs_scheme_13 role from #{scheme_12_fee_types_with_scheme_13_role.count} fee_types".yellow
+          puts Rainbow("Would remove agfs_scheme_13 role from #{scheme_12_fee_types_with_scheme_13_role.count} fee_types").yellow
         else
           ActiveRecord::Base.transaction do
             scheme_12_fee_types_with_scheme_13_role.each do |ft|
@@ -74,56 +74,56 @@ module Seeds
               ft.save!
             end
           end
-          puts "Removed agfs scheme 13 role from #{scheme_12_fee_types_with_scheme_13_role.count} fee_types".green
+          puts Rainbow("Removed agfs scheme 13 role from #{scheme_12_fee_types_with_scheme_13_role.count} fee_types").green
         end
       end
 
       def destroy_scheme_13_update_12
         if pretending?
-          puts "Would delete fee scheme 13: #{agfs_fee_scheme_13&.attributes || 'does not exist'}".yellow
-          puts "Would update #{agfs_fee_scheme_12.attributes} end date to nil".yellow
-          puts "Would reset fee_schemes PK sequence to max id value".yellow
+          puts Rainbow("Would delete fee scheme 13: #{agfs_fee_scheme_13&.attributes || 'does not exist'}").yellow
+          puts Rainbow("Would update #{agfs_fee_scheme_12.attributes} end date to nil").yellow
+          puts Rainbow("Would reset fee_schemes PK sequence to max id value").yellow
         else
-          puts 'Deleted fee scheme 13'.green if agfs_fee_scheme_13&.destroy
-          puts 'Updated fee scheme 12 end date to nil'.green if agfs_fee_scheme_12&.update(end_date: nil)
-          puts "Reset fee_schemes pk sequence to #{FeeScheme.ids.max}".green \
+          puts Rainbow('Deleted fee scheme 13').green if agfs_fee_scheme_13&.destroy
+          puts Rainbow('Updated fee scheme 12 end date to nil').green if agfs_fee_scheme_12&.update(end_date: nil)
+          puts Rainbow("Reset fee_schemes pk sequence to #{FeeScheme.ids.max}").green \
             if ActiveRecord::Base.connection.set_pk_sequence!('fee_schemes', FeeScheme.ids.max)
         end
       end
 
       def create_or_update_agfs_scheme_twelve
-        print "Finding AGFS scheme 12".yellow
+        print Rainbow("Finding AGFS scheme 12").yellow
         agfs_fee_scheme_twelve = FeeScheme.find_by(name: 'AGFS', version: 12, start_date: Settings.clar_release_date.beginning_of_day)
-        agfs_fee_scheme_twelve ? print("...found\n".green) : print("...not found\n".red)
+        agfs_fee_scheme_twelve ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating AGFS scheme 12 end date to #{Settings.agfs_scheme_13_clair_release_date.end_of_day-1.day}".yellow
-        print "...not updated\n".green if pretending?
+        print Rainbow("Updating AGFS scheme 12 end date to #{Settings.agfs_scheme_13_clair_release_date.end_of_day-1.day}").yellow
+        print Rainbow("...not updated\n").green if pretending?
         return if pretending?
 
         agfs_fee_scheme_twelve.update(end_date: Settings.agfs_scheme_13_clair_release_date.end_of_day-1.day)
-        print "...updated\n".green
+        print Rainbow("...updated\n").green
       end
 
       def create_agfs_scheme_thirteen
-        print "Finding or creating scheme 13 with start date #{Settings.agfs_scheme_13_clair_release_date.beginning_of_day}...".yellow
-        print "...not created\n".green if pretending?
+        print Rainbow("Finding or creating scheme 13 with start date #{Settings.agfs_scheme_13_clair_release_date.beginning_of_day}...").yellow
+        print Rainbow("...not created\n").green if pretending?
         return if pretending?
 
         FeeScheme.find_or_create_by(name: 'AGFS', version: 13, start_date: Settings.agfs_scheme_13_clair_release_date.beginning_of_day)
-        print "...created\n".green
+        print Rainbow("...created\n").green
       end
 
       def create_agfs_scheme_thirteen_offences
-        puts "Scheme 13 offence count before: #{scheme_13_offence_count}".yellow
+        puts Rainbow("Scheme 13 offence count before: #{scheme_13_offence_count}").yellow
         copy_scheme_12_offences
-        puts "Scheme 13 offence count after: #{scheme_13_offence_count}".yellow
+        puts Rainbow("Scheme 13 offence count after: #{scheme_13_offence_count}").yellow
       end
 
       def create_scheme_thirteen_fee_types
-        puts "Scheme 13 fee type count before: #{scheme_13_fee_type_count}".yellow
+        puts Rainbow("Scheme 13 fee type count before: #{scheme_13_fee_type_count}").yellow
         require Rails.root.join('db', 'seeds', 'fee_types', 'csv_seeder')
         Seeds::FeeTypes::CsvSeeder.new(dry_mode: pretending?, stdout: false).call
-        puts "Scheme 13 fee type count after: #{scheme_13_fee_type_count}".yellow
+        puts Rainbow("Scheme 13 fee type count after: #{scheme_13_fee_type_count}").yellow
       end
 
       def scheme_13_offence_count
@@ -136,18 +136,18 @@ module Seeds
 
       def copy_scheme_12_offences
         set_offence_pk_sequence(10000)
-        puts 'Adding scheme 13 offences'.yellow
+        puts Rainbow('Adding scheme 13 offences').yellow
 
         Offence.transaction do
           agfs_scheme_twelve_offences.each do |offence|
             if pretending?
-              puts "[WOULD-COPY] " + "#{offence.unique_code} => #{offence.unique_code.sub('~12','~13')}".yellow
+              puts Rainbow("[WOULD-COPY] " + "#{offence.unique_code} => #{offence.unique_code.sub('~12','~13')}").yellow
             else
               new_offence = offence.dup
               new_offence.unique_code = new_offence.unique_code.sub('~12','~13')
               new_offence.fee_schemes << agfs_fee_scheme_13
               new_offence.save!
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
@@ -157,8 +157,8 @@ module Seeds
 
       def set_offence_pk_sequence(sequence_start)
         if pretending?
-          print "Resetting offences sequence to max offence id unless Offence.ids.max > sequence_start (#{Offence.ids.max} > #{sequence_start})...".yellow
-          puts 'not resetting'.green
+          print Rainbow("Resetting offences sequence to max offence id unless Offence.ids.max > sequence_start (#{Offence.ids.max} > #{sequence_start})...").yellow
+          puts Rainbow('not resetting').green
           return
         end
         raise StandardError, "Sequence cannot be set to value less than greatest id in use - #{Offence.ids.max} > #{sequence_start}" if Offence.ids.max > sequence_start

--- a/db/seeds/schemas/add_agfs_fee_scheme_14.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_14.rb
@@ -51,46 +51,46 @@ module Seeds
       end
 
       def create_agfs_scheme_fourteen
-        print "Finding AGFS scheme 13".yellow
+        print Rainbow("Finding AGFS scheme 13").yellow
         agfs_fee_scheme_thirteen = FeeScheme.find_by(name: 'AGFS', version: 13, start_date: Settings.agfs_scheme_13_clair_release_date.beginning_of_day)
-        agfs_fee_scheme_thirteen ? print("...found\n".green) : print("...not found\n".red)
+        agfs_fee_scheme_thirteen ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating AGFS scheme 13 end date to #{Settings.agfs_scheme_14_section_twenty_eight.end_of_day-1.day}".yellow
+        print Rainbow("Updating AGFS scheme 13 end date to #{Settings.agfs_scheme_14_section_twenty_eight.end_of_day-1.day}").yellow
         if pretending?
-          print "...not updated\n".green if pretending?
+          print Rainbow("...not updated\n").green if pretending?
         else
           agfs_fee_scheme_thirteen.update(end_date: Settings.agfs_scheme_14_section_twenty_eight.end_of_day-1.day)
-          print "...updated\n".green
+          print Rainbow("...updated\n").green
         end
 
-        print "Finding or creating scheme 14 with start date #{Settings.agfs_scheme_14_section_twenty_eight.beginning_of_day}...".yellow
+        print Rainbow("Finding or creating scheme 14 with start date #{Settings.agfs_scheme_14_section_twenty_eight.beginning_of_day}...").yellow
         if pretending?
-          print "...not created\n".green if pretending?
+          print Rainbow("...not created\n").green if pretending?
         else
           FeeScheme.find_or_create_by(name: 'AGFS', version: 14, start_date: Settings.agfs_scheme_14_section_twenty_eight.beginning_of_day)
-          print "...created\n".green
+          print Rainbow("...created\n").green
         end
       end
 
       def destroy_agfs_scheme_fourteen
         if pretending?
-          puts "Would delete fee scheme 14: #{agfs_fee_scheme_14&.attributes || 'does not exist'}".yellow
-          puts "Would update #{agfs_fee_scheme_13.attributes} end date to nil".yellow
+          puts Rainbow("Would delete fee scheme 14: #{agfs_fee_scheme_14&.attributes || 'does not exist'}").yellow
+          puts Rainbow("Would update #{agfs_fee_scheme_13.attributes} end date to nil").yellow
         else
-          puts 'Deleted fee scheme 14'.red if agfs_fee_scheme_14&.destroy
-          puts 'Updated fee scheme 13 end date to nil'.green if agfs_fee_scheme_13&.update(end_date: nil)
+          puts Rainbow('Deleted fee scheme 14').red if agfs_fee_scheme_14&.destroy
+          puts Rainbow('Updated fee scheme 13 end date to nil').green if agfs_fee_scheme_13&.update(end_date: nil)
         end
       end
 
       def set_agfs_scheme_fourteen_offences
-        puts 'Setting scheme 11 offences to include scheme 14'.yellow
+        puts Rainbow('Setting scheme 11 offences to include scheme 14').yellow
         Offence.transaction do
           agfs_scheme_eleven_offences.each do |offence|
             if pretending?
-              puts "[WOULD-ADD] Fee Scheme 14 to #{offence.unique_code}".yellow
+              puts Rainbow("[WOULD-ADD] Fee Scheme 14 to #{offence.unique_code}").yellow
             else
               offence.fee_schemes << agfs_fee_scheme_14
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
@@ -101,10 +101,10 @@ module Seeds
         Offence.transaction do
           Offence.joins(:fee_schemes).merge(FeeScheme.version(14)).merge(FeeScheme.agfs).distinct.each do |offence|
             if pretending?
-              puts "[WOULD-REMOVE] Fee Scheme 14 from #{offence.unique_code}".yellow
+              puts Rainbow("[WOULD-REMOVE] Fee Scheme 14 from #{offence.unique_code}").yellow
             else
               offence.fee_schemes.delete(agfs_fee_scheme_14)
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
@@ -121,31 +121,31 @@ module Seeds
       end
 
       def create_scheme_fourteen_fee_types
-        puts "Scheme 14 fee type count before: #{scheme_14_fee_type_count}".yellow
+        puts  Rainbow("Scheme 14 fee type count before: #{scheme_14_fee_type_count}").yellow
         require Rails.root.join('db', 'seeds', 'fee_types', 'csv_seeder')
         Seeds::FeeTypes::CsvSeeder.new(dry_mode: pretending?, stdout: false).call
-        puts "Scheme 14 fee type count after: #{scheme_14_fee_type_count}".yellow
+        puts Rainbow("Scheme 14 fee type count after: #{scheme_14_fee_type_count}").yellow
       end
 
       def remove_scheme_fourteen_fee_type_roles
         fee_types_with_scheme_14_role = Fee::BaseFeeType.agfs_scheme_14s
 
         if pretending?
-          puts "Would remove agfs_scheme_14 role from #{fee_types_with_scheme_14_role.count} fee_types".yellow
+          puts Rainbow("Would remove agfs_scheme_14 role from #{fee_types_with_scheme_14_role.count} fee_types").yellow
         else
           ActiveRecord::Base.transaction do
             fee_types_with_scheme_14_role.each do |ft|
               if ft.roles == ['agfs_scheme_14']
-                puts "Deleting fee type #{ft.description}".red
+                puts Rainbow("Deleting fee type #{ft.description}").red
                 ft.delete
               else
-                puts "Removing agfs_scheme_14 role from #{ft.description}".green
+                puts Rainbow("Removing agfs_scheme_14 role from #{ft.description}").green
                 ft.roles.delete('agfs_scheme_14')
                 ft.save!
               end
             end
           end
-          puts "Removed agfs scheme 14 role from #{fee_types_with_scheme_14_role.count} fee_types".green
+          puts Rainbow("Removed agfs scheme 14 role from #{fee_types_with_scheme_14_role.count} fee_types").green
         end
       end
     end

--- a/db/seeds/schemas/add_agfs_fee_scheme_15.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_15.rb
@@ -51,69 +51,69 @@ module Seeds
       end
 
       def create_agfs_scheme_fifteen
-        print "Finding AGFS scheme 14".yellow
+        print Rainbow("Finding AGFS scheme 14").yellow
         agfs_fee_scheme_fourteen = FeeScheme.find_by(name: 'AGFS', version: 14, start_date: Settings.agfs_scheme_14_section_twenty_eight.beginning_of_day)
-        agfs_fee_scheme_fourteen ? print("...found\n".green) : print("...not found\n".red)
+        agfs_fee_scheme_fourteen ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating AGFS scheme 14 end date to #{Settings.agfs_scheme_15_additional_prep_fee_and_kc.end_of_day-1.day}".yellow
+        print Rainbow("Updating AGFS scheme 14 end date to #{Settings.agfs_scheme_15_additional_prep_fee_and_kc.end_of_day-1.day}").yellow
         if pretending?
-          print "...not updated\n".green if pretending?
+          print Rainbow("...not updated\n").green if pretending?
         else
           agfs_fee_scheme_fourteen.update(end_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc.end_of_day-1.day)
-          print "...updated\n".green
+          print Rainbow("...updated\n").green
         end
 
-        print "Finding or creating scheme 15 with start date #{Settings.agfs_scheme_15_additional_prep_fee_and_kc.beginning_of_day}...".yellow
+        print Rainbow("Finding or creating scheme 15 with start date #{Settings.agfs_scheme_15_additional_prep_fee_and_kc.beginning_of_day}...").yellow
         if pretending?
-          print "...not created\n".green if pretending?
+          print Rainbow("...not created\n").green if pretending?
         else
           FeeScheme.find_or_create_by(name: 'AGFS', version: 15, start_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc.beginning_of_day)
-          print "...created\n".green
+          print Rainbow("...created\n").green
         end
       end
 
       def destroy_agfs_scheme_fifteen
         if pretending?
-          puts "Would delete fee scheme 15: #{agfs_fee_scheme_15&.attributes || 'does not exist'}".yellow
-          puts "Would update #{agfs_fee_scheme_14.attributes} end date to nil".yellow
+          puts Rainbow("Would delete fee scheme 15: #{agfs_fee_scheme_15&.attributes || 'does not exist'}").yellow
+          puts Rainbow("Would update #{agfs_fee_scheme_14.attributes} end date to nil").yellow
         else
-          puts 'Deleted fee scheme 15'.red if agfs_fee_scheme_15&.destroy
-          puts 'Updated fee scheme 14 end date to nil'.green if agfs_fee_scheme_14&.update(end_date: nil)
+          puts Rainbow('Deleted fee scheme 15').red if agfs_fee_scheme_15&.destroy
+          puts Rainbow('Updated fee scheme 14 end date to nil').green if agfs_fee_scheme_14&.update(end_date: nil)
         end
       end
 
       def set_agfs_scheme_fifteen_offences
-        puts 'Setting scheme 11 offences to include scheme 15'.yellow
-        puts "Scheme 15 offence count before: #{scheme_15_offence_count}".yellow
+        puts Rainbow('Setting scheme 11 offences to include scheme 15').yellow
+        puts Rainbow("Scheme 15 offence count before: #{scheme_15_offence_count}").yellow
         Offence.transaction do
           agfs_scheme_eleven_offences.each do |offence|
             if pretending?
-              puts "[WOULD-ADD] Fee Scheme 15 to #{offence.unique_code}".yellow
+              puts Rainbow("[WOULD-ADD] Fee Scheme 15 to #{offence.unique_code}").yellow
             else
               next if offence.fee_schemes.include? agfs_fee_scheme_15
 
               offence.fee_schemes << agfs_fee_scheme_15
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
         print "\n"
-        puts "Scheme 15 offence count after: #{scheme_15_offence_count}".yellow
+        puts Rainbow("Scheme 15 offence count after: #{scheme_15_offence_count}").yellow
       end
 
       def unset_agfs_scheme_fifteen_offences
         Offence.transaction do
           Offence.joins(:fee_schemes).merge(FeeScheme.version(15)).merge(FeeScheme.agfs).distinct.each do |offence|
             if pretending?
-              puts "[WOULD-REMOVE] Fee Scheme 15 from #{offence.unique_code}".yellow
+              puts Rainbow("[WOULD-REMOVE] Fee Scheme 15 from #{offence.unique_code}").yellow
             else
               offence.fee_schemes.delete(agfs_fee_scheme_15)
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
         print "\n"
-        puts "Scheme 15 offence count after: #{scheme_15_offence_count}".yellow
+        puts Rainbow("Scheme 15 offence count after: #{scheme_15_offence_count}").yellow
       end
 
       def agfs_scheme_eleven_offences
@@ -126,31 +126,31 @@ module Seeds
       end
 
       def create_scheme_fifteen_fee_types
-        puts "Scheme 15 fee type count before: #{scheme_15_fee_type_count}".yellow
+        puts Rainbow("Scheme 15 fee type count before: #{scheme_15_fee_type_count}").yellow
         require Rails.root.join('db', 'seeds', 'fee_types', 'csv_seeder')
         Seeds::FeeTypes::CsvSeeder.new(dry_mode: pretending?, stdout: false).call
-        puts "Scheme 15 fee type count after: #{scheme_15_fee_type_count}".yellow
+        puts Rainbow("Scheme 15 fee type count after: #{scheme_15_fee_type_count}").yellow
       end
 
       def remove_scheme_fifteen_fee_type_roles
         fee_types_with_scheme_15_role = Fee::BaseFeeType.agfs_scheme_15s
 
         if pretending?
-          puts "Would remove agfs_scheme_15 role from #{fee_types_with_scheme_15_role.count} fee_types".yellow
+          puts Rainbow("Would remove agfs_scheme_15 role from #{fee_types_with_scheme_15_role.count} fee_types").yellow
         else
           ActiveRecord::Base.transaction do
             fee_types_with_scheme_15_role.each do |ft|
               if ft.roles == ['agfs_scheme_15']
-                puts "Deleting fee type #{ft.description}".red
+                puts Rainbow("Deleting fee type #{ft.description}").red
                 ft.delete
               else
-                puts "Removing agfs_scheme_15 role from #{ft.description}".green
+                puts Rainbow("Removing agfs_scheme_15 role from #{ft.description}").green
                 ft.roles.delete('agfs_scheme_15')
                 ft.save!
               end
             end
           end
-          puts "Fee types with scheme 15 role after: #{fee_types_with_scheme_15_role.count}".green
+          puts Rainbow("Fee types with scheme 15 role after: #{fee_types_with_scheme_15_role.count}").green
         end
       end
     end

--- a/db/seeds/schemas/add_agfs_fee_scheme_16.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_16.rb
@@ -51,69 +51,69 @@ module Seeds
       end
 
       def create_agfs_scheme_sixteen
-        print "Finding AGFS scheme 15".yellow
+        print Rainbow("Finding AGFS scheme 15").yellow
         agfs_fee_scheme_fifteen = FeeScheme.find_by(name: 'AGFS', version: 15, start_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc.beginning_of_day)
-        agfs_fee_scheme_fifteen ? print("...found\n".green) : print("...not found\n".red)
+        agfs_fee_scheme_fifteen ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating AGFS scheme 15 end date to #{Settings.agfs_scheme_16_section_twenty_eight_increase.end_of_day-1.day}".yellow
+        print Rainbow("Updating AGFS scheme 15 end date to #{Settings.agfs_scheme_16_section_twenty_eight_increase.end_of_day-1.day}").yellow
         if pretending?
-          print "...not updated\n".green if pretending?
+          print Rainbow("...not updated\n").green if pretending?
         else
           agfs_fee_scheme_fifteen.update(end_date: Settings.agfs_scheme_16_section_twenty_eight_increase.end_of_day-1.day)
-          print "...updated\n".green
+          print Rainbow("...updated\n").green
         end
 
-        print "Finding or creating scheme 16 with start date #{Settings.agfs_scheme_16_section_twenty_eight_increase.beginning_of_day}...".yellow
+        print Rainbow("Finding or creating scheme 16 with start date #{Settings.agfs_scheme_16_section_twenty_eight_increase.beginning_of_day}...").yellow
         if pretending?
-          print "...not created\n".green if pretending?
+          print Rainbow("...not created\n").green if pretending?
         else
           FeeScheme.find_or_create_by(name: 'AGFS', version: 16, start_date: Settings.agfs_scheme_16_section_twenty_eight_increase.beginning_of_day)
-          print "...created\n".green
+          print Rainbow("...created\n").green
         end
       end
 
       def destroy_agfs_scheme_sixteen
         if pretending?
-          puts "Would delete fee scheme 16: #{agfs_fee_scheme_16&.attributes || 'does not exist'}".yellow
-          puts "Would update #{agfs_fee_scheme_15.attributes} end date to nil".yellow
+          puts Rainbow("Would delete fee scheme 16: #{agfs_fee_scheme_16&.attributes || 'does not exist'}").yellow
+          puts Rainbow("Would update #{agfs_fee_scheme_15.attributes} end date to nil").yellow
         else
-          puts 'Deleted fee scheme 16'.red if agfs_fee_scheme_16&.destroy
-          puts 'Updated fee scheme 15 end date to nil'.green if agfs_fee_scheme_15&.update(end_date: nil)
+          puts Rainbow('Deleted fee scheme 16').red if agfs_fee_scheme_16&.destroy
+          puts Rainbow('Updated fee scheme 15 end date to nil').green if agfs_fee_scheme_15&.update(end_date: nil)
         end
       end
 
       def set_agfs_scheme_sixteen_offences
-        puts 'Setting scheme 15 offences to include scheme 16'.yellow
-        puts "Scheme 16 offence count before: #{scheme_16_offence_count}".yellow
+        puts Rainbow('Setting scheme 15 offences to include scheme 16').yellow
+        puts Rainbow("Scheme 16 offence count before: #{scheme_16_offence_count}").yellow
         Offence.transaction do
           agfs_scheme_fifteen_offences.each do |offence|
             if pretending?
-              puts "[WOULD-ADD] Fee Scheme 16 to #{offence.unique_code}".yellow
+              puts Rainbow("[WOULD-ADD] Fee Scheme 16 to #{offence.unique_code}").yellow
             else
               next if offence.fee_schemes.include? agfs_fee_scheme_16
 
               offence.fee_schemes << agfs_fee_scheme_16
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
         print "\n"
-        puts "Scheme 16 offence count after: #{scheme_16_offence_count}".yellow
+        puts Rainbow("Scheme 16 offence count after: #{scheme_16_offence_count}").yellow
       end
 
       def unset_agfs_scheme_sixteen_offences
         Offence.transaction do
           Offence.joins(:fee_schemes).merge(FeeScheme.version(16)).merge(FeeScheme.agfs).distinct.each do |offence|
             if pretending?
-              puts "[WOULD-REMOVE] Fee Scheme 16 from #{offence.unique_code}".yellow
+              puts Rainbow("[WOULD-REMOVE] Fee Scheme 16 from #{offence.unique_code}").yellow
             else
               offence.fee_schemes.delete(agfs_fee_scheme_16)
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
         print "\n"
-        puts "Scheme 16 offence count after: #{scheme_16_offence_count}".yellow
+        puts Rainbow("Scheme 16 offence count after: #{scheme_16_offence_count}").yellow
       end
 
       def agfs_scheme_fifteen_offences
@@ -126,31 +126,31 @@ module Seeds
       end
 
       def create_scheme_sixteen_fee_types
-        puts "Scheme 16 fee type count before: #{scheme_16_fee_type_count}".yellow
+        puts Rainbow("Scheme 16 fee type count before: #{scheme_16_fee_type_count}").yellow
         require Rails.root.join('db', 'seeds', 'fee_types', 'csv_seeder')
         Seeds::FeeTypes::CsvSeeder.new(dry_mode: pretending?, stdout: false).call
-        puts "Scheme 16 fee type count after: #{scheme_16_fee_type_count}".yellow
+        puts Rainbow("Scheme 16 fee type count after: #{scheme_16_fee_type_count}").yellow
       end
 
       def remove_scheme_sixteen_fee_type_roles
         fee_types_with_scheme_16_role = Fee::BaseFeeType.agfs_scheme_16s
 
         if pretending?
-          puts "Would remove agfs_scheme_16 role from #{fee_types_with_scheme_16_role.count} fee_types".yellow
+          puts Rainbow("Would remove agfs_scheme_16 role from #{fee_types_with_scheme_16_role.count} fee_types").yellow
         else
           ActiveRecord::Base.transaction do
             fee_types_with_scheme_16_role.each do |ft|
               if ft.roles == ['agfs_scheme_16']
-                puts "Deleting fee type #{ft.description}".red
+                puts Rainbow("Deleting fee type #{ft.description}").red
                 ft.delete
               else
-                puts "Removing agfs_scheme_16 role from #{ft.description}".green
+                puts Rainbow("Removing agfs_scheme_16 role from #{ft.description}").green
                 ft.roles.delete('agfs_scheme_16')
                 ft.save!
               end
             end
           end
-          puts "Fee types with scheme 16 role after: #{fee_types_with_scheme_16_role.count}".green
+          puts Rainbow("Fee types with scheme 16 role after: #{fee_types_with_scheme_16_role.count}").green
         end
       end
     end

--- a/db/seeds/schemas/add_lgfs_fee_scheme_10.rb
+++ b/db/seeds/schemas/add_lgfs_fee_scheme_10.rb
@@ -54,13 +54,13 @@ module Seeds
 
       def destroy_lgfs_scheme_ten_offences
         if pretending?
-          puts "Would delete #{scheme_10_offence_count} LGFS fee scheme 10 offences".yellow
-          puts "Would reset offence PK sequence to max id value: #{Offence.ids.max}".yellow
+          puts Rainbow("Would delete #{scheme_10_offence_count} LGFS fee scheme 10 offences").yellow
+          puts Rainbow("Would reset offence PK sequence to max id value: #{Offence.ids.max}").yellow
         else
           scheme_10_offences = Offence.joins(:fee_schemes).merge(FeeScheme.ten).merge(FeeScheme.lgfs).distinct
           before_count = scheme_10_offences.count
-          puts "Deleted #{before_count} LGFS fee scheme 10 offences".green if scheme_10_offences.destroy_all
-          puts "Reset offence pk sequence to #{Offence.ids.max}".green if set_offence_pk_sequence(Offence.ids.max)
+          puts Rainbow("Deleted #{before_count} LGFS fee scheme 10 offences").green if scheme_10_offences.destroy_all
+          puts Rainbow("Reset offence pk sequence to #{Offence.ids.max}").green if set_offence_pk_sequence(Offence.ids.max)
         end
       end
 
@@ -68,7 +68,7 @@ module Seeds
         scheme_9_fee_types_with_scheme_10_role = Fee::BaseFeeType.lgfs_scheme_9s.select { |ft| ft.roles.include?('lgfs_scheme_10') }
 
         if pretending?
-          puts "Would remove lgfs_scheme_10 role from #{scheme_9_fee_types_with_scheme_10_role.count} fee_types".yellow
+          puts Rainbow("Would remove lgfs_scheme_10 role from #{scheme_9_fee_types_with_scheme_10_role.count} fee_types").yellow
         else
           ActiveRecord::Base.transaction do
             scheme_9_fee_types_with_scheme_10_role.each do |ft|
@@ -76,67 +76,67 @@ module Seeds
               ft.save!
             end
           end
-          puts "Removed lgfs scheme 10 role from #{scheme_9_fee_types_with_scheme_10_role.count} fee_types".green
+          puts Rainbow("Removed lgfs scheme 10 role from #{scheme_9_fee_types_with_scheme_10_role.count} fee_types").green
         end
       end
 
       def destroy_lgfs_scheme_ten
         if pretending?
-          puts "Would delete LGFS fee scheme 10: #{lgfs_fee_scheme_10&.attributes || 'does not exist'}".yellow
-          puts "Would reset fee_schemes PK sequence to max id value".yellow
+          puts Rainbow("Would delete LGFS fee scheme 10: #{lgfs_fee_scheme_10&.attributes || 'does not exist'}").yellow
+          puts Rainbow("Would reset fee_schemes PK sequence to max id value").yellow
         else
-          puts 'Deleted LGFS fee scheme 10'.green if lgfs_fee_scheme_10&.destroy
-          puts "Reset fee_schemes pk sequence to #{FeeScheme.ids.max}".green \
+          puts Rainbow('Deleted LGFS fee scheme 10').green if lgfs_fee_scheme_10&.destroy
+          puts Rainbow("Reset fee_schemes pk sequence to #{FeeScheme.ids.max}").green \
             if ActiveRecord::Base.connection.set_pk_sequence!('fee_schemes', FeeScheme.ids.max)
         end
       end
 
       def rollback_scheme_nine
-        print "Finding LGFS fee scheme 9".yellow
+        print Rainbow("Finding LGFS fee scheme 9").yellow
         lgfs_fee_scheme_nine = FeeScheme.find_by(name: 'LGFS', version: 9)
-        lgfs_fee_scheme_nine ? print("...found\n".green) : print("...not found\n".red)
+        lgfs_fee_scheme_nine ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating LGFS fee scheme 9 end date to nil".yellow
-        print "...not updated\n".green if pretending?
+        print Rainbow("Updating LGFS fee scheme 9 end date to nil").yellow
+        print Rainbow("...not updated\n").green if pretending?
         return if pretending?
 
         lgfs_fee_scheme_nine.update(end_date: nil)
-        print "...updated\n".green
+        print Rainbow("...updated\n").green
       end
 
       def create_or_update_lgfs_scheme_nine
-        print "Finding LGFS fee scheme 9".yellow
+        print Rainbow("Finding LGFS fee scheme 9").yellow
         lgfs_fee_scheme_nine = FeeScheme.find_by(name: 'LGFS', version: 9)
-        lgfs_fee_scheme_nine ? print("...found\n".green) : print("...not found\n".red)
+        lgfs_fee_scheme_nine ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating LGFS fee scheme 9 end date to #{Settings.lgfs_scheme_10_clair_release_date.end_of_day-1.day}".yellow
-        print "...not updated\n".green if pretending?
+        print Rainbow("Updating LGFS fee scheme 9 end date to #{Settings.lgfs_scheme_10_clair_release_date.end_of_day-1.day}").yellow
+        print Rainbow("...not updated\n").green if pretending?
         return if pretending?
 
         lgfs_fee_scheme_nine.update(end_date: Settings.lgfs_scheme_10_clair_release_date.end_of_day-1.day)
-        print "...updated\n".green
+        print Rainbow("...updated\n").green
       end
 
       def create_lgfs_scheme_ten
-        print "Finding or creating LGFS fee scheme 10 with start date #{Settings.lgfs_scheme_10_clair_release_date.beginning_of_day}...".yellow
-        print "...not created\n".green if pretending?
+        print Rainbow("Finding or creating LGFS fee scheme 10 with start date #{Settings.lgfs_scheme_10_clair_release_date.beginning_of_day}...").yellow
+        print Rainbow("...not created\n").green if pretending?
         return if pretending?
 
         FeeScheme.find_or_create_by(name: 'LGFS', version: 10, start_date: Settings.lgfs_scheme_10_clair_release_date.beginning_of_day)
-        print "...created\n".green
+        print Rainbow("...created\n").green
       end
 
       def create_lgfs_scheme_ten_offences
-        puts "LGFS fee scheme 10 offence count before: #{scheme_10_offence_count}".yellow
+        puts Rainbow("LGFS fee scheme 10 offence count before: #{scheme_10_offence_count}").yellow
         copy_scheme_9_offences
-        puts "LGFS fee scheme 10 offence count after: #{scheme_10_offence_count}".yellow
+        puts Rainbow("LGFS fee scheme 10 offence count after: #{scheme_10_offence_count}").yellow
       end
 
       def create_lgfs_scheme_ten_fee_types
-        puts "LGFS fee scheme 10 fee type count before: #{scheme_10_fee_type_count}".yellow
+        puts Rainbow("LGFS fee scheme 10 fee type count before: #{scheme_10_fee_type_count}").yellow
         require Rails.root.join('db', 'seeds', 'fee_types', 'csv_seeder')
         Seeds::FeeTypes::CsvSeeder.new(dry_mode: pretending?, stdout: false).call
-        puts "LGFS fee scheme 10 fee type count after: #{scheme_10_fee_type_count}".yellow
+        puts Rainbow("LGFS fee scheme 10 fee type count after: #{scheme_10_fee_type_count}").yellow
       end
 
       def scheme_10_offence_count
@@ -149,18 +149,18 @@ module Seeds
 
       def copy_scheme_9_offences
         set_offence_pk_sequence(8000)
-        puts 'Adding LGFS fee scheme 10 offences'.yellow
+        puts Rainbow('Adding LGFS fee scheme 10 offences').yellow
 
         Offence.transaction do
           lgfs_scheme_nine_offences.each do |offence|
             if pretending?
-              puts "[WOULD-COPY] " + "#{offence.unique_code} => #{offence.unique_code}~10".yellow
+              puts Rainbow("[WOULD-COPY] " + "#{offence.unique_code} => #{offence.unique_code}~10").yellow
             else
               new_offence = offence.dup
               new_offence.unique_code += '~10'
               new_offence.fee_schemes << lgfs_fee_scheme_10
               new_offence.save!
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
@@ -170,8 +170,8 @@ module Seeds
 
       def set_offence_pk_sequence(sequence_start)
         if pretending?
-          print "Resetting offences sequence to max offence id unless Offence.ids.max > sequence_start (#{Offence.ids.max} > #{sequence_start})...".yellow
-          puts 'not resetting'.green
+          print Rainbow("Resetting offences sequence to max offence id unless Offence.ids.max > sequence_start (#{Offence.ids.max} > #{sequence_start})...").yellow
+          puts Rainbow('not resetting').green
           return
         end
         raise StandardError, "Sequence cannot be set to value less than greatest id in use - #{Offence.ids.max} > #{sequence_start}" if Offence.ids.max > sequence_start

--- a/db/seeds/schemas/add_lgfs_fee_scheme_11.rb
+++ b/db/seeds/schemas/add_lgfs_fee_scheme_11.rb
@@ -56,7 +56,7 @@ module Seeds
         Offence.transaction do
           Offence.joins(:fee_schemes).merge(FeeScheme.version(11)).merge(FeeScheme.lgfs).distinct.each do |offence|
             if pretending?
-              puts "[WOULD-REMOVE] Fee Scheme 11 from #{offence.unique_code}".yellow
+              puts Rainbow("[WOULD-REMOVE] Fee Scheme 11 from #{offence.unique_code}").yellow
             else
               offence.fee_schemes.delete(lgfs_fee_scheme_11)
               print '.'.green
@@ -64,14 +64,14 @@ module Seeds
           end
         end
         print "\n"
-        puts "LGFS Scheme 11 offence count after: #{lgfs_scheme_11_offence_count}".yellow
+        puts Rainbow("LGFS Scheme 11 offence count after: #{lgfs_scheme_11_offence_count}").yellow
       end
 
       def remove_lgfs_scheme_eleven_fee_type_roles
         lgfs_scheme_10_fee_types_with_lgfs_scheme_11_role = Fee::BaseFeeType.lgfs_scheme_10s.select { |ft| ft.roles.include?('lgfs_scheme_11') }
 
         if pretending?
-          puts "Would remove lgfs_scheme_11 role from #{lgfs_scheme_10_fee_types_with_lgfs_scheme_11_role.count} fee_types".yellow
+          puts Rainbow("Would remove lgfs_scheme_11 role from #{lgfs_scheme_10_fee_types_with_lgfs_scheme_11_role.count} fee_types").yellow
         else
           ActiveRecord::Base.transaction do
             lgfs_scheme_10_fee_types_with_lgfs_scheme_11_role.each do |ft|
@@ -79,80 +79,80 @@ module Seeds
               ft.save!
             end
           end
-          puts "Removed lgfs scheme 11 role from #{lgfs_scheme_10_fee_types_with_lgfs_scheme_11_role.count} fee_types".green
+          puts Rainbow("Removed lgfs scheme 11 role from #{lgfs_scheme_10_fee_types_with_lgfs_scheme_11_role.count} fee_types").green
         end
       end
 
       def destroy_lgfs_scheme_eleven
         if pretending?
-          puts "Would delete LGFS fee scheme 11: #{lgfs_fee_scheme_11&.attributes || 'does not exist'}".yellow
-          puts "Would reset fee_schemes PK sequence to max id value".yellow
+          puts Rainbow("Would delete LGFS fee scheme 11: #{lgfs_fee_scheme_11&.attributes || 'does not exist'}").yellow
+          puts Rainbow("Would reset fee_schemes PK sequence to max id value").yellow
         else
-          puts 'Deleted LGFS fee scheme 11'.green if lgfs_fee_scheme_11&.destroy
-          puts "Reset fee_schemes pk sequence to #{FeeScheme.ids.max}".green \
+          puts Rainbow('Deleted LGFS fee scheme 11').green if lgfs_fee_scheme_11&.destroy
+          puts Rainbow("Reset fee_schemes pk sequence to #{FeeScheme.ids.max}").green \
             if ActiveRecord::Base.connection.set_pk_sequence!('fee_schemes', FeeScheme.ids.max)
         end
       end
 
       def rollback_lgfs_scheme_ten
-        print "Finding LGFS fee scheme 10".yellow
+        print Rainbow("Finding LGFS fee scheme 10").yellow
         lgfs_fee_scheme_ten = FeeScheme.find_by(name: 'LGFS', version: 10)
-        lgfs_fee_scheme_ten ? print("...found\n".green) : print("...not found\n".red)
+        lgfs_fee_scheme_ten ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating LGFS fee scheme 10 end date to nil".yellow
-        print "...not updated\n".green if pretending?
+        print Rainbow("Updating LGFS fee scheme 10 end date to nil").yellow
+        print Rainbow("...not updated\n").green if pretending?
         return if pretending?
 
         lgfs_fee_scheme_ten.update(end_date: nil)
-        print "...updated\n".green
+        print Rainbow("...updated\n").green
       end
 
       def update_lgfs_scheme_ten
-        print "Finding LGFS fee scheme 10".yellow
+        print Rainbow("Finding LGFS fee scheme 10").yellow
         lgfs_fee_scheme_ten = FeeScheme.find_by(name: 'LGFS', version: 10)
-        lgfs_fee_scheme_ten ? print("...found\n".green) : print("...not found\n".red)
+        lgfs_fee_scheme_ten ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print "Updating LGFS fee scheme 10 end date to #{Settings.lgfs_scheme_11_release_date.end_of_day-1.day}".yellow
-        print "...not updated\n".green if pretending?
+        print Rainbow("Updating LGFS fee scheme 10 end date to #{Settings.lgfs_scheme_11_release_date.end_of_day-1.day}").yellow
+        print Rainbow("...not updated\n").green if pretending?
         return if pretending?
 
         lgfs_fee_scheme_ten.update(end_date: Settings.lgfs_scheme_11_release_date.end_of_day-1.day)
-        print "...updated\n".green
+        print Rainbow("...updated\n").green
       end
 
       def create_lgfs_scheme_eleven
-        print "Finding or creating LGFS fee scheme 11 with start date #{Settings.lgfs_scheme_11_release_date.beginning_of_day}...".yellow
-        print "...not created\n".green if pretending?
+        print Rainbow("Finding or creating LGFS fee scheme 11 with start date #{Settings.lgfs_scheme_11_release_date.beginning_of_day}...").yellow
+        print Rainbow("...not created\n").green if pretending?
         return if pretending?
 
         FeeScheme.find_or_create_by(name: 'LGFS', version: 11, start_date: Settings.lgfs_scheme_11_release_date.beginning_of_day)
-        print "...created\n".green
+        print Rainbow("...created\n").green
       end
 
       def set_lgfs_scheme_eleven_offences
-        puts 'Setting LGFS scheme 10 offences to include scheme 11'.yellow
-        puts "LGFS Scheme 11 offence count before: #{lgfs_scheme_11_offence_count}".yellow
+        puts Rainbow('Setting LGFS scheme 10 offences to include scheme 11').yellow
+        puts Rainbow("LGFS Scheme 11 offence count before: #{lgfs_scheme_11_offence_count}").yellow
         Offence.transaction do
           lgfs_scheme_ten_offences.each do |offence|
             if pretending?
-              puts "[WOULD-ADD] LGFS Fee Scheme 11 to #{offence.unique_code}".yellow
+              puts Rainbow("[WOULD-ADD] LGFS Fee Scheme 11 to #{offence.unique_code}").yellow
             else
               next if offence.fee_schemes.include? lgfs_fee_scheme_11
 
               offence.fee_schemes << lgfs_fee_scheme_11
-              print '.'.green
+              print Rainbow('.').green
             end
           end
         end
         print "\n"
-        puts "LGFS Scheme 11 offence count after: #{lgfs_scheme_11_offence_count}".yellow
+        puts Rainbow("LGFS Scheme 11 offence count after: #{lgfs_scheme_11_offence_count}").yellow
       end
 
       def create_lgfs_scheme_eleven_fee_types
-        puts "LGFS fee scheme 11 fee type count before: #{lgfs_scheme_11_fee_type_count}".yellow
+        puts Rainbow("LGFS fee scheme 11 fee type count before: #{lgfs_scheme_11_fee_type_count}").yellow
         require Rails.root.join('db', 'seeds', 'fee_types', 'csv_seeder')
         Seeds::FeeTypes::CsvSeeder.new(dry_mode: pretending?, stdout: false).call
-        puts "LGFS fee scheme 11 fee type count after: #{lgfs_scheme_11_fee_type_count}".yellow
+        puts Rainbow("LGFS fee scheme 11 fee type count after: #{lgfs_scheme_11_fee_type_count}").yellow
       end
 
       def lgfs_scheme_11_offence_count

--- a/db/seeds/schemas/clean_agfs_offences.rb
+++ b/db/seeds/schemas/clean_agfs_offences.rb
@@ -58,13 +58,13 @@ module Seeds
               unlink_redundant(offence)
             else
               if pretending?
-                puts "    [WOULD-UPDATE] Unique code of #{offence.unique_code}".yellow unless @quiet
+                puts Rainbow("    [WOULD-UPDATE] Unique code of #{offence.unique_code}").yellow unless @quiet
               else
-                puts "    [UPDATE] Unique code of #{offence.unique_code}".green unless @quiet
-                puts "      [BEFORE] #{offence.unique_code}".green unless @quiet
+                puts Rainbow("    [UPDATE] Unique code of #{offence.unique_code}").green unless @quiet
+                puts Rainbow("      [BEFORE] #{offence.unique_code}").green unless @quiet
                 offence.unique_code.gsub!('~11', '')
                 offence.save!
-                puts "      [AFTER] #{offence.unique_code}".green unless @quiet
+                puts Rainbow("      [AFTER] #{offence.unique_code}").green unless @quiet
               end
             end
           end
@@ -132,20 +132,20 @@ module Seeds
         offences.each do |offence|
           if pretending?
             if offence.fee_schemes.empty?
-              puts "    [WOULD-REMOVE] #{offence.unique_code}".yellow unless @quiet
+              puts Rainbow("    [WOULD-REMOVE] #{offence.unique_code}").yellow unless @quiet
             else
-              puts "    [WOULD-NOT-REMOVE] #{offence.unique_code}".yellow unless @quiet
+              puts Rainbow("    [WOULD-NOT-REMOVE] #{offence.unique_code}").yellow unless @quiet
             end
             puts "      Fee schemes: #{offence.description}" unless @quiet
             puts "      Fee schemes: #{display_fee_schemes(*offence.fee_schemes)}" unless @quiet
           else
             if offence.fee_schemes.empty?
-              puts "    [REMOVE] #{offence.unique_code}".green unless @quiet
+              puts Rainbow("    [REMOVE] #{offence.unique_code}").green unless @quiet
               puts "      Fee schemes: #{offence.description}" unless @quiet
               puts "      Fee schemes: #{display_fee_schemes(*offence.fee_schemes)}" unless @quiet
               offence.destroy
             else
-              puts "    [NOT-REMOVING] #{offence.unique_code}".yellow unless @quiet
+              puts Rainbow("    [NOT-REMOVING] #{offence.unique_code}").yellow unless @quiet
               puts "      Fee schemes: #{offence.description}" unless @quiet
               puts "      Fee schemes: #{display_fee_schemes(*offence.fee_schemes)}" unless @quiet
             end
@@ -186,61 +186,61 @@ module Seeds
 
       def update_claims(claims, new_offence)
         if pretending?
-          puts "    [WOULD-UPDATE] #{claims.count} claims".yellow unless @quiet
+          puts Rainbow("    [WOULD-UPDATE] #{claims.count} claims").yellow unless @quiet
         else
-          puts "    [UPDATE] #{claims.count} claims".green unless @quiet
+          puts Rainbow("    [UPDATE] #{claims.count} claims").green unless @quiet
           claims.update_all(offence_id: new_offence.id)
         end
       end
 
       def update_claims_with_ids(claims, new_offence)
         if pretending?
-          puts "    [WOULD-UPDATE] #{claims.count} claims".yellow unless @quiet
+          puts Rainbow("    [WOULD-UPDATE] #{claims.count} claims").yellow unless @quiet
         else
-          puts "    [UPDATE] #{claims.count} claims".green unless @quiet
+          puts Rainbow("    [UPDATE] #{claims.count} claims").green unless @quiet
           Claim::BaseClaim.where(id: claims.map(&:id)).update_all(offence_id: new_offence.id)
         end
       end
 
       def copy_schemes(from:, to:)
         if pretending?
-          puts "    [WOULD-COPY] Fee schemes #{display_fee_schemes(*from.fee_schemes)} from offence #{from.unique_code} to offence #{to.unique_code}".yellow unless @quiet
+          puts Rainbow("    [WOULD-COPY] Fee schemes #{display_fee_schemes(*from.fee_schemes)} from offence #{from.unique_code} to offence #{to.unique_code}").yellow unless @quiet
         else
-          puts "    [COPY] Fee schemes #{display_fee_schemes(*from.fee_schemes)} from offence #{from.unique_code} to offence #{to.unique_code}".green unless @quiet
-          puts "      [UPDATE] Before: #{display_fee_schemes(*to.fee_schemes)}".green unless @quiet
+          puts Rainbow("    [COPY] Fee schemes #{display_fee_schemes(*from.fee_schemes)} from offence #{from.unique_code} to offence #{to.unique_code}").green unless @quiet
+          puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*to.fee_schemes)}").green unless @quiet
           to.fee_schemes.append(*from.fee_schemes)
           to.reload
-          puts "      [UPDATE] After: #{display_fee_schemes(*to.fee_schemes)}".green unless @quiet
+          puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*to.fee_schemes)}").green unless @quiet
         end
       end
 
       def add_scheme_twelve_to(offence)
         if pretending?
-          puts "    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_twelve)}' to offence #{offence.unique_code}".yellow unless @quiet
+          puts Rainbow("    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_twelve)}' to offence #{offence.unique_code}").yellow unless @quiet
         else
-          puts "    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_twelve)}' to offence #{offence.unique_code}".green unless @quiet
-          puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+          puts Rainbow("    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_twelve)}' to offence #{offence.unique_code}").green unless @quiet
+          puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
           offence.fee_schemes << fee_scheme_twelve
           offence.reload
-          puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+          puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
         end
       end
 
       def add_scheme_thirteen_to(offence)
         if pretending?
-          puts "    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_thirteen)}' to offence #{offence.unique_code}".yellow unless @quiet
+          puts Rainbow("    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_thirteen)}' to offence #{offence.unique_code}").yellow unless @quiet
         else
-          puts "    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_thirteen)}' to offence #{offence.unique_code}".green unless @quiet
-          puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+          puts Rainbow("    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_thirteen)}' to offence #{offence.unique_code}").green unless @quiet
+          puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
           offence.fee_schemes << fee_scheme_thirteen
           offence.reload
-          puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+          puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
         end
       end
 
       def restore_scheme_eleven_offence_for(offence, claims)
         if offence.unique_code.match(/~/)
-          puts "    [NOT-UPDATING] Offence #{offence.unique_code}".yellow
+          puts Rainbow("    [NOT-UPDATING] Offence #{offence.unique_code}").yellow
           return
         end
 
@@ -248,92 +248,92 @@ module Seeds
         if new_offence
           # Scheme 11 has exact copy of scheme 10 offence
           if pretending?
-            puts "    [WOULD-REMOVE] Fee schemes 11, 14 and 15 from offence #{offence.unique_code}".yellow unless @quiet
-            puts "    [WOULD-ADD] Fee schemes 11, 14 and 15 to offence #{new_offence.unique_code}".yellow unless @quiet
-            puts "    [WOULD-UPDATE] Move #{claims.count} fee scheme 11, 14 and 15 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}".yellow unless @quiet
+            puts Rainbow("    [WOULD-REMOVE] Fee schemes 11, 14 and 15 from offence #{offence.unique_code}").yellow unless @quiet
+            puts Rainbow("    [WOULD-ADD] Fee schemes 11, 14 and 15 to offence #{new_offence.unique_code}").yellow unless @quiet
+            puts Rainbow("    [WOULD-UPDATE] Move #{claims.count} fee scheme 11, 14 and 15 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}").yellow unless @quiet
           else
-            puts "    [REMOVE] Fee schemes 11, 14 and 15 from offence #{offence.unique_code}".green unless @quiet
-            puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+            puts Rainbow("    [REMOVE] Fee schemes 11, 14 and 15 from offence #{offence.unique_code}").green unless @quiet
+            puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
             offence.fee_schemes.delete(fee_scheme_eleven)
             offence.fee_schemes.delete(fee_scheme_fourteen)
             offence.fee_schemes.delete(fee_scheme_fifteen)
-            puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet    
-            puts "    [ADD] Fee schemes 11, 14 and 15 to offence #{new_offence.unique_code}".green unless @quiet
-            puts "      [UPDATE] Before: #{display_fee_schemes(*new_offence.fee_schemes)}".green unless @quiet
+            puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
+            puts Rainbow("    [ADD] Fee schemes 11, 14 and 15 to offence #{new_offence.unique_code}").green unless @quiet
+            puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*new_offence.fee_schemes)}").green unless @quiet
             new_offence.fee_schemes = [fee_scheme_eleven, fee_scheme_fourteen, fee_scheme_fifteen]
-            puts "      [UPDATE] After: #{display_fee_schemes(*new_offence.fee_schemes)}".green unless @quiet    
-            puts "    [UPDATE] Move #{claims.count} fee scheme 11, 14 and 15 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}".green unless @quiet
+            puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*new_offence.fee_schemes)}").green unless @quiet
+            puts Rainbow("    [UPDATE] Move #{claims.count} fee scheme 11, 14 and 15 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}").green unless @quiet
             update_claims_with_ids(claims, new_offence)
           end
         elsif !offence.fee_schemes.include?(fee_scheme_ten)
           # Offence in scheme 11 is in a different band from offence in scheme 10 so new offence record exists
           if pretending?
-            puts "    [WOULD-UPDATE] Offence code #{offence.unique_code} to #{offence.unique_code}~11".yellow unless @quiet
+            puts Rainbow("    [WOULD-UPDATE] Offence code #{offence.unique_code} to #{offence.unique_code}~11").yellow unless @quiet
           else
-            puts "    [UPDATE] Offence code #{offence.unique_code} to #{offence.unique_code}~11".green unless @quiet
+            puts Rainbow("    [UPDATE] Offence code #{offence.unique_code} to #{offence.unique_code}~11").green unless @quiet
             offence.unique_code = "#{offence.unique_code}~11"
             offence.save!
           end
         else
-          puts "    [FAILURE] Offence code #{offence.unique_code} linked to fee scheme 10 but with no separate fee scheme 11 offence".red unless @quiet
+          puts Rainbow("    [FAILURE] Offence code #{offence.unique_code} linked to fee scheme 10 but with no separate fee scheme 11 offence").red unless @quiet
         end
       end
 
       def restore_scheme_twelve_offence_for(offence, claims)
         if offence.unique_code.match(/~/) && !offence.unique_code.match(/~11/)
-          puts "    [NOT-DUPLICATING] Offence #{offence.unique_code}".yellow
+          puts Rainbow("    [NOT-DUPLICATING] Offence #{offence.unique_code}").yellow
           return
         end
 
         new_offence = Offence.find_by(unique_code: "#{offence.unique_code.gsub('~11', '')}~12")
         if new_offence
           if pretending?
-            puts "    [WOULD-REMOVE] Fee schemes 12 from offence #{offence.unique_code}".yellow unless @quiet
-            puts "    [WOULD-ADD] Fee schemes 12 to offence #{new_offence.unique_code}".yellow unless @quiet
-            puts "    [WOULD-UPDATE] Move #{claims.count} fee scheme 12 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}".yellow unless @quiet
+            puts Rainbow("    [WOULD-REMOVE] Fee schemes 12 from offence #{offence.unique_code}").yellow unless @quiet
+            puts Rainbow("    [WOULD-ADD] Fee schemes 12 to offence #{new_offence.unique_code}").yellow unless @quiet
+            puts Rainbow("    [WOULD-UPDATE] Move #{claims.count} fee scheme 12 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}").yellow unless @quiet
           else
-            puts "    [REMOVE] Fee schemes 12 from offence #{offence.unique_code}".green unless @quiet
-            puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+            puts Rainbow("    [REMOVE] Fee schemes 12 from offence #{offence.unique_code}").green unless @quiet
+            puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
             offence.fee_schemes.delete(fee_scheme_twelve)
-            puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet    
-            puts "    [ADD] Fee schemes 12 to offence #{new_offence.unique_code}".green unless @quiet
-            puts "      [UPDATE] Before: #{display_fee_schemes(*new_offence.fee_schemes)}".green unless @quiet
+            puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
+            puts Rainbow("    [ADD] Fee schemes 12 to offence #{new_offence.unique_code}").green unless @quiet
+            puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*new_offence.fee_schemes)}").green unless @quiet
             new_offence.fee_schemes = [fee_scheme_twelve]
-            puts "      [UPDATE] After: #{display_fee_schemes(*new_offence.fee_schemes)}".green unless @quiet    
-            puts "    [UPDATE] Move #{claims.count} fee scheme 12 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}".green unless @quiet
+            puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*new_offence.fee_schemes)}").green unless @quiet
+            puts Rainbow("    [UPDATE] Move #{claims.count} fee scheme 12 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}").green unless @quiet
             update_claims_with_ids(claims, new_offence)
           end
         else
-          puts "    [FAILURE] Unable to find offence for fee scheme twelve for #{offence.unique_code}".red unless @quiet
+          puts Rainbow("    [FAILURE] Unable to find offence for fee scheme twelve for #{offence.unique_code}").red unless @quiet
         end
       end
 
       def restore_scheme_thirteen_offence_for(offence, claims)
         if offence.unique_code.match(/~/) && !offence.unique_code.match(/~11/)
-          puts "    [NOT-DUPLICATING] Offence #{offence.unique_code}".yellow
+          puts Rainbow("    [NOT-DUPLICATING] Offence #{offence.unique_code}").yellow
           return
         end
 
         new_offence = Offence.find_by(unique_code: "#{offence.unique_code.gsub('~11', '')}~13")
         if new_offence
           if pretending?
-            puts "    [WOULD-REMOVE] Fee schemes 13 from offence #{offence.unique_code}".yellow unless @quiet
-            puts "    [WOULD-ADD] Fee schemes 13 to offence #{new_offence.unique_code}".yellow unless @quiet
-            puts "    [WOULD-UPDATE] Move #{claims.count} fee scheme 13 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}".yellow unless @quiet
+            puts Rainbow("    [WOULD-REMOVE] Fee schemes 13 from offence #{offence.unique_code}").yellow unless @quiet
+            puts Rainbow("    [WOULD-ADD] Fee schemes 13 to offence #{new_offence.unique_code}").yellow unless @quiet
+            puts Rainbow("    [WOULD-UPDATE] Move #{claims.count} fee scheme 13 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}").yellow unless @quiet
           else
-            puts "    [REMOVE] Fee schemes 13 from offence #{offence.unique_code}".green unless @quiet
-            puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+            puts Rainbow("    [REMOVE] Fee schemes 13 from offence #{offence.unique_code}").green unless @quiet
+            puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
             offence.fee_schemes.delete(fee_scheme_thirteen)
-            puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet    
-            puts "    [ADD] Fee schemes 13 to offence #{new_offence.unique_code}".green unless @quiet
-            puts "      [UPDATE] Before: #{display_fee_schemes(*new_offence.fee_schemes)}".green unless @quiet
+            puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
+            puts Rainbow("    [ADD] Fee schemes 13 to offence #{new_offence.unique_code}").green unless @quiet
+            puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*new_offence.fee_schemes)}").green unless @quiet
             new_offence.fee_schemes = [fee_scheme_thirteen]
-            puts "      [UPDATE] After: #{display_fee_schemes(*new_offence.fee_schemes)}".green unless @quiet    
-            puts "    [UPDATE] Move #{claims.count} fee scheme 13 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}".green unless @quiet
+            puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*new_offence.fee_schemes)}").green unless @quiet
+            puts Rainbow("    [UPDATE] Move #{claims.count} fee scheme 13 claims (out of #{offence.claims.count}) to #{new_offence.unique_code}").green unless @quiet
             update_claims_with_ids(claims, new_offence)
           end
         else
-          puts "    [FAILURE] Unable to find offence for fee scheme thirteen for #{offence.unique_code}".red unless @quiet
+          puts Rainbow("    [FAILURE] Unable to find offence for fee scheme thirteen for #{offence.unique_code}").red unless @quiet
         end
       end
 
@@ -343,13 +343,13 @@ module Seeds
 
       def unlink_redundant(offence)
         if pretending?
-          puts "    [WOULD-DETATCH] Fee schemes #{display_fee_schemes(*offence.fee_schemes)} (all) from offence #{offence.unique_code}".yellow unless @quiet
+          puts Rainbow("    [WOULD-DETATCH] Fee schemes #{display_fee_schemes(*offence.fee_schemes)} (all) from offence #{offence.unique_code}").yellow unless @quiet
         else
-          puts "    [DETATCH] Fee schemes #{display_fee_schemes(*offence.fee_schemes)} (all) from offence #{offence.unique_code}".green unless @quiet
-          puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+          puts Rainbow("    [DETATCH] Fee schemes #{display_fee_schemes(*offence.fee_schemes)} (all) from offence #{offence.unique_code}").green unless @quiet
+          puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
           offence.fee_schemes = []
           offence.reload
-          puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+          puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
         end
       end
 
@@ -360,7 +360,7 @@ module Seeds
           other_unique_code = unique_code.gsub(fee_scheme_marker, other_fee_scheme_marker)
           other_offence = Offence.find_by(unique_code: other_unique_code)
           if !other_offence
-            puts "    #{unique_code}: No equivalent offence".red
+            puts Rainbow("    #{unique_code}: No equivalent offence").red
             generic_unique_code = unique_code.gsub(/_.*/, '')
             generic_offences = Offence.where('unique_code LIKE ?', "#{generic_unique_code}%")
             puts "      #{offence.description}"
@@ -369,7 +369,7 @@ module Seeds
               puts "      #{o.unique_code}: #{offence.description == o.description ? 'Description matches'.green : 'Description does not match'.red }"
             end
           elsif !offences_match?(offence, other_offence)
-            puts "    #{unique_code}: Equivalent offence does not match".red
+            puts Rainbow("    #{unique_code}: Equivalent offence does not match").red
           end
           claim_count += offence.claims.count
         end

--- a/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
+++ b/db/seeds/schemas/clean_lgfs_fee_scheme_10.rb
@@ -84,7 +84,7 @@ module Seeds
 
       def create_scheme_ten_offence_for(offence)
         if offence.unique_code.match(/~10/)
-          puts "    [NOT-DUPLICATING] Offence #{offence.unique_code}".yellow
+          puts Rainbow("    [NOT-DUPLICATING] Offence #{offence.unique_code}").yellow
           return
         end
         begin
@@ -95,14 +95,14 @@ module Seeds
           # claims = offence.claims.select { |claim| claim.fee_scheme == fee_scheme_ten }
           raise SchemeTenOffenceExists unless new_offence.valid?
           if pretending?
-            puts "    [WOULD-CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}".yellow unless @quiet
-            puts "    [WOULD-REMOVE] Fee scheme 10 from offence #{offence.unique_code}".yellow unless @quiet
+            puts Rainbow("    [WOULD-CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}").yellow unless @quiet
+            puts Rainbow("    [WOULD-REMOVE] Fee scheme 10 from offence #{offence.unique_code}").yellow unless @quiet
             # puts "    [WOULD-UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".yellow unless @quiet
           else
-            puts "    [CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}".green unless @quiet
+            puts Rainbow("    [CREATE] Offence #{new_offence.id}/#{new_offence.unique_code}").green unless @quiet
             new_offence.save!
-            puts "      [SUCCESS]".green unless @quiet
-            puts "    [REMOVE] Fee scheme 10 from offence #{offence.unique_code}".green unless @quiet
+            puts Rainbow("      [SUCCESS]").green unless @quiet
+            puts Rainbow("    [REMOVE] Fee scheme 10 from offence #{offence.unique_code}").green unless @quiet
             offence.fee_schemes.delete(fee_scheme_ten)
             # puts "    [UPDATE] Move #{claims.count} fee scheme 10 claims (out of #{offence.claims.count}) to new offence".green unless @quiet
             # # It should be possible to do update_claims(claims, new_offence) but claims is an array instead of an ActiveRecord collection
@@ -116,7 +116,7 @@ module Seeds
             # end
           end
         rescue SchemeTenOffenceExists, ActiveRecord::RecordNotUnique
-          puts "      [FAILED]".red unless @quiet
+          puts Rainbow("      [FAILED]").red unless @quiet
         end
       end
 
@@ -128,22 +128,22 @@ module Seeds
 
       def update_claims(claims, new_offence)
         if pretending?
-          puts "    [WOULD-UPDATE] #{claims.count} claims".yellow unless @quiet
+          puts Rainbow("    [WOULD-UPDATE] #{claims.count} claims").yellow unless @quiet
         else
-          puts "    [UPDATE] #{claims.count} claims".green unless @quiet
+          puts Rainbow("    [UPDATE] #{claims.count} claims").green unless @quiet
           claims.update_all(offence_id: new_offence.id)
         end
       end
 
       def add_scheme_ten_to(offence)
         if pretending?
-          puts "    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}".yellow unless @quiet
+          puts Rainbow("    [WOULD-UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}").yellow unless @quiet
         else
-          puts "    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}".green unless @quiet
-          puts "      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+          puts Rainbow("    [UPDATE] Add fee scheme '#{display_fee_schemes(fee_scheme_ten)}' to offence #{offence.unique_code}").green unless @quiet
+          puts Rainbow("      [UPDATE] Before: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
           offence.fee_schemes << fee_scheme_ten
           offence.reload
-          puts "      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}".green unless @quiet
+          puts Rainbow("      [UPDATE] After: #{display_fee_schemes(*offence.fee_schemes)}").green unless @quiet
         end
       end
 
@@ -153,9 +153,9 @@ module Seeds
 
       def remove_redundant(offence)
         if pretending?
-          puts "    [WOULD-REMOVE] Offence #{offence.unique_code}".yellow unless @quiet
+          puts Rainbow("    [WOULD-REMOVE] Offence #{offence.unique_code}").yellow unless @quiet
         else
-          puts "    [REMOVE] Offence #{offence.unique_code}".green unless @quiet
+          puts Rainbow("    [REMOVE] Offence #{offence.unique_code}").green unless @quiet
           offence.destroy
         end
       end

--- a/docs/creating_a_new_fee_scheme.md
+++ b/docs/creating_a_new_fee_scheme.md
@@ -63,7 +63,7 @@ Add the new role to `app/models/fee/base_fee_type.rb`:
 # app/models/fee/base_fee_type.rb
 ROLES = %w[
   lgfs lgfs_scheme_9 lgfs_scheme_10 lgfs_scheme_11
-  agfs agfs_scheme_9 agfs_scheme_10 agfs_scheme_12 agfs_scheme_13 
+  agfs agfs_scheme_9 agfs_scheme_10 agfs_scheme_12 agfs_scheme_13
   agfs_scheme_14 agfs_scheme_15 agfs_scheme_16 agfs_scheme_17
 ].freeze
 ```
@@ -157,7 +157,7 @@ Add a scope and query method in `app/models/offence.rb`:
 class Offence < ApplicationRecord
   # Add scope to find offences in the new scheme
   scope :in_scheme_17, -> { joins(:fee_schemes).merge(FeeScheme.agfs.where(version: 17)) }
-  
+
   # Method to determine if offence is valid for the new fee scheme
   def scheme_seventeen?
     fee_schemes.map(&:version).any?(17)
@@ -186,9 +186,9 @@ Update `app/services/claims/fetch_eligible_misc_fee_types.rb`:
 class Claims::FetchEligibleMiscFeeTypes
   # Add delegation
   delegate :agfs_scheme_17?, to: :claim
-  
+
   private
-  
+
   # Update scheme scope determination
   def agfs_scheme_scope
       return Fee::MiscFeeType.agfs_scheme_17s if agfs_scheme_17?
@@ -207,12 +207,12 @@ end
 ### Step 8: Update Claim::TransferBrain::DataItem model
 
 > [!NOTE]
-> This is only necessary for LGFS fee schemes. An update may only be required if the new fee scheme includes a change to the 
+> This is only necessary for LGFS fee schemes. An update may only be required if the new fee scheme includes a change to the
 > logic governing transfer cases
 
-The Claim::TransferBrain::DataItem model contains logic used for LGFS transfer claims. The rules for transfer claims changed 
+The Claim::TransferBrain::DataItem model contains logic used for LGFS transfer claims. The rules for transfer claims changed
 after LGFS fee scheme 9. This class contains two methods used to override the `==` operater depending on fee scheme in effect.
-The `equal_for_scheme_nine?` and `equal_for_scheme_ten_or_later?` methods are used to do this. If the rules around transfer 
+The `equal_for_scheme_nine?` and `equal_for_scheme_ten_or_later?` methods are used to do this. If the rules around transfer
 claims change again in a future fee scheme, it may be necessary to update this class.
 
 For example by renaming `equal_for_scheme_ten_or_later?` to `equal_for_scheme_ten_or_eleven` and creating `equal_for_scheme_twelve?`
@@ -347,7 +347,7 @@ namespace :agfs do
       pretend = !not_pretend
 
       continue?('This will seed data for AGFS Fee Scheme 17. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -364,7 +364,7 @@ namespace :agfs do
       pretend = !not_pretend
 
       continue?('This will rollback data for AGFS Fee Scheme 17. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -410,7 +410,7 @@ Update `spec/factories/offences.rb`:
 FactoryBot.define do
   factory :offence do
     # ... existing code ...
-    
+
     trait :with_fee_scheme_seventeen do
       offence_class { nil }
       offence_band
@@ -431,7 +431,7 @@ Update `spec/factories/fee_scheme.rb`:
 FactoryBot.define do
   factory :fee_scheme do
     # ... existing code ...
-    
+
     # Update previous scheme trait with end date
     trait :agfs_sixteen do
       name { 'AGFS' }
@@ -439,7 +439,7 @@ FactoryBot.define do
       start_date { Settings.agfs_scheme_16_start_date }
       end_date { Settings.agfs_scheme_17_start_date - 1.day }
     end
-    
+
     # Add new scheme trait
     trait :agfs_seventeen do
       name { 'AGFS' }
@@ -510,14 +510,14 @@ Update `spec/support/scheme_date_helpers.rb`:
 # spec/support/scheme_date_helpers.rb
 module SchemeDateHelpers
   # ... existing code ...
-  
+
   def scheme_date_mappings
     {
       'scheme 17' => Settings.agfs_scheme_17_start_date.strftime,
       # Existing dates
     }
   end
-  
+
   def main_hearing_date_mappings
     {
       'scheme 17' => Settings.agfs_scheme_17_start_date.strftime,
@@ -536,13 +536,13 @@ Update `spec/support/seed_helpers.rb`:
 module SeedHelpers
   def self.seed_fee_schemes
     # ... existing schemes ...
-    
+
     # Update previous scheme with end date
     FeeScheme.find_or_create_by!(name: 'AGFS', version: 16) do |fs|
       fs.start_date = Settings.agfs_scheme_16_start_date
       fs.end_date = Settings.agfs_scheme_17_start_date - 1.day
     end
-    
+
     # Create new scheme
     FeeScheme.find_or_create_by!(name: 'AGFS', version: 17) do |fs|
       fs.start_date = Settings.agfs_scheme_17_start_date
@@ -566,13 +566,13 @@ The fee scheme factory finds the correct fee scheme based on the representation
 order and main hearing date. The main hearing date was introduced specifically
 for AGFS fee scheme 13 and LGFS fee scheme 10 which applied to earlier
 representation order dates depending on this main hearing date. It was not used
-again in subsequent fee schemes and this is reflected in the spec files. 
+again in subsequent fee schemes and this is reflected in the spec files.
 
-In the AGFS tests there are shared examples for fee schemes 9 to 11 and a separate 
+In the AGFS tests there are shared examples for fee schemes 9 to 11 and a separate
 set of shared examples for fee schemes 12 onwards. This is to accommodate the
 special case of fee schemes 12 and 13. In the LGFS tests there are shared examples
 for fee schemes 9 and 10 which accommodate this special case, and a separate set
-of shared examples for fee schemes 11 onwards for fee schemes where the main 
+of shared examples for fee schemes 11 onwards for fee schemes where the main
 hearing date is not relevant.
 
 #### Base fee type spec
@@ -593,10 +593,10 @@ Update `spec/services/claims/fetch_eligible_advocate_categories_spec.rb`:
 # spec/services/claims/fetch_eligible_advocate_categories_spec.rb
 RSpec.describe Claims::FetchEligibleAdvocateCategories do
   # ... existing code ...
-  
+
   context 'with AGFS scheme 17 claim' do
     let(:claim) { create(:advocate_claim, :agfs_scheme_17) }
-    
+
     it 'returns correct categories' do
       # Test appropriate categories for scheme 17
     end
@@ -642,14 +642,14 @@ Update `spec/models/claim/transfer_brain/data_item_spec.rb` if changes have been
 Update `spec/services/stats/fee_scheme_usage_generator_spec.rb` and `spec/services/stats/graphs/six_month_period_spec.rb`
 to include the new fee scheme in specs that test the visualisation of fee scheme usage.
 
-A test in `spec/requests/super_admins/stats_request_spec.rb` will fail if the number of fee schemes is greater than or equal 
+A test in `spec/requests/super_admins/stats_request_spec.rb` will fail if the number of fee schemes is greater than or equal
 to the number of colours defined for use by the ChartKick library. If this occurs, it can fixed by adding additional colours
 to the `@chart_colours` variable in `app/controllers/super_admins/stats_controller.rb`.
 
 ### Step 15: Create Feature Tests
 
 Create new feature tests in `features/claims/advocate/` (or `features/claims/litigator/`).
-These can be copied from the previous fee scheme and modified. 
+These can be copied from the previous fee scheme and modified.
 
 These tests assert that the fee values returned from Fee Calculator are correct. To test
 this. It will be necessary to initially run these tests using the `FEE_CALC_VCR_MODE=new_episodes`
@@ -661,13 +661,13 @@ changes implemented.
 ### Step 16: Update API release notes
 
 Update `app/views/pages/api_release_notes.html.haml` to provide details of the new fee scheme to
-software vendors who maintain case management systems that integrate with the CCCD API and may need 
+software vendors who maintain case management systems that integrate with the CCCD API and may need
 to make changes to their software.
 
 ### Step 17: Enable manual testing
 
-Manual testing will need to be carried out before the start date of the new fee scheme. CCCD does 
-not allow the creation of claims with dates in the future. To facilitate this testing, the 
+Manual testing will need to be carried out before the start date of the new fee scheme. CCCD does
+not allow the creation of claims with dates in the future. To facilitate this testing, the
 `ALLOW_FUTURE_DATES` flag can be set to `true` in the `app-config.yaml` file for the appropriate
 environment.
 

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -58,6 +58,9 @@ end
 
 Given(/^I am later on the Your claims page$/) do
   @external_user_home_page.load
+  patiently do
+    expect(@external_user_home_page).to be_displayed
+  end
 end
 
 When(/I click the claim '(.*?)'$/) do |case_number|

--- a/features/super_admins/stats.feature
+++ b/features/super_admins/stats.feature
@@ -5,7 +5,7 @@ Feature: Stats
     Given I am a signed in super admin
     Given I have created test claims for "10/08/2022"
     When I visit "/super_admins/stats"
-    And I enter the From date "01/8/2022"
-    And I enter the To date "31/8/2022"
+    And I enter the From date "01/08/2022"
+    And I enter the To date "31/08/2022"
     And I click Update
     Then the Javascript variable createChart should change

--- a/lib/data_migrator/offence_unique_code_migrator.rb
+++ b/lib/data_migrator/offence_unique_code_migrator.rb
@@ -1,4 +1,5 @@
 require_relative 'offence_code_generator'
+require 'rainbow'
 
 module DataMigrator
   class OffenceUniqueCodeMigrator
@@ -39,8 +40,8 @@ module DataMigrator
         sql = "UPDATE offences SET unique_code = '#{code}' WHERE id = #{offence[:id]}"
         @offences.connection.execute sql
       end
-      out "codes generated: #{offence_set.count}".green
-      out "unique codes generated: #{offence_set.keys.uniq.count}".green
+      out Rainbow("codes generated: #{offence_set.count}").green
+      out Rainbow("unique codes generated: #{offence_set.keys.uniq.count}").green
     end
 
     def pretend(format: :text)
@@ -75,15 +76,17 @@ module DataMigrator
     def output(code, offence, format)
       case format.downcase.to_sym
       when :sql
-        puts "UPDATE offences SET unique_code = #{code} WHERE id = #{offence[:id]}".yellow
+        puts Rainbow("UPDATE offences SET unique_code = #{code} WHERE id = #{offence[:id]}").yellow
       when :diff
         unless offence[:unique_code].eql?(code)
-          puts offence[:description].concat("\n -#{offence[:unique_code]}".red).concat("\n +#{code} ".green)
+          puts Rainbow(offence[:description]
+                         .concat(Rainbow("\n -#{offence[:unique_code]}").red)
+                         .concat(Rainbow("\n +#{code} ")).green)
         end
       when :csv
         puts [offence[:description], offence[:band] || offence[:class_letter], code].to_csv
       when :text
-        puts "-- [would have] updated #{offence[:description]},#{offence[:band] || offence[:class_letter]}".white.concat(" unique_code: #{offence[:unique_code]} --> #{code}".green)
+        puts Rainbow("-- [would have] updated #{offence[:description]},#{offence[:band] || offence[:class_letter]}").white.concat(Rainbow(" unique_code: #{offence[:unique_code]} --> #{code}").green)
       end
     end
   end

--- a/lib/demo_data/base_claim_generator.rb
+++ b/lib/demo_data/base_claim_generator.rb
@@ -114,7 +114,7 @@ module DemoData
       begin
         ClaimStateAdvancer.new(claim).advance_to(state)
       rescue => err
-        puts "ERROR: #{err.class} :: #{err.message}".red
+        puts Rainbow("ERROR: #{err.class} :: #{err.message}").red
         raise err
       end
     end

--- a/lib/tasks/agfs_scheme_fifteen.rake
+++ b/lib/tasks/agfs_scheme_fifteen.rake
@@ -17,7 +17,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will seed data for AGFS Fee Scheme 15 (Additional Preparation Fee & KC - April 2023). Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -36,7 +36,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will destroy AGFS Fee Scheme 15 (Additional Preparation Fee & KC - April 2023), offences and fee types. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       adder = Seeds::Schemas::AddAGFSFeeScheme15.new(pretend: pretend)
       adder.down

--- a/lib/tasks/agfs_scheme_fourteen.rake
+++ b/lib/tasks/agfs_scheme_fourteen.rake
@@ -17,7 +17,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will seed data for AGFS Fee Scheme 14 (Section 28 - February 2023). Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -36,7 +36,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will destroy AGFS Fee Scheme 14 (Section 28 - February 2023), offences and fee types. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       adder = Seeds::Schemas::AddAGFSFeeScheme14.new(pretend: pretend)
       adder.down

--- a/lib/tasks/agfs_scheme_offences_clean.rake
+++ b/lib/tasks/agfs_scheme_offences_clean.rake
@@ -17,8 +17,8 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will merge AGFS fee scheme 12 and 13 offences into AGFS fee scheme 11. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
-      
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
+
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
       cleaner = Seeds::Schemas::CleanAgfsOffences.new(pretend: pretend)
@@ -37,7 +37,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will recreate spearate offences for AGFS fee scheme 12 and 13. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -55,7 +55,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will all offences that are not linked to a fee scheme. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1

--- a/lib/tasks/agfs_scheme_sixteen.rake
+++ b/lib/tasks/agfs_scheme_sixteen.rake
@@ -17,7 +17,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will seed data for AGFS Fee Scheme 16 (Section 28 Fee Increase - November 2023). Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -36,7 +36,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will destroy AGFS Fee Scheme 16 (Section 28 Fee Increase - November 2023), offences and fee types. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       adder = Seeds::Schemas::AddAGFSFeeScheme16.new(pretend: pretend)
       adder.down

--- a/lib/tasks/agfs_scheme_thirteen.rake
+++ b/lib/tasks/agfs_scheme_thirteen.rake
@@ -17,7 +17,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will seed data for AGFS Fee Scheme 13 (CLAIR - September 2022). Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -35,7 +35,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will destroy AGFS Fee Scheme 13 (CLAIR - September 2022), offences and fee types. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       adder = Seeds::Schemas::AddAGFSFeeScheme13.new(pretend: pretend)
       adder.down

--- a/lib/tasks/brakeman.rake
+++ b/lib/tasks/brakeman.rake
@@ -15,9 +15,9 @@ namespace :brakeman do
     time_taken = (report.scan_info.end_time.to_datetime.to_f - report.scan_info.start_time.to_datetime.to_f).to_i
 
     if report.warnings.size > 0
-      puts "New warnings: #{report.warnings.size} - see #{report_output.first} for details".red
+      puts Rainbow("New warnings: #{report.warnings.size} - see #{report_output.first} for details").red
     else
-      puts "No new warnings".green
+      puts Rainbow("No new warnings").green
     end
     puts "Finished in #{time_taken} seconds"
     puts "warnings: #{report.ignored_warnings.size}, new warnings: #{report.warnings.size}, errors: #{report.errors.size}"

--- a/lib/tasks/ci.rake
+++ b/lib/tasks/ci.rake
@@ -8,7 +8,7 @@ namespace :ci do
     Rake::Task['jasmine:run'].invoke
     Rake::Task['spec'].invoke
     duration = 5
-    puts "Info: Sleeping for #{duration} seconds to give CPU time to cool down and perhaps not fail on the cuke tasks because drop down lists aren't populated fast enough.".green
+    puts Rainbow("Info: Sleeping for #{duration} seconds to give CPU time to cool down and perhaps not fail on the cuke tasks because drop down lists aren't populated fast enough.").green
     sleep duration
     Rake::Task['cucumber'].invoke
   end

--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -70,7 +70,7 @@ namespace :claims do
     desc 'CCCD Task: Load demo data Advocate Claims [num_claims_per_state=1, num_claims_per_user=1]'
     task :advocates, :num_claims_per_state, :num_external_users do |task, args|
       Rake::Task[:environment].invoke
-      puts "#{task.name} with #{args}".green
+      puts Rainbow("#{task.name} with #{args}").green
       require 'fileutils'
       doc_store = File.join(Rails.root, 'public', 'assets', 'dev', 'images', 'docs')
       FileUtils.rm_r(doc_store, secure: true) if Dir.exist?(doc_store)
@@ -81,7 +81,7 @@ namespace :claims do
     desc "Load demo data Litigator Claims [num_claims_per_state=1, num_claims_per_user=1]"
     task :litigators, :num_claims_per_state, :num_external_users do |task, args|
       Rake::Task[:environment].invoke
-      puts "#{task.name} with #{args}".green
+      puts Rainbow("#{task.name} with #{args}").green
       require File.join(Rails.root, 'lib', 'demo_data', 'litigator_claim_generator')
       DemoData::LitigatorClaimGenerator.new(num_external_users: 1).run
     end
@@ -89,7 +89,7 @@ namespace :claims do
     desc "Load demo data Interim Claims [num_claims_per_state=1, num_claims_per_user=1]"
     task :interims, :num_claims_per_state, :num_external_users do |task, args|
       Rake::Task[:environment].invoke
-      puts "#{task.name} with #{args}".green
+      puts Rainbow("#{task.name} with #{args}").green
       require File.join(Rails.root, 'lib', 'demo_data', 'interim_claim_generator')
       DemoData::InterimClaimGenerator.new(num_external_users: 1).run
     end
@@ -97,7 +97,7 @@ namespace :claims do
     desc 'Load demo data Transfer Claims [num_claims_per_state=1, num_claims_per_user=1]'
     task :transfers, :num_claims_per_state, :num_external_users do |task, args|
       Rake::Task[:environment].invoke
-      puts "#{task.name} with #{args}".green
+      puts Rainbow("#{task.name} with #{args}").green
       require File.join(Rails.root, 'lib', 'demo_data', 'transfer_claim_generator')
       DemoData::TransferClaimGenerator.new(num_external_users: 1).run
     end
@@ -137,8 +137,8 @@ namespace :claims do
   task :archive_report, [:filename] => :environment do |_task, args|
     require_relative 'rake_helpers/archived_claims'
 
-    puts "Writing archived claims to #{args[:filename]}".green
+    puts Rainbow("Writing archived claims to #{args[:filename]}").green
     RakeHelpers::ArchivedClaims.write args[:filename]
-    puts 'Done'.green
+    puts Rainbow('Done').green
   end
 end

--- a/lib/tasks/dump.rake
+++ b/lib/tasks/dump.rake
@@ -38,7 +38,7 @@ namespace :db do
     task :anonymised => :environment do
       cmd = 'pg_dump --version'
       puts '---------------------------'
-      print "Using: #{%x(#{cmd})}".yellow
+      print Rainbow("Using: #{%x(#{cmd})}").yellow
       host = Rails.host.env || 'localhost'
       puts "Host environment: #{host}"
       filename = File.join('tmp', "#{Time.now.strftime('%Y%m%d%H%M%S')}_dump.psql")
@@ -104,12 +104,12 @@ namespace :db do
       s3_bucket = Tasks::RakeHelpers::S3Bucket.new(host)
       dump_files = s3_bucket.list('tmp').select { |item| item.key.match?('dump') }
 
-      abort("#{dump_files.size} dump file(s) found!".yellow) if dump_files.empty?
+      abort(Rainbow("#{dump_files.size} dump file(s) found!").yellow) if dump_files.empty?
 
       dump_files.sort_by(&:last_modified).reverse[start..].map do |object|
         print "Deleting #{object.key}..."
         object.delete
-        puts 'done'.green
+        puts Rainbow('done').green
       end
     end
 

--- a/lib/tasks/lgfs_scheme_eleven.rake
+++ b/lib/tasks/lgfs_scheme_eleven.rake
@@ -17,7 +17,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will seed data for LGFS Fee Scheme 11 - March 2026. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -35,7 +35,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will destroy LGFS Fee Scheme 11 - March 2026, offences and fee types. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       adder = Seeds::Schemas::AddLGFSFeeScheme11.new(pretend: pretend)
       adder.down

--- a/lib/tasks/lgfs_scheme_ten.rake
+++ b/lib/tasks/lgfs_scheme_ten.rake
@@ -17,7 +17,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will seed data for LGFS Fee Scheme 10 (CLAIR - September 2022). Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -35,7 +35,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will destroy LGFS Fee Scheme 10 (CLAIR - September 2022), offences and fee types. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       adder = Seeds::Schemas::AddLGFSFeeScheme10.new(pretend: pretend)
       adder.down

--- a/lib/tasks/lgfs_scheme_ten_clean.rake
+++ b/lib/tasks/lgfs_scheme_ten_clean.rake
@@ -17,7 +17,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will merge LGFS fee scheme 10 offences into LGFS fee scheme 9. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -36,7 +36,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will recreate spearate offences for LGFS fee scheme 10. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1

--- a/lib/tasks/rake_helpers/archived_claims.rb
+++ b/lib/tasks/rake_helpers/archived_claims.rb
@@ -26,7 +26,7 @@ module Tasks
             title: 'Archive',
             format: "%a [%e] %b\u{15E7}%i %c/%C %t",
             progress_mark: '#'.green,
-            remainder_mark: "\u{FF65}".yellow,
+            remainder_mark: Rainbow( "\u{FF65}").yellow,
             starting_at: 0,
             total: rows.count
           )

--- a/lib/tasks/rake_helpers/fix_offences.rb
+++ b/lib/tasks/rake_helpers/fix_offences.rb
@@ -3,7 +3,7 @@ include Tasks::RakeHelpers::RakeUtils
 
 module Tasks
   module RakeHelpers
-    class FixOffences      
+    class FixOffences
       def initialize(dir, dry_run: true)
         @dir = dir
         @data_sets = [
@@ -27,13 +27,13 @@ module Tasks
       end
 
       def fix_ids
-        puts "[DRY RUN]".blue if @dry_run
+        puts Rainbow("[DRY RUN]").blue if @dry_run
 
-        puts "Offences count before: #{Offence.count}".green
+        puts Rainbow("Offences count before: #{Offence.count}").green
         csv_data = CSV.read(File.expand_path('offences.csv', @dir), headers: true)
         offset = Offence.maximum(:id) + 10000
         Offence.transaction do
-          puts 'FIRST PASS - Move records with incorrect ids out of range'.yellow
+          puts Rainbow('FIRST PASS - Move records with incorrect ids out of range').yellow
           db_records = []
           new_records = []
           ids = []
@@ -46,7 +46,7 @@ module Tasks
               if db_record.id.to_s != csv_record['id']
                 claims = db_record.claims
 
-                print "Setting id #{db_record.id} to #{csv_record['id'].to_i + offset}\r".red
+                print Rainbow("Setting id #{db_record.id} to #{csv_record['id'].to_i + offset}\r").red
                 db_record.id = csv_record['id'].to_i + offset
                 db_record.save
 
@@ -59,11 +59,11 @@ module Tasks
           end
           print "                              \r"
 
-          puts 'SECOND PASS - Remove extra records'.yellow
+          puts Rainbow('SECOND PASS - Remove extra records').yellow
           extras = Offence.where.not(id: ids)
           extras.delete_all
 
-          puts 'THIRD PASS - Add missing records'.yellow
+          puts Rainbow('THIRD PASS - Add missing records').yellow
           new_records.each do |record|
             offence = Offence.new(record.to_h.except('id'))
             offence.save
@@ -71,11 +71,11 @@ module Tasks
             offence.save
           end
 
-          puts 'FOURTH PASS - Move records that had incorrect ids into their correct range'.yellow
+          puts Rainbow('FOURTH PASS - Move records that had incorrect ids into their correct range').yellow
           db_records.each do |db_record|
             claims = db_record.claims
 
-            print "Setting id #{db_record.id} to #{db_record.id - offset}\r".red
+            print Rainbow("Setting id #{db_record.id} to #{db_record.id - offset}\r").red
             db_record.id = db_record.id - offset
             db_record.save
 
@@ -83,10 +83,10 @@ module Tasks
           end
           print "                              \r"
 
-          puts "Offences count after: #{Offence.count}".green
+          puts Rainbow("Offences count after: #{Offence.count}").green
 
           if @dry_run
-            puts "[ROLLING BACK]".blue
+            puts Rainbow("[ROLLING BACK]").blue
             raise ActiveRecord::Rollback
           end
         end
@@ -96,13 +96,13 @@ module Tasks
 
       def check_counts(set)
         csv_data = CSV.read(File.expand_path("#{set[:name]}.csv", @dir), headers: true)
-        puts "Number of #{set[:name]} in CSV file: #{csv_data.count}".yellow
-        puts "Number of #{set[:name]} in database: #{set[:class].count}".yellow
-        puts csv_data.count == set[:class].count ? '  [OK]'.green : '  [MISMATCH]'.red
+        puts Rainbow("Number of #{set[:name]} in CSV file: #{csv_data.count}").yellow
+        puts Rainbow("Number of #{set[:name]} in database: #{set[:class].count}").yellow
+        puts csv_data.count == set[:class].count ? '  [OK]'.green : Rainbow('  [MISMATCH]').red
       end
 
       def check_records(set)
-        puts "Matches:".yellow
+        puts Rainbow("Matches:").yellow
         csv_data = CSV.read(File.expand_path("#{set[:name]}.csv", @dir), headers: true)
 
         missing = []
@@ -119,10 +119,10 @@ module Tasks
             missing << csv_record
           end
         end
-        puts "#{missing.count} records in production not found in this environment".yellow
-        puts "#{incorrect.count} records in production found in this environment with an incorrect id".yellow
+        puts Rainbow("#{missing.count} records in production not found in this environment").yellow
+        puts Rainbow("#{incorrect.count} records in production found in this environment with an incorrect id").yellow
         extras = set[:class].where.not(id: extras)
-        puts "#{extras.count} records in this environment and not in production".yellow
+        puts Rainbow("#{extras.count} records in this environment and not in production").yellow
         output('Missing records:') if missing.count.positive?
         missing.each do |record|
           output("#{record['id']}")

--- a/lib/tasks/scheme_twelve.rake
+++ b/lib/tasks/scheme_twelve.rake
@@ -19,7 +19,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will seed CLAR. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       log_level = ActiveRecord::Base.logger.level
       ActiveRecord::Base.logger.level = 1
@@ -37,7 +37,7 @@ namespace :db do
       pretend = !not_pretend
 
       continue?('This will destroy CLAR scheme, offences and fee types. Are you sure?') if not_pretend
-      puts "#{pretend ? 'pretending' : 'working'}...".yellow
+      puts Rainbow("#{pretend ? 'pretending' : 'working'}...").yellow
 
       adder = Seeds::Schemas::AddAGFSFeeScheme12.new(pretend: pretend)
       adder.down

--- a/lib/tasks/vacuum.rake
+++ b/lib/tasks/vacuum.rake
@@ -3,8 +3,8 @@
 namespace :db do
   desc 'Perform a full vacuum of the postgres database'
   task :vacuum => :environment do
-    puts "[#{DateTime.current}]".yellow
+    puts Rainbow("[#{DateTime.current}]").yellow
     ActiveRecord::Base.connection.execute('VACUUM (VERBOSE, ANALYZE);')
-    puts "[#{DateTime.current}]".yellow
+    puts Rainbow("[#{DateTime.current}]").yellow
   end
 end

--- a/lib/utils/account_setter.rb
+++ b/lib/utils/account_setter.rb
@@ -56,9 +56,9 @@ module Utils
 
         if user
           user.persona.soft_delete
-          puts "Softly deleted #{user.email}!".green
+          puts Rainbow("Softly deleted #{user.email}!").green
         else
-          puts "User with email #{email} not found!".red
+          puts Rainbow("User with email #{email} not found!").red
         end
       end
     end
@@ -77,9 +77,9 @@ module Utils
           user.persona.update(deleted_at: nil)
           user.update!(deleted_at: nil)
           user.update!(email:)
-          puts "Undid soft delete for #{user.email}!".green
+          puts Rainbow("Undid soft delete for #{user.email}!").green
         else
-          puts "User email \"#{email}.delete.%\" not found!".red
+          puts Rainbow("User email \"#{email}.delete.%\" not found!").red
         end
       end
     end
@@ -98,9 +98,9 @@ module Utils
 
         if user&.enabled?
           user.disable
-          puts "User with email \"#{user.email}\" disabled!".green
+          puts Rainbow("User with email \"#{user.email}\" disabled!").green
         else
-          puts "Enabled user with email \"#{email}\" not found!".red
+          puts Rainbow("Enabled user with email \"#{email}\" not found!").red
         end
       end
     end
@@ -116,9 +116,9 @@ module Utils
 
         if user&.disabled?
           user.enable
-          puts "User with email \"#{user.email}\" enabled!".green
+          puts Rainbow("User with email \"#{user.email}\" enabled!").green
         else
-          puts "Disabled user with email \"#{email}\" not found!".red
+          puts Rainbow("Disabled user with email \"#{email}\" not found!").red
         end
       end
     end
@@ -138,9 +138,9 @@ module Utils
         if user
           pwd = SecureRandom.base64(15)
           user.update!(password: pwd, password_confirmation: pwd)
-          puts "Updated password for #{user.email} with id #{user.id}! They will need to reest it to login!".green
+          puts Rainbow("Updated password for #{user.email} with id #{user.id}! They will need to reest it to login!").green
         else
-          puts "User with email #{email} not found!".red
+          puts Rainbow("User with email #{email} not found!").red
         end
       end
     end


### PR DESCRIPTION
#### What
This branch updates a PR that was approved and merged but then failed when deployed to production.

  ```And I enter the From date "01/8/2022"                  # features/step_definitions/super_admins_stats_steps.rb:17
      Unable to find css "#stats_date_from_3i" (Capybara::ElementNotFound)
      ./features/step_definitions/super_admins_stats_steps.rb:19:in `"I enter the From date {string}"'
      features/super_admins/stats.feature:8:in `I enter the From date "01/8/2022"'
```
     
`Capybara::ElementNotFound for "#stats_date_from_3i"` suggests that the date input field for the day is not present on the page when Capybara tries to interact with it. 

It was suggested (AI) that this could be to do with the date format that was `dd/m/yyyy` as opposed to `dd/mm/yyyy`

#### Ticket

[CCCD - Replace awesome_print](https://dsdmoj.atlassian.net/browse/CTSKF-1550)

#### Why
I don't know why it suddenly failed as I don't think the awesome print overlapped with the date field. 

#### How

This was (hopefully) fixed by standardising the date format to dd/mm/yyyy from dd/m/yyyy within the feature file. But I might need to try something else if this fails again. 


