### PR TITLE
Fixing Software Composition Analysis 

### DIFF
--- a/.github/workflows/devsecops_sca_scan.yml
+++ b/.github/workflows/devsecops_sca_scan.yml
@@ -19,7 +19,7 @@ jobs:
       contents: write
       pull-requests: write
       issues: write
-      security-events: read
+      security-events: write
 
     steps:
       - name: Run SCA

--- a/.github/workflows/devsecops_sca_scan.yml
+++ b/.github/workflows/devsecops_sca_scan.yml
@@ -20,6 +20,7 @@ jobs:
       pull-requests: write
       issues: write
       security-events: write
+      actions: read
 
     steps:
       - name: Run SCA


### PR DESCRIPTION
#### What

Fixing the build error for Software Composition Analysis build 

#### Ticket

- No ticket, just build error

#### Why

To remove the build error for the Software Composition Analysis build as it started running errors on the private Git repo now it isn't public.

#### How

Changed 
```
security-events: read
```

to 

```
security-events: write
actions: read
```

within the devsecops_sca_scan.yml file.

--------



