### PR TITLE
[CTSKF-1765] Set AGFS 17 start date

### DIFF
--- a/app/models/fee_scheme_factory/agfs.rb
+++ b/app/models/fee_scheme_factory/agfs.rb
@@ -39,11 +39,11 @@ module FeeSchemeFactory
     end
 
     def scheme_sixteen_range
-      Settings.agfs_scheme_16_section_twenty_eight_increase..(Settings.agfs_scheme_17 - 1.day)
+      Settings.agfs_scheme_16_section_twenty_eight_increase..(Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date - 1.day)
     end
 
     def scheme_seventeen_range
-      Settings.agfs_scheme_17..Time.zone.today
+      Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date..Time.zone.today
     end
   end
 end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -149,7 +149,7 @@ agfs_scheme_13_clair_release_date: 2022-09-30
 agfs_scheme_14_section_twenty_eight: 2023-02-01
 agfs_scheme_15_additional_prep_fee_and_kc: 2023-04-17
 agfs_scheme_16_section_twenty_eight_increase: 2023-11-16
-agfs_scheme_17: 2026-06-24
+agfs_scheme_17: 2026-07-28
 
 # LGFS Fee scheme dates
 lgfs_scheme_10_clair_release_date: 2022-09-30

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -149,7 +149,7 @@ agfs_scheme_13_clair_release_date: 2022-09-30
 agfs_scheme_14_section_twenty_eight: 2023-02-01
 agfs_scheme_15_additional_prep_fee_and_kc: 2023-04-17
 agfs_scheme_16_section_twenty_eight_increase: 2023-11-16
-agfs_scheme_17: 2026-07-28
+agfs_scheme_17_additional_prep_fee_underspend_release_date: 2026-07-28
 
 # LGFS Fee scheme dates
 lgfs_scheme_10_clair_release_date: 2022-09-30

--- a/db/seeds/schemas/add_agfs_fee_scheme_17.rb
+++ b/db/seeds/schemas/add_agfs_fee_scheme_17.rb
@@ -55,19 +55,19 @@ module Seeds
         agfs_fee_scheme_sixteen = FeeScheme.find_by(name: 'AGFS', version: 16, start_date: Settings.agfs_scheme_16_section_twenty_eight_increase.beginning_of_day)
         agfs_fee_scheme_sixteen ? print(Rainbow("...found\n").green) : print(Rainbow("...not found\n").red)
 
-        print Rainbow("Updating AGFS scheme 16 end date to #{Settings.agfs_scheme_17.end_of_day-1.day}").yellow
+        print Rainbow("Updating AGFS scheme 16 end date to #{Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date.end_of_day-1.day}").yellow
         if pretending?
           print Rainbow("...not updated\n").green if pretending?
         else
-          agfs_fee_scheme_sixteen.update(end_date: Settings.agfs_scheme_17.end_of_day-1.day)
+          agfs_fee_scheme_sixteen.update(end_date: Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date.end_of_day-1.day)
           print Rainbow("...updated\n").green
         end
 
-        print Rainbow("Finding or creating scheme 17 with start date #{Settings.agfs_scheme_17.beginning_of_day}...").yellow
+        print Rainbow("Finding or creating scheme 17 with start date #{Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date.beginning_of_day}...").yellow
         if pretending?
           print Rainbow("...not created\n").green if pretending?
         else
-          FeeScheme.find_or_create_by(name: 'AGFS', version: 17, start_date: Settings.agfs_scheme_17.beginning_of_day)
+          FeeScheme.find_or_create_by(name: 'AGFS', version: 17, start_date: Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date.beginning_of_day)
           print Rainbow("...created\n").green
         end
       end

--- a/features/claims/advocate/scheme_seventeen/advocate_final_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_seventeen/advocate_final_fixed_fee_claim_submit.feature
@@ -20,7 +20,7 @@ Feature: Advocate submits an LGFS Fee Scheme 17 claim for a Fixed fee (Appeal ag
     And I enter defendant, scheme 17 representation order and MAAT reference
     Then I click "Continue" in the claim form
 
-    Given I insert the VCR cassette 'features/claims/advocate/scheme/seventeen/fixed_fee_calculations'
+    Given I insert the VCR cassette 'features/claims/advocate/scheme_seventeen/fixed_fee_calculations'
 
     And I should see the advocate categories 'Junior,Leading junior,KC'
     And I select an advocate category of 'Junior'

--- a/features/claims/advocate/scheme_seventeen/advocate_final_fixed_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_seventeen/advocate_final_fixed_fee_claim_submit.feature
@@ -4,7 +4,7 @@ Feature: Advocate submits an LGFS Fee Scheme 17 claim for a Fixed fee (Appeal ag
   @fee_calc_vcr
   Scenario: I create and submit an Appeal against conviction claim
 
-    Given the current date is '2026-06-24'
+    Given the current date is '2026-07-28'
     And I am a signed in advocate
     And I am on the 'Your claims' page
 

--- a/features/claims/advocate/scheme_seventeen/advocate_final_graduated_fee_claim_submit.feature
+++ b/features/claims/advocate/scheme_seventeen/advocate_final_graduated_fee_claim_submit.feature
@@ -3,7 +3,7 @@ Feature: Advocate submits an AGFS Fee Scheme 17 final graduated fee claims
 
   @fee_calc_vcr
   Scenario: I create and submit a trial claim with a graduated fee and miscellaneous fees
-    Given the current date is '2026-06-24'
+    Given the current date is '2026-07-28'
     And I am a signed in advocate
     And I am on the 'Your claims' page
     And I click 'Start a claim'
@@ -82,7 +82,7 @@ Feature: Advocate submits an AGFS Fee Scheme 17 final graduated fee claims
   @fee_calc_vcr
   Scenario: I create and submit a guilty plea claim with a fixed fee and miscellaneous fees
 
-    Given the current date is '2026-06-24'
+    Given the current date is '2026-07-28'
     And I am a signed in advocate
     And I am on the 'Your claims' page
 

--- a/features/claims/advocate/scheme_seventeen/advocate_hardship_claim_submit.feature
+++ b/features/claims/advocate/scheme_seventeen/advocate_hardship_claim_submit.feature
@@ -4,7 +4,7 @@ Feature: Advocate submits an AGFS Fee Scheme 17 hardship claim for a trial with 
   @fee_calc_vcr
   Scenario: I create a hardship claim for a trial
 
-    Given the current date is '2026-06-24'
+    Given the current date is '2026-07-28'
     And I am a signed in advocate
     And I am on the 'Your claims' page
     And I click 'Start a claim'
@@ -150,4 +150,3 @@ Feature: Advocate submits an AGFS Fee Scheme 17 hardship claim for a trial with 
     Then I should be on the your claims page
 
     And Claim 'A20201234' should be listed with a status of 'Submitted' and a claimed amount of '£2,914.27'
-

--- a/features/claims/advocate/scheme_seventeen/advocate_interim_claim_submit.feature
+++ b/features/claims/advocate/scheme_seventeen/advocate_interim_claim_submit.feature
@@ -3,7 +3,7 @@ Feature: Advocate submits an AGFS scheme 17 interim claim for a warrant fee
 
   Scenario: I create an AGFS interim claim and submit it
 
-    Given the current date is '2026-09-24'
+    Given the current date is '2026-10-28'
     And I am a signed in advocate
     And I am on the 'Your claims' page
     And I click 'Start a claim'
@@ -25,7 +25,7 @@ Feature: Advocate submits an AGFS scheme 17 interim claim for a warrant fee
     When I select the first search result
     Then I should see a page title "Enter fees for advocate warrant fees claim"
     And I select an advocate category of 'Junior'
-    And I fill in '2026-06-24' as the warrant issued date
+    And I fill in '2026-07-28' as the warrant issued date
     And I enter a Warrant net amount of '100'
 
     When I click "Continue" in the claim form

--- a/features/claims/advocate/scheme_seventeen/advocate_supplementary_claim_submit.feature
+++ b/features/claims/advocate/scheme_seventeen/advocate_supplementary_claim_submit.feature
@@ -4,7 +4,7 @@ Feature: Advocate submits a fee scheme 17 supplementary claim for miscellaneous 
   @fee_calc_vcr
   Scenario: I create a supplementary claim and add applicable misc fees
 
-    Given the current date is '2026-06-24'
+    Given the current date is '2026-07-28'
     And I am a signed in advocate
     And I am on the 'Your claims' page
     And I click 'Start a claim'

--- a/spec/factories/claim/shared/advocate_claim_traits.rb
+++ b/spec/factories/claim/shared/advocate_claim_traits.rb
@@ -84,7 +84,7 @@ FactoryBot.define do
       claim.defendants.each do |defendant|
         defendant
           .representation_orders
-          .update_all(representation_order_date: Settings.agfs_scheme_17)
+          .update_all(representation_order_date: Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date)
       end
     end
   end

--- a/spec/models/fee_scheme_factory/agfs_spec.rb
+++ b/spec/models/fee_scheme_factory/agfs_spec.rb
@@ -83,6 +83,8 @@ RSpec.shared_examples 'find AGFS fee schemes 12+' do
   end
 
   context 'with a rep order on 28 July 2026' do
+    before { travel_to(Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date) }
+
     let(:representation_order_date) { Date.parse('28 July 2026') }
 
     it { is_expected.to eq FeeScheme.find_by(name: 'AGFS', version: 17) }

--- a/spec/models/fee_scheme_factory/agfs_spec.rb
+++ b/spec/models/fee_scheme_factory/agfs_spec.rb
@@ -83,7 +83,7 @@ RSpec.shared_examples 'find AGFS fee schemes 12+' do
   end
 
   context 'with a rep order on 28 July 2026' do
-    let(:representation_order_date) { Date.parse('24 June 2026') }
+    let(:representation_order_date) { Date.parse('28 July 2026') }
 
     it { is_expected.to eq FeeScheme.find_by(name: 'AGFS', version: 17) }
   end

--- a/spec/models/fee_scheme_spec.rb
+++ b/spec/models/fee_scheme_spec.rb
@@ -158,6 +158,8 @@ RSpec.describe FeeScheme do
     subject { fee_scheme.agfs_scheme_17_or_later? }
 
     context 'with an agfs scheme 17 claim' do
+      before { travel_to(Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date) }
+
       let(:claim) { create(:advocate_claim, :agfs_scheme_17) }
 
       it { is_expected.to be_truthy }

--- a/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
+++ b/spec/services/claims/fetch_eligible_misc_fee_types_spec.rb
@@ -355,6 +355,8 @@ RSpec.describe Claims::FetchEligibleMiscFeeTypes, type: :service do
         end
 
         context 'with a scheme 17 claim' do
+          before { travel_to(Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date) }
+
           let(:claim) { create(:advocate_claim, :agfs_scheme_17, case_type:) }
 
           context 'with "trial" case type' do

--- a/spec/support/scheme_date_helpers.rb
+++ b/spec/support/scheme_date_helpers.rb
@@ -11,7 +11,7 @@ module SchemeDateHelpers
 
   def scheme_date_mappings
     {
-      'scheme 17' => Settings.agfs_scheme_17.strftime,
+      'scheme 17' => Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date.strftime,
       'scheme 16' => Settings.agfs_scheme_16_section_twenty_eight_increase.strftime,
       'scheme 15' => Settings.agfs_scheme_15_additional_prep_fee_and_kc.strftime,
       'scheme 13' => Settings.agfs_scheme_13_clair_release_date.strftime,
@@ -32,7 +32,7 @@ module SchemeDateHelpers
 
   def main_hearing_date_mappings
     {
-      'scheme 17' => Settings.agfs_scheme_17.strftime,
+      'scheme 17' => Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date.strftime,
       'scheme 16' => Settings.agfs_scheme_16_section_twenty_eight_increase.strftime,
       'scheme 15' => Settings.agfs_scheme_15_additional_prep_fee_and_kc.strftime,
       'scheme 13' => Settings.agfs_scheme_13_clair_release_date.strftime,

--- a/spec/support/seed_helpers.rb
+++ b/spec/support/seed_helpers.rb
@@ -14,8 +14,8 @@ module SeedHelpers
     FeeScheme.find_or_create_by(name: 'AGFS', version: 13, start_date: Settings.agfs_scheme_13_clair_release_date.beginning_of_day, end_date: Settings.agfs_scheme_14_section_twenty_eight.end_of_day - 1.day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 14, start_date: Settings.agfs_scheme_14_section_twenty_eight.beginning_of_day, end_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc.end_of_day - 1.day)
     FeeScheme.find_or_create_by(name: 'AGFS', version: 15, start_date: Settings.agfs_scheme_15_additional_prep_fee_and_kc.beginning_of_day, end_date: Settings.agfs_scheme_16_section_twenty_eight_increase.end_of_day - 1.day)
-    FeeScheme.find_or_create_by(name: 'AGFS', version: 16, start_date: Settings.agfs_scheme_16_section_twenty_eight_increase.beginning_of_day, end_date: Settings.agfs_scheme_17.end_of_day - 1.day)
-    FeeScheme.find_or_create_by(name: 'AGFS', version: 17, start_date: Settings.agfs_scheme_17.beginning_of_day, end_date: nil)
+    FeeScheme.find_or_create_by(name: 'AGFS', version: 16, start_date: Settings.agfs_scheme_16_section_twenty_eight_increase.beginning_of_day, end_date: Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date.end_of_day - 1.day)
+    FeeScheme.find_or_create_by(name: 'AGFS', version: 17, start_date: Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date.beginning_of_day, end_date: nil)
   end
   # rubocop:enable Metrics/MethodLength
 

--- a/spec/validators/fee/base_fee_validator_spec.rb
+++ b/spec/validators/fee/base_fee_validator_spec.rb
@@ -676,6 +676,8 @@ RSpec.describe Fee::BaseFeeValidator, type: :validator do
   end
 
   describe '#validate_miapf_case_type_eligibility' do
+    before { travel_to(Settings.agfs_scheme_17_additional_prep_fee_underspend_release_date) }
+
     let(:claim) { create(:advocate_claim, :agfs_scheme_17, case_type:) }
 
     context 'with a fee type that is not an Additional preparation fee' do

--- a/vcr/cassettes/features/claims/advocate/scheme_seventeen/fixed_fee_calculations.yml
+++ b/vcr/cassettes/features/claims/advocate/scheme_seventeen/fixed_fee_calculations.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 10:32:31 GMT
+      - Thu, 23 Jul 2026 08:04:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -44,7 +44,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 10:32:31 GMT
+      - Thu, 23 Jul 2026 08:04:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_APPEAL_CON&limit_from=1&offence_class=17.1&scenario=5
@@ -116,7 +116,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 10:32:31 GMT
+      - Thu, 23 Jul 2026 08:04:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -142,10 +142,10 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448498,"scenario":5,"advocate_type":"JUNIOR","fee_type":8,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"380.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -162,7 +162,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 10:32:32 GMT
+      - Thu, 23 Jul 2026 08:04:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -187,7 +187,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -207,7 +207,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 10:32:32 GMT
+      - Thu, 23 Jul 2026 08:04:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -239,7 +239,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_APPEAL_CON&limit_from=1&offence_class=17.1&scenario=5
@@ -259,7 +259,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 10:32:32 GMT
+      - Thu, 23 Jul 2026 08:04:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -285,5 +285,5 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448498,"scenario":5,"advocate_type":"JUNIOR","fee_type":8,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"380.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 recorded_with: VCR 6.4.0

--- a/vcr/cassettes/features/claims/advocate/scheme_seventeen/graduated_fee_calculations.yml
+++ b/vcr/cassettes/features/claims/advocate/scheme_seventeen/graduated_fee_calculations.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:37 GMT
+      - Thu, 23 Jul 2026 07:51:40 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -44,7 +44,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:37 GMT
+      - Thu, 23 Jul 2026 07:51:40 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/calculate/?day=1&fee_type_code=AGFS_FEE&offence_class=8.1&pages_of_prosecuting_evidence=0&scenario=4
@@ -116,7 +116,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:37 GMT
+      - Thu, 23 Jul 2026 07:51:40 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -140,10 +140,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":0.0}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -160,7 +160,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:38 GMT
+      - Thu, 23 Jul 2026 07:51:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -185,7 +185,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -205,7 +205,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:38 GMT
+      - Thu, 23 Jul 2026 07:51:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -237,7 +237,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/calculate/?advocate_type=JUNIOR&day=1&fee_type_code=AGFS_FEE&offence_class=8.1&pages_of_prosecuting_evidence=0&scenario=4
@@ -257,7 +257,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:38 GMT
+      - Thu, 23 Jul 2026 07:51:41 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -281,10 +281,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1392.0}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -301,7 +301,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:39 GMT
+      - Thu, 23 Jul 2026 07:51:42 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -326,7 +326,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -346,7 +346,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:39 GMT
+      - Thu, 23 Jul 2026 07:51:42 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -378,7 +378,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_FEE&limit_from=1&offence_class=8.1&scenario=4&unit=DAY
@@ -398,7 +398,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:39 GMT
+      - Thu, 23 Jul 2026 07:51:42 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -424,10 +424,10 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":447779,"scenario":4,"advocate_type":"JUNIOR","fee_type":34,"offence_class":"8.1","scheme":14,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1392.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -444,7 +444,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:40 GMT
+      - Thu, 23 Jul 2026 07:51:43 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -469,7 +469,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -489,7 +489,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:40 GMT
+      - Thu, 23 Jul 2026 07:51:43 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -521,7 +521,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_FEE&limit_from=1&offence_class=8.1&scenario=4&unit=DAY
@@ -541,7 +541,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:40 GMT
+      - Thu, 23 Jul 2026 07:51:43 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -567,10 +567,10 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":447779,"scenario":4,"advocate_type":"JUNIOR","fee_type":34,"offence_class":"8.1","scheme":14,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1392.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -587,7 +587,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:41 GMT
+      - Thu, 23 Jul 2026 07:51:44 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -612,10 +612,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -632,7 +632,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:41 GMT
+      - Thu, 23 Jul 2026 07:51:44 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -657,7 +657,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -677,7 +677,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:41 GMT
+      - Thu, 23 Jul 2026 07:51:44 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -709,7 +709,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -729,7 +729,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:41 GMT
+      - Thu, 23 Jul 2026 07:51:44 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -761,7 +761,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -781,7 +781,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:41 GMT
+      - Thu, 23 Jul 2026 07:51:44 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -805,7 +805,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -825,7 +825,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:41 GMT
+      - Thu, 23 Jul 2026 07:51:44 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -849,10 +849,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -869,7 +869,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:42 GMT
+      - Thu, 23 Jul 2026 07:51:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -894,7 +894,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -914,7 +914,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:42 GMT
+      - Thu, 23 Jul 2026 07:51:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -946,52 +946,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:42 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -1011,7 +966,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:42 GMT
+      - Thu, 23 Jul 2026 07:51:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1035,7 +990,52 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:45 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1055,7 +1055,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:42 GMT
+      - Thu, 23 Jul 2026 07:51:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1087,7 +1087,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -1107,7 +1107,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:42 GMT
+      - Thu, 23 Jul 2026 07:51:45 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1131,10 +1131,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1151,7 +1151,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:44 GMT
+      - Thu, 23 Jul 2026 07:51:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1176,7 +1176,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1196,7 +1196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:44 GMT
+      - Thu, 23 Jul 2026 07:51:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1228,7 +1228,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -1248,7 +1248,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:44 GMT
+      - Thu, 23 Jul 2026 07:51:46 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1272,10 +1272,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1292,7 +1292,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1317,10 +1317,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1337,7 +1337,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1362,7 +1362,52 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:47 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1382,7 +1427,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1414,7 +1459,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1434,7 +1479,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1466,7 +1511,59 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:47 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -1486,7 +1583,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1510,245 +1607,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -1768,7 +1627,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1792,7 +1651,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -1812,7 +1671,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:45 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1836,10 +1695,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1856,7 +1715,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1881,52 +1740,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1946,7 +1760,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
+      - Thu, 23 Jul 2026 07:51:47 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1978,297 +1792,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -2288,7 +1812,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
+      - Thu, 23 Jul 2026 07:51:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2312,7 +1836,395 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:48 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -2332,7 +2244,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
+      - Thu, 23 Jul 2026 07:51:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2356,7 +2268,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -2376,7 +2288,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:46 GMT
+      - Thu, 23 Jul 2026 07:51:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2400,10 +2312,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -2420,7 +2332,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
+      - Thu, 23 Jul 2026 07:51:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2434,7 +2346,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '186'
+      - '278'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2443,449 +2355,8 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -2905,7 +2376,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
+      - Thu, 23 Jul 2026 07:51:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2929,7 +2400,483 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
@@ -2949,7 +2896,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
+      - Thu, 23 Jul 2026 07:51:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2973,51 +2920,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -3037,7 +2940,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
+      - Thu, 23 Jul 2026 07:51:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3061,10 +2964,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -3081,51 +2984,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
+      - Thu, 23 Jul 2026 07:51:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3150,7 +3009,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3170,7 +3029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
+      - Thu, 23 Jul 2026 07:51:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3202,7 +3061,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
@@ -3222,7 +3081,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:48 GMT
+      - Thu, 23 Jul 2026 07:51:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3246,10 +3105,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -3266,7 +3125,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
+      - Thu, 23 Jul 2026 07:51:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3291,97 +3150,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3401,7 +3170,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
+      - Thu, 23 Jul 2026 07:51:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3433,289 +3202,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -3735,7 +3222,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
+      - Thu, 23 Jul 2026 07:51:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3759,7 +3246,232 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3779,7 +3491,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
+      - Thu, 23 Jul 2026 07:51:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3811,7 +3523,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3831,7 +3543,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
+      - Thu, 23 Jul 2026 07:51:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3863,7 +3575,163 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -3883,7 +3751,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
+      - Thu, 23 Jul 2026 07:51:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3907,7 +3775,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -3927,7 +3795,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
+      - Thu, 23 Jul 2026 07:51:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3951,104 +3819,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
@@ -4068,7 +3839,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:49 GMT
+      - Thu, 23 Jul 2026 07:51:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4092,580 +3863,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -4685,7 +3883,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
+      - Thu, 23 Jul 2026 07:51:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4709,7 +3907,148 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -4729,7 +4068,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
+      - Thu, 23 Jul 2026 07:51:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4753,7 +4092,536 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
@@ -4773,7 +4641,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
+      - Thu, 23 Jul 2026 07:51:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4797,818 +4665,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:51 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -5628,7 +4685,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
+      - Thu, 23 Jul 2026 07:51:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5652,7 +4709,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -5672,7 +4729,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
+      - Thu, 23 Jul 2026 07:51:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5696,7 +4753,430 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
@@ -5716,7 +5196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
+      - Thu, 23 Jul 2026 07:51:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5740,10 +5220,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -5760,51 +5240,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
+      - Thu, 23 Jul 2026 07:51:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5829,7 +5265,142 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5849,7 +5420,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
+      - Thu, 23 Jul 2026 07:51:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5881,7 +5452,260 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -5901,7 +5725,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
+      - Thu, 23 Jul 2026 07:51:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5925,386 +5749,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
@@ -6324,7 +5769,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:52 GMT
+      - Thu, 23 Jul 2026 07:51:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6348,536 +5793,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -6897,7 +5813,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
+      - Thu, 23 Jul 2026 07:51:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6921,7 +5837,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
@@ -6941,7 +5857,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
+      - Thu, 23 Jul 2026 07:51:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6965,7 +5881,1796 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=4
@@ -6985,7 +7690,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
+      - Thu, 23 Jul 2026 07:51:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7010,712 +7715,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448428,"scenario":4,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=4
@@ -7735,7 +7735,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:54 GMT
+      - Thu, 23 Jul 2026 07:51:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7760,10 +7760,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448428,"scenario":4,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7780,7 +7780,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7805,10 +7805,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7825,7 +7825,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7850,10 +7850,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7870,7 +7870,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7895,10 +7895,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7915,7 +7915,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7940,10 +7940,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7960,7 +7960,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7985,7 +7985,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -8005,7 +8005,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8037,7 +8037,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -8057,7 +8057,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8089,7 +8089,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -8109,7 +8109,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8141,7 +8141,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -8161,7 +8161,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8193,7 +8193,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -8213,7 +8213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8245,7 +8245,51 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -8265,7 +8309,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8289,7 +8333,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '277'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
@@ -8309,7 +8397,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8333,7 +8421,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=4
@@ -8353,7 +8441,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8378,7 +8466,492 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448428,"scenario":4,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
@@ -8398,7 +8971,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8422,624 +8995,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:55 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_UP3&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '277'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448989,"scenario":4,"advocate_type":"JUNIOR","fee_type":230,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"67.95000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -9059,7 +9015,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9083,7 +9039,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=4
@@ -9103,7 +9059,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9127,7 +9083,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448956,"scenario":4,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_UNUSED_OV3&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:51:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449022,"scenario":4,"advocate_type":"JUNIOR","fee_type":231,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=4
@@ -9147,7 +9147,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:16:56 GMT
+      - Thu, 23 Jul 2026 07:51:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9172,7 +9172,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448428,"scenario":4,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/calculate/?day=1&fee_type_code=AGFS_FEE&offence_class=8.1&pages_of_prosecuting_evidence=0&scenario=2
@@ -9192,7 +9192,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:32:53 GMT
+      - Thu, 23 Jul 2026 07:52:21 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9216,7 +9216,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":0.0}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/calculate/?advocate_type=JUNIOR&day=1&fee_type_code=AGFS_FEE&offence_class=8.1&pages_of_prosecuting_evidence=0&scenario=2
@@ -9236,7 +9236,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:32:54 GMT
+      - Thu, 23 Jul 2026 07:52:22 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9260,7 +9260,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":696.0}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -9280,7 +9280,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:32:58 GMT
+      - Thu, 23 Jul 2026 07:52:26 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9304,7 +9304,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -9324,7 +9324,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:32:58 GMT
+      - Thu, 23 Jul 2026 07:52:26 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9348,7 +9348,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -9368,7 +9368,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:32:59 GMT
+      - Thu, 23 Jul 2026 07:52:27 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9392,7 +9392,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -9412,7 +9412,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:32:59 GMT
+      - Thu, 23 Jul 2026 07:52:27 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9436,95 +9436,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:33:00 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:33:00 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
@@ -9544,7 +9456,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:00 GMT
+      - Thu, 23 Jul 2026 07:52:28 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9568,51 +9480,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:33:00 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -9632,7 +9500,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:01 GMT
+      - Thu, 23 Jul 2026 07:52:28 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9656,7 +9524,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
@@ -9676,7 +9544,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:01 GMT
+      - Thu, 23 Jul 2026 07:52:28 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9700,7 +9568,95 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:52:28 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:52:29 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
@@ -9720,7 +9676,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:01 GMT
+      - Thu, 23 Jul 2026 07:52:29 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9744,7 +9700,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -9764,7 +9720,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:01 GMT
+      - Thu, 23 Jul 2026 07:52:29 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9788,51 +9744,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:33:03 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
@@ -9852,7 +9764,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:03 GMT
+      - Thu, 23 Jul 2026 07:52:29 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9876,7 +9788,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -9896,7 +9808,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:03 GMT
+      - Thu, 23 Jul 2026 07:52:31 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9920,7 +9832,95 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:52:31 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:52:31 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=2
@@ -9940,7 +9940,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:03 GMT
+      - Thu, 23 Jul 2026 07:52:31 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9965,7 +9965,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448266,"scenario":2,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
@@ -9985,7 +9985,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:03 GMT
+      - Thu, 23 Jul 2026 07:52:31 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10009,7 +10009,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=2
@@ -10029,7 +10029,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:03 GMT
+      - Thu, 23 Jul 2026 07:52:31 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10054,7 +10054,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448266,"scenario":2,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=2
@@ -10074,7 +10074,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:04 GMT
+      - Thu, 23 Jul 2026 07:52:32 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10099,7 +10099,51 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448266,"scenario":2,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:52:32 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '279'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -10119,7 +10163,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:04 GMT
+      - Thu, 23 Jul 2026 07:52:32 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10143,51 +10187,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Thu, 02 Jul 2026 12:33:04 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '279'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=2
@@ -10207,7 +10207,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:04 GMT
+      - Thu, 23 Jul 2026 07:52:32 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10231,7 +10231,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449058,"scenario":2,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_DEF_SEN_HR&limit_from=1&offence_class=8.1&scenario=2
@@ -10251,7 +10251,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:04 GMT
+      - Thu, 23 Jul 2026 07:52:32 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10276,7 +10276,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448266,"scenario":2,"advocate_type":"JUNIOR","fee_type":16,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"201.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PAP_HEAVY&limit_from=1&offence_class=8.1&scenario=2
@@ -10296,7 +10296,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Thu, 02 Jul 2026 12:33:04 GMT
+      - Thu, 23 Jul 2026 07:52:32 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10320,5 +10320,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448950,"scenario":2,"advocate_type":"JUNIOR","fee_type":229,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 recorded_with: VCR 6.4.0

--- a/vcr/cassettes/features/claims/advocate/scheme_seventeen/hardship_fee_calculations.yml
+++ b/vcr/cassettes/features/claims/advocate/scheme_seventeen/hardship_fee_calculations.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:18 GMT
+      - Thu, 23 Jul 2026 07:52:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -44,7 +44,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:18 GMT
+      - Thu, 23 Jul 2026 07:52:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/calculate/?day=1&fee_type_code=AGFS_FEE&offence_class=8.1&pages_of_prosecuting_evidence=0&scenario=4
@@ -116,7 +116,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:18 GMT
+      - Thu, 23 Jul 2026 07:52:57 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -140,10 +140,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":0.0}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -160,7 +160,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:19 GMT
+      - Thu, 23 Jul 2026 07:52:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -185,7 +185,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -205,7 +205,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:19 GMT
+      - Thu, 23 Jul 2026 07:52:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -237,7 +237,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/calculate/?advocate_type=JUNIOR&day=1&fee_type_code=AGFS_FEE&offence_class=8.1&pages_of_prosecuting_evidence=0&scenario=4
@@ -257,7 +257,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:19 GMT
+      - Thu, 23 Jul 2026 07:52:58 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -281,10 +281,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"amount":1392.0}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -301,7 +301,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:19 GMT
+      - Thu, 23 Jul 2026 07:52:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -326,7 +326,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -346,7 +346,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:19 GMT
+      - Thu, 23 Jul 2026 07:52:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -378,7 +378,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_FEE&limit_from=1&offence_class=8.1&scenario=4&unit=DAY
@@ -398,7 +398,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:20 GMT
+      - Thu, 23 Jul 2026 07:52:59 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -424,10 +424,10 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":447779,"scenario":4,"advocate_type":"JUNIOR","fee_type":34,"offence_class":"8.1","scheme":14,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1392.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -444,7 +444,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:21 GMT
+      - Thu, 23 Jul 2026 07:53:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -469,7 +469,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -489,7 +489,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:21 GMT
+      - Thu, 23 Jul 2026 07:53:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -521,7 +521,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_FEE&limit_from=1&offence_class=8.1&scenario=4&unit=DAY
@@ -541,7 +541,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:21 GMT
+      - Thu, 23 Jul 2026 07:53:00 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -567,10 +567,10 @@ http_interactions:
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":447779,"scenario":4,"advocate_type":"JUNIOR","fee_type":34,"offence_class":"8.1","scheme":14,"unit":"DAY","fee_per_unit":"0.00000","fixed_fee":"1392.00000","limit_from":1,"limit_to":1,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":1,"name":"NUMBER_OF_CASES","description":"Number
         of cases","unit":"CASE"},"required":false,"priority":0,"strict_range":false},{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -587,7 +587,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -612,10 +612,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -632,7 +632,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -657,7 +657,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -677,7 +677,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -709,7 +709,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -729,7 +729,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -761,7 +761,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -781,7 +781,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -805,7 +805,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -825,7 +825,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:01 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -849,10 +849,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -869,7 +869,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -894,52 +894,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -959,7 +914,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -991,7 +946,52 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:02 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1011,7 +1011,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1043,7 +1043,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -1063,7 +1063,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1087,7 +1087,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -1107,7 +1107,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:22 GMT
+      - Thu, 23 Jul 2026 07:53:02 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1131,10 +1131,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1151,7 +1151,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1176,10 +1176,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1196,7 +1196,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1221,52 +1221,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1286,7 +1241,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1318,7 +1273,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1338,7 +1293,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1370,10 +1325,10 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1390,7 +1345,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1415,10 +1370,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1435,7 +1390,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1449,7 +1404,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '985'
+      - '186'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1458,68 +1413,9 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -1539,7 +1435,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1563,7 +1459,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
@@ -1583,7 +1479,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1607,10 +1503,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
     body:
       encoding: US-ASCII
       string: ''
@@ -1627,7 +1523,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1641,7 +1537,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '278'
+      - '985'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -1650,8 +1546,16 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
@@ -1671,7 +1575,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:24 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1695,187 +1599,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1895,7 +1619,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
+      - Thu, 23 Jul 2026 07:53:03 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1927,7 +1651,141 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:03 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:04 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:04 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1947,7 +1805,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
+      - Thu, 23 Jul 2026 07:53:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1979,7 +1837,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1999,7 +1857,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
+      - Thu, 23 Jul 2026 07:53:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2031,7 +1889,52 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:04 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -2051,7 +1954,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
+      - Thu, 23 Jul 2026 07:53:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2083,7 +1986,96 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:04 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:04 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
@@ -2103,7 +2095,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
+      - Thu, 23 Jul 2026 07:53:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2127,7 +2119,59 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:04 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -2147,7 +2191,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
+      - Thu, 23 Jul 2026 07:53:04 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2171,7 +2215,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
@@ -2191,7 +2235,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
+      - Thu, 23 Jul 2026 07:53:09 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2215,7 +2259,492 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -2235,7 +2764,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:25 GMT
+      - Thu, 23 Jul 2026 07:53:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2259,492 +2788,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -2764,7 +2808,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
+      - Thu, 23 Jul 2026 07:53:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2788,51 +2832,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
@@ -2852,7 +2852,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
+      - Thu, 23 Jul 2026 07:53:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2876,7 +2876,51 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:11 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_GRH_FULL&limit_from=1&offence_class=8.1&scenario=4
@@ -2896,7 +2940,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
+      - Thu, 23 Jul 2026 07:53:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2921,10 +2965,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448490,"scenario":4,"advocate_type":"JUNIOR","fee_type":101,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"276.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -2941,51 +2985,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
+      - Thu, 23 Jul 2026 07:53:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3010,7 +3010,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3030,7 +3030,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
+      - Thu, 23 Jul 2026 07:53:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3062,7 +3062,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_GRH_FULL&limit_from=1&offence_class=8.1&scenario=4
@@ -3082,7 +3082,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:26 GMT
+      - Thu, 23 Jul 2026 07:53:11 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3107,10 +3107,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448490,"scenario":4,"advocate_type":"JUNIOR","fee_type":101,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"276.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -3127,7 +3127,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3152,10 +3152,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -3172,7 +3172,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3197,10 +3197,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -3217,7 +3217,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3242,52 +3242,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3307,7 +3262,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3339,10 +3294,10 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
     body:
       encoding: US-ASCII
       string: ''
@@ -3359,7 +3314,111 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:12 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3384,7 +3443,52 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:12 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3404,7 +3508,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3436,7 +3540,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3456,7 +3560,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3488,10 +3592,10 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -3508,7 +3612,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3522,7 +3626,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '985'
+      - '278'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3531,19 +3635,11 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_GRH_FULL&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -3560,7 +3656,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3574,7 +3670,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '985'
+      - '522'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -3583,16 +3679,9 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448490,"scenario":4,"advocate_type":"JUNIOR","fee_type":101,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"276.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -3612,7 +3701,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3636,141 +3725,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_GRH_FULL&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '522'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448490,"scenario":4,"advocate_type":"JUNIOR","fee_type":101,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"276.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_GRH_FULL&limit_from=1&offence_class=8.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '522'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448490,"scenario":4,"advocate_type":"JUNIOR","fee_type":101,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"276.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=8.1&scenario=4
@@ -3790,7 +3745,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3814,10 +3769,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_GRH_FULL&limit_from=1&offence_class=8.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -3834,7 +3789,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:27 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '522'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448490,"scenario":4,"advocate_type":"JUNIOR","fee_type":101,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"276.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3859,7 +3859,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -3879,7 +3879,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:28 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3911,7 +3911,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SPCL_PREP&limit_from=1&offence_class=8.1&scenario=4
@@ -3931,7 +3931,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:27:28 GMT
+      - Thu, 23 Jul 2026 07:53:12 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3955,5 +3955,5 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448435,"scenario":4,"advocate_type":"JUNIOR","fee_type":29,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 recorded_with: VCR 6.4.0

--- a/vcr/cassettes/features/claims/advocate/scheme_seventeen/supplementary_fee_calculations.yml
+++ b/vcr/cassettes/features/claims/advocate/scheme_seventeen/supplementary_fee_calculations.yml
@@ -2,7 +2,7 @@
 http_interactions:
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -19,7 +19,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -44,7 +44,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -64,7 +64,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -96,7 +96,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -116,7 +116,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -140,10 +140,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -160,7 +160,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -185,7 +185,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -205,7 +205,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -237,7 +237,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -257,7 +257,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:48 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -281,10 +281,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -301,7 +301,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -326,7 +326,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -346,7 +346,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -378,7 +378,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -398,7 +398,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:16 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -422,10 +422,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -442,7 +442,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -467,7 +467,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -487,7 +487,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -519,291 +519,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -823,7 +539,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -847,10 +563,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -867,7 +583,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -892,10 +608,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -912,7 +628,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -937,7 +653,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -957,7 +673,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -989,7 +705,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1009,7 +725,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1041,7 +757,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -1061,7 +777,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1086,7 +802,291 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -1106,7 +1106,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1130,10 +1130,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1150,7 +1150,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1175,10 +1175,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1195,7 +1195,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1220,10 +1220,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1240,7 +1240,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1265,7 +1265,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1285,7 +1285,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1317,7 +1317,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1337,7 +1337,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1369,7 +1369,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1389,7 +1389,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1421,7 +1421,52 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:49 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -1441,7 +1486,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1465,7 +1510,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -1485,7 +1530,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:49 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1510,10 +1555,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1530,52 +1575,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1600,10 +1600,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1620,7 +1620,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1645,10 +1645,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -1665,7 +1665,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1690,7 +1690,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1710,7 +1710,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1742,7 +1742,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1762,7 +1762,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1794,7 +1794,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -1814,7 +1814,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1846,7 +1846,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -1866,7 +1866,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1891,52 +1891,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -1956,7 +1911,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -1980,298 +1935,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:17 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -2291,7 +1955,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2316,7 +1980,298 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -2336,7 +2291,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2360,7 +2315,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -2380,7 +2335,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2405,395 +2360,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -2813,7 +2380,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2838,7 +2405,395 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -2858,7 +2813,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2882,10 +2837,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -2902,7 +2857,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2916,7 +2871,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '525'
+      - '186'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -2925,9 +2880,9 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -2947,7 +2902,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -2971,439 +2926,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -3423,7 +2946,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3448,7 +2971,440 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:50 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -3468,7 +3424,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:50 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -3492,484 +3448,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '282'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -3989,7 +3468,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4013,7 +3492,142 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -4033,7 +3647,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4058,187 +3672,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:18 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -4258,7 +3692,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4290,97 +3724,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -4400,7 +3744,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4432,7 +3776,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -4452,7 +3796,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4484,111 +3828,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -4608,7 +3848,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4632,7 +3872,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -4652,7 +3892,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4677,52 +3917,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '520'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -4742,7 +3937,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4767,7 +3962,104 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:51 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -4787,7 +4079,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:51 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4811,10 +4103,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -4831,7 +4123,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4856,10 +4148,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -4876,7 +4168,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4901,10 +4193,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -4921,7 +4213,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4946,10 +4238,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -4966,7 +4258,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -4991,10 +4283,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -5011,7 +4303,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5036,7 +4328,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5056,7 +4348,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5088,7 +4380,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5108,7 +4400,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5140,7 +4432,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5160,7 +4452,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5192,7 +4484,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5212,7 +4504,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5244,7 +4536,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5264,7 +4556,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5296,7 +4588,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -5316,7 +4608,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5341,7 +4633,51 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '282'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -5361,7 +4697,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5385,7 +4721,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -5405,7 +4741,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5430,10 +4766,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -5450,7 +4786,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5464,7 +4800,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '520'
+      - '525'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -5473,12 +4809,12 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -5495,51 +4831,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '282'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5564,10 +4856,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -5584,7 +4876,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5609,7 +4901,97 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5629,7 +5011,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5661,7 +5043,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5681,7 +5063,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5713,7 +5095,111 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -5733,7 +5219,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5757,7 +5243,52 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -5777,7 +5308,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5802,142 +5333,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -5957,7 +5353,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -5989,10 +5385,10 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -6009,7 +5405,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6023,7 +5419,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '985'
+      - '525'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -6032,68 +5428,9 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -6113,7 +5450,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6137,582 +5474,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '520'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:19 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -6732,7 +5494,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6756,7 +5518,343 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -6776,7 +5874,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6801,7 +5899,103 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '282'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
@@ -6821,7 +6015,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6846,7 +6040,52 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -6866,7 +6105,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -6891,141 +6130,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '282'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -7045,7 +6150,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7077,194 +6182,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -7284,7 +6202,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7308,10 +6226,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7328,7 +6246,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7342,7 +6260,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '525'
+      - '186'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -7351,9 +6269,54 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -7373,7 +6336,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7405,7 +6368,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -7425,7 +6388,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7457,10 +6420,10 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7477,7 +6440,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7491,7 +6454,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '985'
+      - '186'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -7500,61 +6463,9 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -7574,7 +6485,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7598,7 +6509,104 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:52 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
@@ -7618,7 +6626,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:52 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7643,10 +6651,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7663,7 +6671,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7688,10 +6696,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -7708,7 +6716,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7733,7 +6741,142 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -7753,7 +6896,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7785,7 +6928,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -7805,7 +6948,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7837,10 +6980,10 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
     body:
       encoding: US-ASCII
       string: ''
@@ -7857,7 +7000,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7871,7 +7014,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '525'
+      - '985'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -7880,9 +7023,120 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -7902,7 +7156,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -7926,387 +7180,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '282'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '520'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -8326,7 +7200,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8351,10 +7225,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -8371,7 +7245,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8385,7 +7259,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '186'
+      - '282'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -8394,158 +7268,8 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
@@ -8565,7 +7289,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8590,7 +7314,627 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '520'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -8610,7 +7954,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8634,10 +7978,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -8654,7 +7998,97 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '520'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8679,52 +8113,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -8744,7 +8133,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8776,7 +8165,97 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -8796,7 +8275,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8828,7 +8307,52 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:53 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -8848,7 +8372,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:20 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -8872,97 +8396,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -8982,7 +8416,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9014,142 +8448,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -9169,7 +8468,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:53 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9201,59 +8500,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
@@ -9273,7 +8520,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9298,10 +8545,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -9318,7 +8565,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9332,7 +8579,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '520'
+      - '186'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -9341,494 +8588,54 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -9848,7 +8655,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9872,10 +8679,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
     body:
       encoding: US-ASCII
       string: ''
@@ -9892,7 +8699,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -9906,7 +8713,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '282'
+      - '985'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -9915,53 +8722,16 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '520'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -9981,7 +8751,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10006,7 +8776,342 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '282'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
@@ -10026,7 +9131,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:54 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10051,10 +9156,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -10071,7 +9176,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:54 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '520'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10096,10 +9246,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -10116,7 +9266,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10141,7 +9291,142 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -10161,7 +9446,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10193,7 +9478,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -10213,7 +9498,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10245,10 +9530,10 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
     body:
       encoding: US-ASCII
       string: ''
@@ -10265,7 +9550,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10279,7 +9564,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '186'
+      - '985'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -10288,9 +9573,209 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '282'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -10310,7 +9795,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10334,10 +9819,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -10354,7 +9839,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10368,7 +9853,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '985'
+      - '520'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -10377,64 +9862,12 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -10451,7 +9884,52 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '520'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10476,10 +9954,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -10496,7 +9974,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10521,10 +9999,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -10541,7 +10019,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10555,7 +10033,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '525'
+      - '186'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -10564,9 +10042,99 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -10586,7 +10154,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10618,7 +10186,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -10638,7 +10206,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10670,7 +10238,163 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -10690,7 +10414,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10715,7 +10439,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -10735,7 +10459,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:21 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -10759,388 +10483,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '520'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '520'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
@@ -11160,7 +10503,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -11184,201 +10527,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -11398,7 +10547,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -11423,7 +10572,1052 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '278'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '520'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '520'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '525'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -11443,7 +11637,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -11467,343 +11661,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '525'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
@@ -11823,7 +11681,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -11848,7 +11706,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
@@ -11868,7 +11726,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -11893,10 +11751,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -11913,7 +11771,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -11938,10 +11796,10 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -11958,7 +11816,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -11983,7 +11841,142 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -12003,7 +11996,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12035,7 +12028,7 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -12055,7 +12048,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12087,7 +12080,163 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:55 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_WSTD_PREP&limit_from=1&offence_class=17.1&scenario=4
@@ -12107,7 +12256,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12131,432 +12280,7 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448434,"scenario":4,"advocate_type":"JUNIOR","fee_type":91,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '278'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '520'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -12576,7 +12300,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12601,52 +12325,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '186'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
-        Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_CONFISC_HF&limit_from=1&offence_class=17.1&scenario=4
@@ -12666,7 +12345,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12691,111 +12370,7 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448422,"scenario":4,"advocate_type":"JUNIOR","fee_type":83,"offence_class":null,"scheme":14,"unit":"HALFDAY","fee_per_unit":"151.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":30,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
         of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
-- request:
-    method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
-    body:
-      encoding: US-ASCII
-      string: ''
-    headers:
-      Accept:
-      - application/json
-      User-Agent:
-      - laa-fee-calculator-client/2.0.0
-      Accept-Encoding:
-      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
-  response:
-    status:
-      code: 200
-      message: OK
-    headers:
-      Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
-      Server:
-      - WSGIServer/0.2 CPython/3.14.6
-      Content-Type:
-      - application/json
-      Vary:
-      - Accept, origin, Cookie
-      Allow:
-      - GET, HEAD, OPTIONS
-      Cache-Control:
-      - public, max-age=7200
-      X-Frame-Options:
-      - DENY
-      Content-Length:
-      - '985'
-      X-Content-Type-Options:
-      - nosniff
-      Referrer-Policy:
-      - same-origin
-      Cross-Origin-Opener-Policy:
-      - same-origin
-    body:
-      encoding: UTF-8
-      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
-        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
-        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
-        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
-        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
-        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
-        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
-        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
-        issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_SECTION_28&limit_from=1&offence_class=17.1&scenario=4
@@ -12815,7 +12390,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12839,10 +12414,10 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":449043,"scenario":4,"advocate_type":"JUNIOR","fee_type":232,"offence_class":null,"scheme":14,"unit":"HEARING","fee_per_unit":"1000.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_PREP_FEE&limit_from=1&offence_class=17.1&scenario=4
     body:
       encoding: US-ASCII
       string: ''
@@ -12859,7 +12434,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:55 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12873,7 +12448,7 @@ http_interactions:
       X-Frame-Options:
       - DENY
       Content-Length:
-      - '520'
+      - '278'
       X-Content-Type-Options:
       - nosniff
       Referrer-Policy:
@@ -12882,12 +12457,11 @@ http_interactions:
       - same-origin
     body:
       encoding: UTF-8
-      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
-        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":449055,"scenario":4,"advocate_type":"JUNIOR","fee_type":233,"offence_class":null,"scheme":14,"unit":"FIXED","fee_per_unit":"81.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":1,"modifiers":[],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
-    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-06-24&main_hearing_date=2026-06-24&type=AGFS
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
     body:
       encoding: US-ASCII
       string: ''
@@ -12904,7 +12478,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12929,7 +12503,97 @@ http_interactions:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
         Fee Scheme 17"}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
@@ -12949,7 +12613,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -12981,7 +12645,156 @@ http_interactions:
         conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
         sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
         issued - breach of crown court order","code":null}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '520'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 - request:
     method: get
     uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_WSTD_PREP&limit_from=1&offence_class=17.1&scenario=4
@@ -13001,7 +12814,7 @@ http_interactions:
       message: OK
     headers:
       Date:
-      - Wed, 01 Jul 2026 08:28:22 GMT
+      - Thu, 23 Jul 2026 07:53:56 GMT
       Server:
       - WSGIServer/0.2 CPython/3.14.6
       Content-Type:
@@ -13025,5 +12838,535 @@ http_interactions:
     body:
       encoding: UTF-8
       string: '{"count":1,"next":null,"previous":null,"results":[{"id":448434,"scenario":4,"advocate_type":"JUNIOR","fee_type":91,"offence_class":null,"scheme":14,"unit":"HOUR","fee_per_unit":"45.30000","fixed_fee":"0.00000","limit_from":1,"limit_to":240,"modifiers":[],"strict_range":false}]}'
-  recorded_at: Tue, 23 Jun 2026 23:00:00 GMT
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/prices/?advocate_type=JUNIOR&fee_type_code=AGFS_STD_APPRNC&limit_from=1&limit_to=6&offence_class=17.1&scenario=4
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:56 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '520'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":448416,"scenario":4,"advocate_type":"JUNIOR","fee_type":27,"offence_class":null,"scheme":14,"unit":"DAY","fee_per_unit":"105.00000","fixed_fee":"0.00000","limit_from":1,"limit_to":6,"modifiers":[{"limit_from":2,"limit_to":null,"fixed_percent":"0.00","percent_per_unit":"20.00","modifier_type":{"id":2,"name":"NUMBER_OF_DEFENDANTS","description":"Number
+        of defendants","unit":"DEFENDANT"},"required":false,"priority":0,"strict_range":false}],"strict_range":false}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/?case_date=2026-07-28&main_hearing_date=2026-07-28&type=AGFS
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '186'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":1,"next":null,"previous":null,"results":[{"id":14,"start_date":"2026-06-24","end_date":null,"earliest_main_hearing_date":null,"type":"AGFS","description":"AGFS
+        Fee Scheme 17"}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
+- request:
+    method: get
+    uri: http://localhost:8000/api/v1/fee-schemes/14/scenarios/
+    body:
+      encoding: US-ASCII
+      string: ''
+    headers:
+      Accept:
+      - application/json
+      User-Agent:
+      - laa-fee-calculator-client/2.0.0
+      Accept-Encoding:
+      - gzip;q=1.0,deflate;q=0.6,identity;q=0.3
+  response:
+    status:
+      code: 200
+      message: OK
+    headers:
+      Date:
+      - Thu, 23 Jul 2026 07:53:57 GMT
+      Server:
+      - WSGIServer/0.2 CPython/3.14.6
+      Content-Type:
+      - application/json
+      Vary:
+      - Accept, origin, Cookie
+      Allow:
+      - GET, HEAD, OPTIONS
+      Cache-Control:
+      - public, max-age=7200
+      X-Frame-Options:
+      - DENY
+      Content-Length:
+      - '985'
+      X-Content-Type-Options:
+      - nosniff
+      Referrer-Policy:
+      - same-origin
+      Cross-Origin-Opener-Policy:
+      - same-origin
+    body:
+      encoding: UTF-8
+      string: '{"count":16,"next":null,"previous":null,"results":[{"id":1,"name":"Discontinuance","code":"AS000001"},{"id":2,"name":"Guilty
+        plea","code":"AS000002"},{"id":3,"name":"Cracked trial","code":"AS000003"},{"id":4,"name":"Trial","code":"AS000004"},{"id":5,"name":"Appeal
+        against conviction","code":"AS000005"},{"id":6,"name":"Appeal against sentence","code":"AS000006"},{"id":7,"name":"Committal
+        for sentence","code":"AS000007"},{"id":8,"name":"Contempt","code":"AS000008"},{"id":9,"name":"Breach
+        of crown court order","code":"AS000009"},{"id":10,"name":"Cracked before retrial","code":"AS000010"},{"id":11,"name":"Retrial","code":"AS000011"},{"id":47,"name":"Warrant
+        issued - trial","code":null},{"id":51,"name":"Warrant issued - appeal against
+        conviction","code":null},{"id":52,"name":"Warrant issued - appeal against
+        sentence","code":null},{"id":53,"name":"Warrant issued - committal for sentence","code":null},{"id":54,"name":"Warrant
+        issued - breach of crown court order","code":null}]}'
+  recorded_at: Mon, 27 Jul 2026 23:00:00 GMT
 recorded_with: VCR 6.4.0


### PR DESCRIPTION
#### What

Sets the correct start date (28/07/2026) for AGFS fee scheme 17, replacing the temporary date used for testing. As a result of this it is necessary to amend some tests to ensure they pass as the correct start date is currently in the future.

Additionally renames the variable for the start date of the scheme to add clarity.

#### Ticket

[CTSKF-1765](https://dsdmoj.atlassian.net/browse/CTSKF-1765)

#### Why

To ensure the fee scheme operates correctly when deployed to production.

#### How

- updates `config/settings.yml` to use the correct scheme start date of `2026-07-28`, and tests where the date was referenced
- updates tests for fee scheme 17 to add a `travel_to` command. This ensures that the tests are run with the current
date set to `28/07/2026` and thus pass. This can be removed after 28/07/2026.
- Re-records VCR cassettes to ensure mocked interactions with fee calculator in feature tests continue to behave correctly
- Renames date variable from `agfs_scheme_17` to `agfs_scheme_17_additional_prep_fee_underspend_release_date` for extra context and consistency with other schemes

[CTSKF-1765]: https://dsdmoj.atlassian.net/browse/CTSKF-1765?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ