### PR TITLE
Fix flaky test

### DIFF
--- a/features/page_objects/external_user_home_page.rb
+++ b/features/page_objects/external_user_home_page.rb
@@ -2,4 +2,5 @@ require_relative "user_home_page"
 
 class ExternalUserHomePage < UserHomePage
   set_url "/external_users"
+  set_url_matcher %r{/external_users(/claims)?$}
 end

--- a/features/step_definitions/common_claim_steps.rb
+++ b/features/step_definitions/common_claim_steps.rb
@@ -149,20 +149,11 @@ When(/^I click "Continue" I should be on the 'Case details' page and see a "([^"
 end
 
 When(/^I click "Continue" in the claim form and move to the '(.*?)' form page$/) do |page_title|
-  original_header = page.first('h1.govuk-heading-xl').text
-  sleep 3
+  patiently do
   @claim_form_page.continue_button.click
-  wait_for_ajax
-  using_wait_time(6) do
-    if page.first('h1.govuk-heading-xl').text.eql?(original_header)
-      #clicking again because the first one didn't work
-      @claim_form_page.continue_button.click
-      wait_for_ajax
-    end
-    within('#claim-form') do
-      expect(page.first('h1.govuk-heading-xl')).to have_content(page_title)
-    end
+  expect(page).to have_css('h1.govuk-heading-xl', text: page_title)
   end
+  wait_for_ajax
 end
 
 Then(/^I am on the miscellaneous fees page$/) do

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -1,5 +1,6 @@
 Given(/^I visit "(.*?)"$/) do |path|
   visit path
+  expect(page).to have_current_path(path)
 end
 
 When(/^I save and open page$/) do

--- a/features/step_definitions/common_steps.rb
+++ b/features/step_definitions/common_steps.rb
@@ -58,6 +58,9 @@ end
 
 Given(/^I am later on the Your claims page$/) do
   @external_user_home_page.load
+  patiently do
+    expect(@external_user_home_page).to be_displayed
+  end
 end
 
 When(/I click the claim '(.*?)'$/) do |case_number|

--- a/features/super_admins/stats.feature
+++ b/features/super_admins/stats.feature
@@ -5,7 +5,7 @@ Feature: Stats
     Given I am a signed in super admin
     Given I have created test claims for "10/08/2022"
     When I visit "/super_admins/stats"
-    And I enter the From date "01/8/2022"
-    And I enter the To date "31/8/2022"
+    And I enter the From date "01/08/2022"
+    And I enter the To date "31/08/2022"
     And I click Update
     Then the Javascript variable createChart should change

--- a/spec/services/stats/management_information/daily_report_count_generator_spec.rb
+++ b/spec/services/stats/management_information/daily_report_count_generator_spec.rb
@@ -118,7 +118,7 @@ RSpec.describe Stats::ManagementInformation::DailyReportCountGenerator do
 
       before do
         travel_to(start_date.beginning_of_day) do
-          create_list(:advocate_final_claim, 3, :refused, case_type: build(:case_type, :trial))
+          create_list(:advocate_final_claim, 3, :refused, case_type: create(:case_type, :trial))
         end
       end
 


### PR DESCRIPTION
#### What
**Flaky test 1**: In the cucumber tests `Given I am later on the Your claims page` the test fails as it is not hitting that page. Adds a patiently block to ensure that page is loaded correctly. 

**Flaky test 2** Fix a parsing issue. Enforcing a consistent, zero-padded format ensures the date is always interpreted correctly by the application, eliminating a source of intermittent test failures.

**Flaky test 3:** refactor and simplify the test to use the 'patiently' block. Remove the explicit 'sleep' and the logic for a second button click. The 'patiently' block will retry the click and the title expectation together, as a way to handle slow and transitions and asynchronous behaviour.

**Flaky test 4** 
This test fails because it doesn't reach the expected page. The fix uses Capybara's waiting mechanism to ensure the page navigation has completed before proceeding to the next step. This helps prevent race conditions.

**Flaky test 5**
Changing build to create  
By changing build(:case_type, :trial) to create(:case_type, :trial), you ensure the CaseType record is persisted to the database. This allows the service's queries to find the associated claims correctly, leading to consistent and accurate counts, thus fixing the flaky test.

**Flaky test 6**
Add URL matcher to prevent flaky tests
Add a set_url_matcher to the ExternalUserHomePage to allow for flexible URL matching. This will prevent flaky tests by ensuring the page is recognized at either /external_users or /external_users/claims