### PR TITLE
feat: add workflow to rerun failing tests

### DIFF
--- a/.github/workflows/retry_failed_tests.yml
+++ b/.github/workflows/retry_failed_tests.yml
@@ -1,0 +1,38 @@
+name: Retry failed RSpec and Cucumber jobs
+# Runs only after the CI workflow has completed and retries flaky test shards.
+#  Long-term goal should always be to fix the tests
+on:
+  workflow_run:
+    workflows: ["CI CD"]
+    types: [completed]
+
+jobs:
+  retry-rspec-cucumber-tests:
+    if: github.event.workflow_run.conclusion == 'failure' && github.event.workflow_run.run_attempt < 3
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      # Only RSpec and Cucumber shards are retried; build and deploy jobs never are.
+      - name: Re-run failed RSpec and Cucumber jobs
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          FAILED_JOB_IDS=$(gh api "repos/${{ github.repository }}/actions/runs/$RUN_ID/jobs" --paginate \
+
+            --jq '.jobs[] | select(.conclusion == "failure") | select(
+            (.name | startswith("rspec-tests")) or
+            (.name | startswith("cucumber-tests")) or
+            .name == "other-tests"
+            ) | .id'
+
+          if [ -z "$FAILED_JOB_IDS" ]; then
+            echo "No failed RSpec or Cucumber jobs to retry"
+            exit 0
+          fi
+
+          for JOB_ID in $FAILED_JOB_IDS; do
+            echo "Re-running job $JOB_ID"
+            gh api "repos/${{ github.repository }}/actions/jobs/$JOB_ID/rerun" -X POST
+          done


### PR DESCRIPTION
#### What

Add a workflow which will rerun failing tests from rspec-tests, cucumber-tests or other-tests (in the to-be GHA pipeline)

#### Why
Flaky tests in rspec and cucumber tests are requiring manual operation to re-run failed tests.  These tests will be addressed on a future ticket, however this can help us in the meantime

Because this runs on workflow_run trigger it needs to be merged into main to run against any other branch.


