### PR TITLE
Exclude additional ModSecurity RCE rules for /messages endpoint

### DIFF
--- a/.k8s/live/api-sandbox/ingress.yaml
+++ b/.k8s/live/api-sandbox/ingress.yaml
@@ -16,7 +16,10 @@ metadata:
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
                                                                             ctl:ruleRemoveById=933210, \
                                                                             ctl:ruleRemoveById=932370, \
-                                                                            ctl:ruleRemoveById=932380"
+                                                                            ctl:ruleRemoveById=932380, \
+                                                                            ctl:ruleRemoveById=932230, \
+                                                                            ctl:ruleRemoveById=932235, \
+                                                                            ctl:ruleRemoveById=932250"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/dev-lgfs/ingress.yaml
+++ b/.k8s/live/dev-lgfs/ingress.yaml
@@ -17,7 +17,10 @@ metadata:
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
                                                                             ctl:ruleRemoveById=933210, \
                                                                             ctl:ruleRemoveById=932370, \
-                                                                            ctl:ruleRemoveById=932380"
+                                                                            ctl:ruleRemoveById=932380, \
+                                                                            ctl:ruleRemoveById=932230, \
+                                                                            ctl:ruleRemoveById=932235, \
+                                                                            ctl:ruleRemoveById=932250"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/dev/ingress.yaml
+++ b/.k8s/live/dev/ingress.yaml
@@ -17,7 +17,10 @@ metadata:
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
                                                                             ctl:ruleRemoveById=933210, \
                                                                             ctl:ruleRemoveById=932370, \
-                                                                            ctl:ruleRemoveById=932380"
+                                                                            ctl:ruleRemoveById=932380, \
+                                                                            ctl:ruleRemoveById=932230, \
+                                                                            ctl:ruleRemoveById=932235, \
+                                                                            ctl:ruleRemoveById=932250"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/production/ingress.yaml
+++ b/.k8s/live/production/ingress.yaml
@@ -17,7 +17,10 @@ metadata:
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
                                                                             ctl:ruleRemoveById=933210, \
                                                                             ctl:ruleRemoveById=932370, \
-                                                                            ctl:ruleRemoveById=932380"
+                                                                            ctl:ruleRemoveById=932380, \
+                                                                            ctl:ruleRemoveById=932230, \
+                                                                            ctl:ruleRemoveById=932235, \
+                                                                            ctl:ruleRemoveById=932250"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;

--- a/.k8s/live/staging/ingress.yaml
+++ b/.k8s/live/staging/ingress.yaml
@@ -17,7 +17,10 @@ metadata:
       SecRule REQUEST_URI "@contains /messages" "id:1000,phase:2,pass,nolog,ctl:ruleRemoveById=921110, \
                                                                             ctl:ruleRemoveById=933210, \
                                                                             ctl:ruleRemoveById=932370, \
-                                                                            ctl:ruleRemoveById=932380"
+                                                                            ctl:ruleRemoveById=932380, \
+                                                                            ctl:ruleRemoveById=932230, \
+                                                                            ctl:ruleRemoveById=932235, \
+                                                                            ctl:ruleRemoveById=932250"
     nginx.ingress.kubernetes.io/server-snippet: |
       deny 116.204.211.188;
       deny 94.154.188.130;


### PR DESCRIPTION
#### What

A user has reported that they cannot submit a message requesting a redetermination. The page does not error, there is just no response. This is occurring because the ModSecurity WAF is blocking the request due to three rules being flagged for false positives: 

932230 - Remote Command Execution: Unix Command Injection (2-3 chars)
932235 - Remote Command Execution: Unix Command Injection (command without evasion)
932250 -  Remote Command Execution: Direct Unix Command Execution

These Unix command injection rules are being triggered on legitimate text in message bodies, e.g. the word "time" in "at the same time as ER/02" triggering the `time` command pattern. This produces an anomaly score which exceeded the threshold of 16 and resulted in a failure for users.

These three RCE rules can be safely excluded as they are not relevant to a web application that does not execute shell commands from user input.

#### Why

To prevent users being affected by false positives.

#### How

Adds rules 932230, 932235 and 932250 to the existing ModSecurity exclusion list for POST /messages requests across all environments.