### PR TITLE
[CTSKF-1800] Allow additional prep fee on discontinuances

### DIFF
--- a/app/models/case_type.rb
+++ b/app/models/case_type.rb
@@ -33,7 +33,7 @@ class CaseType < ApplicationRecord
   scope :not_fixed_fee,           -> { where(is_fixed_fee: false) }
   scope :graduated_fees,          -> { where(fee_type_code: Fee::GraduatedFeeType.select(:unique_code)) }
   scope :trial_fees,              -> { where(fee_type_code: TRIAL_FEE_TYPES) }
-  scope :trial_and_guilty_plea_fees, -> { where(fee_type_code: TRIAL_FEE_TYPES + %w[GRGLT]) }
+  scope :trial_guilty_plea_and_discontinuance_fees, -> { where(fee_type_code: TRIAL_FEE_TYPES + %w[GRGLT GRDIS]) }
   scope :requires_cracked_dates,  -> { where(requires_cracked_dates: true) }
   scope :requires_trial_dates,    -> { where(requires_trial_dates: true) }
   scope :requires_retrial_dates,  -> { where(requires_retrial_dates: true) }

--- a/app/services/claims/fetch_eligible_misc_fee_types.rb
+++ b/app/services/claims/fetch_eligible_misc_fee_types.rb
@@ -89,12 +89,16 @@ module Claims
       claim.transfer? && claim.transfer_detail&.case_conclusion == 'Guilty plea'
     end
 
-    def agfs_scheme_17_or_later_guilty_plea?
-      claim.fee_scheme&.agfs_scheme_17_or_later? && case_type&.fee_type_code == 'GRGLT'
+    def agfs_scheme_17_or_later?
+      claim.fee_scheme&.agfs_scheme_17_or_later?
+    end
+
+    def guilty_plea_or_discontinuance_case_type?
+      case_type&.fee_type_code == 'GRGLT' || (case_type&.fee_type_code == 'GRDIS' && claim.prosecution_evidence)
     end
 
     def filter_trial_only_types(misc_fees, filter)
-      if agfs_scheme_17_or_later_guilty_plea?
+      if agfs_scheme_17_or_later? && guilty_plea_or_discontinuance_case_type?
         filter ? misc_fees.without_trial_fee_only_excluding_miapf : misc_fees
       else
         filter ? misc_fees.without_trial_fee_only : misc_fees

--- a/app/validators/fee/agfs/fee_type_rules.rb
+++ b/app/validators/fee/agfs/fee_type_rules.rb
@@ -30,7 +30,7 @@ module Fee
 
         with_set_for_fee_type('MIAPF') do |set|
           set << add_rule(:quantity, :equal, 1, message: :miapf_numericality)
-          set << add_rule(*trial_and_guilty_plea_only_rule)
+          set << add_rule(*trial_guilty_plea_and_discontinuance_rule)
         end
       end
     end

--- a/app/validators/fee/base_fee_validator.rb
+++ b/app/validators/fee/base_fee_validator.rb
@@ -34,6 +34,33 @@ module Fee
     def validate_agfs_fee_type_rules
       rule_sets = Fee::AGFS::FeeTypeRules.where(unique_code: @record.fee_type&.unique_code)
       Rule::Validator.new(@record, rule_sets).validate if rule_sets.present?
+      validate_miapf_case_type_eligibility
+    end
+
+    def validate_miapf_case_type_eligibility
+      return unless miapf_fee?
+      return unless miapf_requires_scheme_check?
+
+      @record.errors.add(:fee_type, 'case_type_inclusion')
+    end
+
+    def miapf_fee?
+      @record.fee_type&.unique_code == 'MIAPF'
+    end
+
+    def miapf_requires_scheme_check?
+      case @record.claim&.case_type&.fee_type_code
+      when 'GRGLT'
+        !agfs_scheme_17_or_later?
+      when 'GRDIS'
+        !(agfs_scheme_17_or_later? && @record.claim&.prosecution_evidence)
+      else
+        false
+      end
+    end
+
+    def agfs_scheme_17_or_later?
+      @record.claim&.fee_scheme&.agfs_scheme_17_or_later?
     end
 
     def validate_date

--- a/app/validators/fee/concerns/fee_type_rules_creator.rb
+++ b/app/validators/fee/concerns/fee_type_rules_creator.rb
@@ -32,11 +32,11 @@ module Fee
                allow_nil: true }]
         end
 
-        def trial_and_guilty_plea_only_rule
-          @trial_and_guilty_plea_only_rule ||=
+        def trial_guilty_plea_and_discontinuance_rule
+          @trial_guilty_plea_and_discontinuance_rule ||=
             ['claim.case_type_id',
              :inclusion,
-             CaseType.trial_and_guilty_plea_fees.ids,
+             CaseType.trial_guilty_plea_and_discontinuance_fees.ids,
              { message: 'case_type_inclusion',
                attribute_for_error: :fee_type,
                allow_nil: true }]

--- a/app/views/pages/api_release_notes.html.haml
+++ b/app/views/pages/api_release_notes.html.haml
@@ -19,7 +19,7 @@
         %li
           increases the payment for Additional Preparation fees from £62 to £81
         %li
-          allows Additional Preparation fees to be claimed on Guilty plea cases
+          allows Additional Preparation fees to be claimed on Guilty plea cases and Discontinuance cases where prosecution evidence has been served
 
 %section.api-documentation
   %hr.govuk-section-break.govuk-section-break--l.govuk-section-break--visible

--- a/spec/factories/fees.rb
+++ b/spec/factories/fees.rb
@@ -123,6 +123,10 @@ FactoryBot.define do
     trait :miumo_fee do
       fee_type { Fee::MiscFeeType.find_by(unique_code: 'MIUMO') || build(:misc_fee_type, :miumo) }
     end
+
+    trait :miapf_fee do
+      fee_type { Fee::MiscFeeType.find_by(unique_code: 'MIAPF') || build(:misc_fee_type, :miapf) }
+    end
   end
 
   factory :warrant_fee, class: 'Fee::WarrantFee' do

--- a/spec/models/case_type_spec.rb
+++ b/spec/models/case_type_spec.rb
@@ -145,13 +145,13 @@ RSpec.describe CaseType do
       it { expect(trial_fees.map(&:fee_type_code)).to all(be_one_of(%w[GRCBR GRRAK GRRTR GRTRL])) }
     end
 
-    describe '.trial_and_guilty_plea_fees' do
-      subject(:trial_and_guilty_plea_fees) { described_class.trial_and_guilty_plea_fees }
+    describe '.trial_guilty_plea_and_discontinuance_fees' do
+      subject(:scope) { described_class.trial_guilty_plea_and_discontinuance_fees }
 
       it { is_expected.not_to be_empty }
 
       it {
-        expect(trial_and_guilty_plea_fees.map(&:fee_type_code)).to all(be_one_of(%w[GRCBR GRRAK GRRTR GRTRL GRGLT]))
+        expect(scope.map(&:fee_type_code)).to all(be_one_of(%w[GRCBR GRRAK GRRTR GRTRL GRGLT GRDIS]))
       }
     end
   end

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -381,7 +381,22 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
             it { is_expected.not_to include(*supplementary_only_types) }
             it { is_expected.not_to include(*unused_materials_types) }
             it { is_expected.not_to include(*section_twenty_eight_types) }
-            it { is_expected.not_to include(*additional_prep_fee_types) }
+
+            context 'when prosecution evidence is present' do
+              before { claim.update!(prosecution_evidence: true) }
+
+              it { is_expected.to include(*additional_prep_fee_types) }
+            end
+
+            context 'when prosecution evidence is not present' do
+              before { claim.update!(prosecution_evidence: false) }
+
+              it { is_expected.not_to include(*additional_prep_fee_types) }
+            end
+
+            context 'when prosecution evidence is nil' do
+              it { is_expected.not_to include(*additional_prep_fee_types) }
+            end
           end
         end
       end

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -674,4 +674,70 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
       end
     end
   end
+
+  describe '#validate_miapf_case_type_eligibility' do
+    let(:claim) { create(:advocate_claim, :agfs_scheme_17, case_type:) }
+
+    context 'with a fee type that is not an Additional preparation fee' do
+      let(:case_type) { create(:case_type, :trial) }
+      let(:fee) { build(:misc_fee, :miumu_fee, claim:, quantity: 1) }
+
+      it { expect(fee).to be_valid }
+    end
+
+    context 'with an Additional preparation fee' do
+      context 'when the case type is Guilty plea' do
+        let(:case_type) { create(:case_type, :guilty_plea) }
+        let(:fee) { build(:misc_fee, :miapf_fee, claim:, quantity: 1) }
+
+        it { expect(fee).to be_valid }
+
+        context 'when the fee scheme is before 17' do
+          let(:claim) { build(:advocate_claim, :agfs_scheme_16, case_type:) }
+
+          it { expect(fee).not_to be_valid }
+
+          it {
+            fee.valid?
+            expect(fee.errors[:fee_type]).to include('case_type_inclusion')
+          }
+        end
+      end
+
+      context 'when the case type is Discontinuance' do
+        let(:case_type) { create(:case_type, :discontinuance) }
+        let(:fee) { build(:misc_fee, :miapf_fee, claim:, quantity: 1) }
+
+        context 'when the fee scheme is 17' do
+          before { claim.prosecution_evidence = true }
+
+          context 'when prosecution evidence is present' do
+            it { expect(fee).to be_valid }
+          end
+
+          context 'when prosecution evidence is not present' do
+            before { claim.prosecution_evidence = false }
+
+            it { expect(fee).not_to be_valid }
+
+            it {
+              fee.valid?
+              expect(fee.errors[:fee_type]).to include('case_type_inclusion')
+            }
+          end
+        end
+
+        context 'when the fee scheme is before 17' do
+          let(:claim) { build(:advocate_claim, :agfs_scheme_16, case_type:) }
+
+          it { expect(fee).not_to be_valid }
+
+          it {
+            fee.valid?
+            expect(fee.errors[:fee_type]).to include('case_type_inclusion')
+          }
+        end
+      end
+    end
+  end
 end


### PR DESCRIPTION
#### What

Allow additional prep fee to be claimed on AGFS fee scheme 17+ discontinuance claims where prosecution evidence has been served.

#### Ticket

[CTSKF-1800](https://dsdmoj.atlassian.net/browse/CTSKF-1800)

#### Why

To allow providers to claim work they are entitled to.

#### How

* Extends functionality in `app/services/claims/fetch_eligible_misc_fee_types.rb` to also cover discontinuances where prosecution evidence exists, so that Additional preparation fees can be claimed from the Miscellaneous fees drop down on appropriate claims
* Updates validation in `app/validators/fee/agfs/fee_type_rules.rb`, `app/validators/fee/base_fee_validator.rb` and `app/validators/fee/concerns/fee_type_rules_creator.rb` to allow Additional preparation fees to be saved on appropriate claims
* Updates tests

[CTSKF-1800]: https://dsdmoj.atlassian.net/browse/CTSKF-1800?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ