### PR TITLE
[CTSKF-1803] Expandable message component

### DIFF
--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -50,12 +50,13 @@
   border: 1px solid $govuk-border-colour;
 
   .messages-list {
+    height: 400px;
     min-height: 200px;
-    max-height: 400px;
     margin-bottom: $gutter-two-thirds;
     padding: $gutter-one-sixth;
     overflow-x: hidden;
-    overflow-y: scroll;
+    overflow-y: auto;
+    resize: vertical;
 
     .history {
       .event {

--- a/app/assets/stylesheets/_messages.scss
+++ b/app/assets/stylesheets/_messages.scss
@@ -50,8 +50,8 @@
   border: 1px solid $govuk-border-colour;
 
   .messages-list {
-    height: 400px;
     min-height: 200px;
+    max-height: 400px;
     margin-bottom: $gutter-two-thirds;
     padding: $gutter-one-sixth;
     overflow-x: hidden;

--- a/app/javascript/modules/Modules.Messaging.js
+++ b/app/javascript/modules/Modules.Messaging.js
@@ -6,6 +6,8 @@ moj.Modules.Messaging = {
 
     if (self.messagesList.length) {
       self.messagesList.scrollTop(self.messagesList.prop('scrollHeight'))
+      self.messagesList.css('height', self.messagesList.height())
+      self.messagesList.css('max-height', 'none')
     }
 
     self.selectedFileUpload()


### PR DESCRIPTION
#### What

Make the message component on the claim summary page vertically expandable

#### Ticket

[CTSKF-1803](https://dsdmoj.atlassian.net/browse/CTSKF-1803)

#### Why

Caseworkers need to be able to see more of the message history of a claim at a single glance.

The rules for this should be:

* if the content is less than 400px (ie it's a new claim with only one message), the box automatically resizes to fit the content, with a minimum height of 200px
* if the content is over 400px, the box defaults to 400px
* in all cases the user has the option to vertically expand the box.

#### How

* adds `resize: vertical;` styling to the `messages-list` component in `app/webpack/stylesheets/_messages.scss`
* also changes `overflow-y: scroll;` to `overflow-y: auto;` so that the scroll bar only appears when the content exceeds the height of the component.
* adds javascript to `app/webpack/javascripts/modules/Modules.Messaging.js` to remove the max-height constraint and allow the element to be resized past 400px

This approach works thus: 

1) CSS renders the initial state: `min-height: 200px`, content auto-sizes, `max-height: 400px` caps it, `overflow-y: auto` adds scrollbar when needed
2) JS captures the computed height (which respects the min/max constraints set above), sets it as an explicit height, then removes `max-height`, which allows the user to expand the box beyond 400px
3) `min-height: 200px` keeps the box small when few messages exist and prevents shrinking below 200px when resizing down 

#### Demo

https://github.com/user-attachments/assets/84a977cb-7640-4be4-a8fd-64b723cf654f



[CTSKF-1803]: https://dsdmoj.atlassian.net/browse/CTSKF-1803?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ