### PR TITLE
Update text colouring to use Rainbow

### DIFF
--- a/lib/tasks/claims.rake
+++ b/lib/tasks/claims.rake
@@ -52,7 +52,7 @@ namespace :claims do
     print 'Seeding sample users...'
     DemoData::ExternalUserSeeder.run
     DemoData::CaseWorkerSeeder.run
-    puts 'done'.green
+    puts Rainbow('done').green
   end
 
   desc 'Loads dummy claims'

--- a/lib/tasks/dump.rake
+++ b/lib/tasks/dump.rake
@@ -30,7 +30,7 @@ namespace :db do
         stdout_and_stderr.each_line do |line|
           puts line
         end
-        raise ['Failure'.red, ': ', cmd].join unless wait_thr.value.success?
+        raise [Rainbow('Failure').red, ': ', cmd].join unless wait_thr.value.success?
       end
     end
 


### PR DESCRIPTION
#### What

There are a two rake tasks where we previously used awesomeprint to colour text output to the terminal. Since moving to the Rainbow library, the previous syntax no longer works. This causes failures when the tasks are run, including in the daily smoke tests.

#### How

Updates both tasks to use the correct syntax: eg `'text'.colour` -> `Rainbow('text').colour`