### PR TITLE
[CTSKF-1874] Add link to HLD

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -5,6 +5,7 @@
 - [Scheduled tasks](#scheduled-tasks)
 - [Mailer previewing](#mailer-previewing)
 - [Anonymised database dump and restore](#anonymised-database-dump-and-restore)
+- [Diagrams](#diagrams)
 - [A note on architecture](#a-note-on-architecture)
 
 ## Other links:
@@ -284,6 +285,12 @@ Databse dump files can also be restored on a remote host. To achieve this you wi
   # restore database
   /usr/src/app $ rails db:restore['tmp/production/dump_file_name.psql.gz']
   ```
+
+## Diagrams
+
+A high level design diagram for CCCD is located in https://github.com/ministryofjustice/laa-architectural-diagrams/tree/main/docs/artefacts/hld/cccd.
+
+A network diagram for CCCD is located in the `docs/diagrams` directory of this repository.
 
 ## A note on architecture
 


### PR DESCRIPTION
#### What

Adds a link to the high level design diagram held in the `laa-architectural-diagrams` repository to `docs/development.md` (note that the existence of that file is dependent on the approval and merge of https://github.com/ministryofjustice/laa-architectural-diagrams/pull/87).

Also updates the links at the top of that page to reflect the sections available below, so that each section is linked to.

#### Ticket

[CTSKF-1874](https://dsdmoj.atlassian.net/browse/CTSKF-1874)


[CTSKF-1874]: https://dsdmoj.atlassian.net/browse/CTSKF-1874?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ